### PR TITLE
Add support for executing CustomScans

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -525,13 +525,12 @@ DirectDispatchUpdateContentIdsFromPlan(PlannerInfo *root, Plan *plan)
 			/* no change to dispatchInfo */
 			break;
 		case T_ForeignScan:
+		case T_CustomScan:
 			DisableTargetedDispatch(&dispatchInfo); /* not sure about
 													 * foreign tables ...
 													 * so disable */
 			break;
 		case T_SplitUpdate:
-			break;
-		case T_CustomScan:
 			break;
 		default:
 			elog(ERROR, "unknown plan node %d", nodeTag(plan));

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -805,6 +805,9 @@ ExecSquelchNode(PlanState *node)
 			 */
 			ExecShutdownForeignScan((ForeignScanState *) node);
 			break;
+		case T_CustomScanState:
+			ExecShutdownCustomScan((CustomScanState*) node);
+			break;
 		case T_DynamicForeignScanState:
 			/* TODO: Add logic to shutdown the dynamic foreign scan for cases of parallel
 			 * execution (currently unsupported in Orca)

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -2416,6 +2416,11 @@ expression_tree_walker(Node *node,
 					return true;
 			}
 			break;
+		case T_String:
+			// When walking a CustomScan with a CustomScanState that's a list of strings,
+			// we eventually start looking at String and for some reason this is not
+			// included here
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(node));


### PR DESCRIPTION
This commit adds support for T_CustomScan nodes in certain branches, as well as shipping their state (assuming it's a List of T_String nodes) to executors.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
