### PR TITLE
Workaround the `capture_output` parameter in cases

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
@@ -97,7 +97,7 @@ CREATE FUNCTION
 -- create a resource group that contains all the cpu cores
 0: CREATE OR REPLACE FUNCTION create_allcores_group(grp TEXT) RETURNS BOOL AS $$ import subprocess 
 file = "/sys/fs/cgroup/cpuset/gpdb/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
-# plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
+# plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], stdout=subprocess.PIPE, stderr=subprocess.PIPE) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
 file = "/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
 return True $$ LANGUAGE plpython3u;
 CREATE FUNCTION
@@ -118,8 +118,8 @@ CREATE FUNCTION
 sql = "select sess_id from pg_stat_activity where pid = '%d'" % pid result = plpy.execute(sql) session_id = result[0]['sess_id'] 
 sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 sql = "select hostname from gp_segment_configuration group by hostname" result = plpy.execute(sql) hosts = [_['hostname'] for _ in result] 
-def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], capture_output=True, check=True).stdout session_pids = stdout.splitlines() 
-path = "/sys/fs/cgroup/cpu/gpdb/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
+def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout session_pids = stdout.splitlines() 
+path = "/sys/fs/cgroup/cpu/gpdb/{}/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout cgroups_pids = stdout.splitlines() 
 return set(session_pids).issubset(set(cgroups_pids)) 
 for host in hosts: if not get_result(host): return False return True 
 $$ LANGUAGE plpython3u;

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -98,7 +98,7 @@ CREATE FUNCTION
 -- create a resource group that contains all the cpu cores
 0: CREATE OR REPLACE FUNCTION create_allcores_group(grp TEXT) RETURNS BOOL AS $$ import subprocess 
 file = "/sys/fs/cgroup/gpdb/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')" 
-# plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
+# plpy SPI will always start a transaction, but res group cannot be created in a transaction. ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], stdout=subprocess.PIPE, stderr=subprocess.PIPE) if ret.returncode != 0: plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr)) 
 file = "/sys/fs/cgroup/gpdb/1/cpuset.cpus" fd = open(file) line = fd.readline() fd.close() line = line.strip('\n') if line != "0": return False 
 return True $$ LANGUAGE plpython3u;
 CREATE FUNCTION
@@ -119,8 +119,8 @@ CREATE FUNCTION
 sql = "select sess_id from pg_stat_activity where pid = '%d'" % pid result = plpy.execute(sql) session_id = result[0]['sess_id'] 
 sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname='%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 sql = "select hostname from gp_segment_configuration group by hostname" result = plpy.execute(sql) hosts = [_['hostname'] for _ in result] 
-def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], capture_output=True, check=True).stdout session_pids = stdout.splitlines() 
-path = "/sys/fs/cgroup/gpdb/{}/queries/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout cgroups_pids = stdout.splitlines() 
+def get_result(host): stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout session_pids = stdout.splitlines() 
+path = "/sys/fs/cgroup/gpdb/{}/queries/cgroup.procs".format(groupid) stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout cgroups_pids = stdout.splitlines() 
 return set(session_pids).issubset(set(cgroups_pids)) 
 for host in hosts: if not get_result(host): return False return True 
 $$ LANGUAGE plpython3u;

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v1.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v1.sql
@@ -163,7 +163,7 @@ $$ LANGUAGE plpython3u;
     sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')"
 
     # plpy SPI will always start a transaction, but res group cannot be created in a transaction.
-    ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True)
+    ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if ret.returncode != 0:
         plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr))
 
@@ -261,11 +261,11 @@ $$ LANGUAGE plpython3u;
 
     def get_result(host):
         stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)],
-                                capture_output=True, check=True).stdout
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
         session_pids = stdout.splitlines()
 
         path = "/sys/fs/cgroup/cpu/gpdb/{}/cgroup.procs".format(groupid)
-        stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout
+        stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
         cgroups_pids = stdout.splitlines()
 
         return set(session_pids).issubset(set(cgroups_pids))

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -159,7 +159,7 @@ $$ LANGUAGE plpython3u;
     sql = "create resource group " + grp + " with (" + "cpuset='" + line + "')"
 
     # plpy SPI will always start a transaction, but res group cannot be created in a transaction.
-    ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], capture_output=True)
+    ret = subprocess.run(['psql', 'postgres', '-c' , '{}'.format(sql)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if ret.returncode != 0:
         plpy.error('failed to create resource group.\n {} \n {}'.format(ret.stdout, ret.stderr))
 
@@ -257,11 +257,11 @@ $$ LANGUAGE plpython3u;
 
     def get_result(host):
         stdout = subprocess.run(["ssh", "{}".format(host), "ps -ef | grep postgres | grep con{} | grep -v grep | awk '{{print $2}}'".format(session_id)],
-                                capture_output=True, check=True).stdout
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
         session_pids = stdout.splitlines()
 
         path = "/sys/fs/cgroup/gpdb/{}/queries/cgroup.procs".format(groupid)
-        stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], capture_output=True, check=True).stdout
+        stdout = subprocess.run(["ssh", "{}".format(host), "cat {}".format(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
         cgroups_pids = stdout.splitlines()
 
         return set(session_pids).issubset(set(cgroups_pids))

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -53,7 +53,7 @@ for pid in pids_to_check:
     # We check count of those connections which have not been established.
     # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
     lsof_ret = subprocess.run(["lsof", "-i", "-nP", "-a", "-p", str(pid)],
-        capture_output=True, check=True).stdout
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
     plpy.info(
         f'Checking postgres backend {pid}, ' \
         f'lsof output:\n{os.linesep.join(map(str, lsof_ret.splitlines()))}')

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -55,7 +55,7 @@ for pid in pids_to_check:
     # We check count of those connections which have not been established.
     # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
     lsof_ret = subprocess.run(["lsof", "-i", "-nP", "-a", "-p", str(pid)],
-        capture_output=True, check=True).stdout
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True).stdout
     plpy.info(
         f'Checking postgres backend {pid}, ' \
         f'lsof output:\n{os.linesep.join(map(str, lsof_ret.splitlines()))}')


### PR DESCRIPTION
Python added the capture_output parameter at Python 3.7, but EL8 only
has Python 3.6, change the `capture_output` parameter to its alternative
`stdout=subprocess.PIPE, stderr=subprocess.PIPE`.