### PR TITLE
Fix work_mem reference in hash aggregate

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1867,9 +1867,7 @@ hash_agg_set_limits(AggState *aggstate, double hashentrysize, double input_group
 
 	if (aggstate)
 	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
-		if (operator_mem < strict_memlimit)
-			strict_memlimit = operator_mem;
+		strict_memlimit = PlanStateOperatorMemKB((PlanState *) aggstate);
 	}
 
 	/* if not expected to spill, use all of work_mem */
@@ -2139,9 +2137,7 @@ hash_choose_num_partitions(AggState *aggstate, double input_groups, double hashe
 
 	if (aggstate)
 	{
-		uint64 operator_mem = PlanStateOperatorMemKB((PlanState *) aggstate);
-		if (operator_mem < strict_memlimit)
-			strict_memlimit = operator_mem;
+		strict_memlimit = PlanStateOperatorMemKB((PlanState *) aggstate);
 	}
 
 	/*


### PR DESCRIPTION
WarehousePG/Greenplum uses the PlanStateOperatorMemKB() as memory limit
instead of work_mem. Almost all references were fixed but this one was
missed, hash aggregate likely didn't use all the planned memory, likely
triggered more spills, thereby affecting performance.