### PR TITLE
Fix wrong result when correlated subquery  containing PlaceHolderVar.

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -215,6 +215,15 @@ CorrelatedVarWalker(Node *node, CorrelatedVarWalkerContext *ctx)
 		}
 		return false;
 	}
+	else if (IsA(node, PlaceHolderVar))
+	{
+		PlaceHolderVar *phv = (PlaceHolderVar *) node;
+		if (phv->phlevelsup > ctx->maxLevelsUp)
+		{
+			ctx->maxLevelsUp = phv->phlevelsup;
+		}
+		return false;
+	}
 	else if (IsA(node, Query))
 	{
 		return query_tree_walker((Query *) node, CorrelatedVarWalker, ctx, 0 /* flags */);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -70,6 +70,46 @@ select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum fr
 (3 rows)
 
 --
+-- Correlated subquery in the targetlist: PlaceHolderVar
+--
+drop table if exists sub_phv;
+NOTICE:  table "sub_phv" does not exist, skipping
+create table sub_phv(a int, b int) distributed by (a);
+insert into sub_phv values(1,1),(2,2);
+explain(costs off)
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: t1.a, t1.b
+   ->  Sort
+         Sort Key: t1.a, t1.b
+         ->  Hash Left Join
+               Hash Cond: (t1.b = t2.a)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t1.b
+                     ->  Seq Scan on sub_phv t1
+               ->  Hash
+                     ->  Seq Scan on sub_phv t2
+               SubPlan 1
+                 ->  Limit
+                       ->  Result
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on sub_phv t3
+ Optimizer: Postgres-based planner
+(18 rows)
+
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join 
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+ a | b | x | y  | z  
+---+---+---+----+----
+ 1 | 1 | 1 | 42 | 42
+ 2 | 2 | 2 | 42 | 42
+(2 rows)
+
+--
 -- CSQs with partitioned tables
 --
 drop table if exists csq_t1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -70,6 +70,47 @@ select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum fr
 (3 rows)
 
 --
+-- Correlated subquery in the targetlist: PlaceHolderVar
+--
+drop table if exists sub_phv;
+NOTICE:  table "sub_phv" does not exist, skipping
+create table sub_phv(a int, b int) distributed by (a);
+insert into sub_phv values(1,1),(2,2);
+explain(costs off)
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: t1.a, t1.b
+   ->  Result
+         ->  Sort
+               Sort Key: t1.a, t1.b
+               ->  Hash Left Join
+                     Hash Cond: (t1.b = t2.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1.b
+                           ->  Seq Scan on sub_phv t1
+                     ->  Hash
+                           ->  Seq Scan on sub_phv t2
+         SubPlan 1
+           ->  Limit
+                 ->  Result
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                   ->  Seq Scan on sub_phv t3
+ Optimizer: GPORCA
+(19 rows)
+
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join 
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+ a | b | x | y  | z  
+---+---+---+----+----
+ 1 | 1 | 1 | 42 | 42
+ 2 | 2 | 2 | 42 | 42
+(2 rows)
+
+--
 -- CSQs with partitioned tables
 --
 drop table if exists csq_t1;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -60,6 +60,23 @@ select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x = csq_t1.x) as s
 select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
 
 --
+-- Correlated subquery in the targetlist: PlaceHolderVar
+--
+
+drop table if exists sub_phv;
+
+create table sub_phv(a int, b int) distributed by (a);
+
+insert into sub_phv values(1,1),(2,2);
+
+explain(costs off)
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+
+select *, (select ss.y as z from sub_phv t3 limit 1) from sub_phv t1 left join 
+(select a as x, 42 as y from sub_phv t2) ss on t1.b = ss.x order by 1,2;
+
+--
 -- CSQs with partitioned tables
 --
 


### PR DESCRIPTION
Hi,

Glad to see this project open again.

I encountered a few gpdb optimizer bugs over the last two years. I don't have a chance to report them because gpdb has closed
source code.

This PR is about correlated suquery. See below:

```
postgres=# create table phv_t(a int, b int) distributed by (a);
CREATE TABLE
postgres=# insert into phv_t values(1,1),(2,2);
INSERT 0 2
postgres=# explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
                                    QUERY PLAN                                     
-----------------------------------------------------------------------------------
 Sort
   Sort Key: t1.a, t1.b
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Hash Left Join
               Hash Cond: (t1.b = t2.a)
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Hash Key: t1.b
                     ->  Seq Scan on phv_t t1
               ->  Hash
                     ->  Seq Scan on phv_t t2
               SubPlan 1
                 ->  Limit
                       ->  Result
                             ->  Materialize
                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                         ->  Seq Scan on phv_t t3
 Optimizer: GPORCA
(17 rows)

postgres=#  select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
 a | b | x | y  | z  
---+---+---+----+----
 1 | 1 | 1 | 42 | 42
 2 | 2 | 2 | 42 | 42
(2 rows)

postgres=# set optimizer = off;
SET
postgres=# explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Merge Key: t1.a, t1.b
   ->  Sort
         Sort Key: t1.a, t1.b
         ->  Hash Left Join
               Hash Cond: (t1.b = t2.a)
               ->  Redistribute Motion 3:3  (slice4; segments: 3)
                     Hash Key: t1.b
                     ->  Seq Scan on phv_t t1
               ->  Hash
                     ->  Seq Scan on phv_t t2
               SubPlan 1
                 ->  Materialize
                       ->  Broadcast Motion 1:3  (slice2)
                             ->  Limit
                                   ->  Gather Motion 3:1  (slice3; segments: 3)
                                         ->  Limit
                                               ->  Seq Scan on phv_t t3
 Optimizer: Postgres-based planner
(19 rows)

postgres=#  select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
 a | b | x | y  | z 
---+---+---+----+---
 1 | 1 | 1 | 42 | 0
 2 | 2 | 2 | 42 | 0
(2 rows)
```
The Postgres-based planner returns wrong results.
I think the plan of the subquery in the original query created by the Postgres-based planner is wrong.
As far as I know, in Postgres optimizer code, Var and PlaceholderVar most of the time appear simultaneously.

What will happen if we forget to process PlaceHolderVar in this case? IsSubqueryCorrelated() will return false, then,
root->is_correlated_subplan will be false when we enter (select ss.y as z from t as t3 limit 1).

The code in make_rel_from_joinlist() will not call bring_to_outer_query() if root->is_correlated_subplan is false.
So, a wrong plan will be created.
