### PR TITLE
Initialize attnumsWithEntries to prevent failures during CO rewrite

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -932,6 +932,8 @@ ExistValidLastrownums(Oid relid, int natts)
 
 /*
  * Determine which attnums have an entry present in pg_attribute_encoding
+ *
+ * attnum_entry_present[] should be initialized with false.
  */
 void
 check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
@@ -943,8 +945,6 @@ check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
 	bool 			isnull;
 
 	Assert(OidIsValid(relid));
-
-	MemSet(attnum_entry_present, false, sizeof(attnum_entry_present));
 
 	rel = heap_open(AttributeEncodingRelationId, AccessShareLock);
 

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -604,7 +604,7 @@ AddOrUpdateCOAttributeEncodings(Oid relid, List *attr_encodings)
 	ListCell *lc;
 	ListCell *lc_filenum;
 	List *filenums = NIL;
-	bool attnumsWithEntries[MaxHeapAttributeNumber];
+	bool attnumsWithEntries[MaxHeapAttributeNumber] = { false };
 
 	check_attribute_encoding_entry_exist(relid, attnumsWithEntries);
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -2113,3 +2113,32 @@ SELECT objid::regtype, refobjid::regtype FROM pg_depend
 
 -- Alter it back to ao_column so that we test the upgrade path
 ALTER TABLE at_array_type_co_to_heap SET ACCESS METHOD ao_column;
+-- Alter a very wide table from HEAP to CO
+CREATE OR REPLACE FUNCTION create_very_wide_table(num_columns INTEGER, column_prefix TEXT, data_type TEXT)
+RETURNS VOID AS $$
+DECLARE
+    sql_statement TEXT := 'CREATE TABLE very_wide_table (';
+    i INTEGER;
+BEGIN
+    FOR i IN 1..num_columns LOOP
+        sql_statement := sql_statement || quote_ident(column_prefix || i) || ' ' || data_type;
+        IF i < num_columns THEN
+            sql_statement := sql_statement || ', ';
+        END IF;
+    END LOOP;
+    sql_statement := sql_statement || ');';
+
+    EXECUTE sql_statement;
+    RAISE NOTICE 'Table "very_wide_table" created with % columns.', num_columns;
+END;
+$$ LANGUAGE plpgsql;
+SELECT create_very_wide_table(1594, 'col_', 'TEXT');
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col_1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  Table "very_wide_table" created with 1594 columns.
+ create_very_wide_table 
+------------------------
+ 
+(1 row)
+
+ALTER TABLE very_wide_table SET ACCESS METHOD ao_column WITH (compresstype=zstd);


### PR DESCRIPTION
The rewrite process detects previous encodings of every column and stores them
in `attnumsWithEntries[]` to decide whether to add a new encoding or update the
existing one. Only the first 8 elements of that array were initialized, which could
result in "ERROR: could not find tuple for attnum X for relid Y during scan on
pg_attribute_encoding" in most cases, especially with wide tables.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
