### PR TITLE
Fix gpcheckcat mix_distribution_policy test

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2093,8 +2093,8 @@ where
             logger.warning('Unable to generate verify file for {}'.format(filename))
 
 
-# Check if there are both type tables that use legacy or modern opclass as
-# their distribution policy in one database
+# Check if there are two types of tables within one database, some use legacy
+# hashops, and others use modern hashops as their distribution policies.
 def checkMixDistPolicy():
 
     qry = '''
@@ -2153,8 +2153,8 @@ def checkMixDistPolicy():
                     #if this condition is true then we have mix distribution policy
                     setError(ERROR_NOREPAIR)
                     myprint(
-                        '[ERROR]: Found both type tables that use legacy or modern hashops'
-                        ' as their distribution policy in one database.\n'
+                        '[ERROR]: Found two types of tables within one database, some use legacy hashops, '
+                        'and others use modern hashops as their distribution policies.\n'
                         'Please run the gpcheckcat.distpolicy.sql file to list the tables.'
                     )
                 else:

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1432,8 +1432,8 @@ class checkAOSegVpinfoThread(execThread):
     def run(self):
         aoseg_query = """
            SELECT a.relname, a.relid, a.segrelid, cl.relname, a.relnatts
-           FROM (SELECT p.relid, p.segrelid, c.relname, c.relnatts FROM pg_appendonly p LEFT JOIN pg_class c ON p.relid = c.oid LEFT JOIN pg_am a ON (a.oid = c.relam) 
-           WHERE a.amname = 'ao_column') a 
+           FROM (SELECT p.relid, p.segrelid, c.relname, c.relnatts FROM pg_appendonly p LEFT JOIN pg_class c ON p.relid = c.oid LEFT JOIN pg_am a ON (a.oid = c.relam)
+           WHERE a.amname = 'ao_column') a
            LEFT JOIN pg_class cl ON a.segrelid = cl.oid;
         """
 
@@ -2050,7 +2050,7 @@ def generateDistPolicyQueryFile():
      where
          policytype = 'p'
          and distclass :: oid[] && oid_array;
-  
+
  -- all tables that don't use any legacy policy:
  with legacy_opclass_oids(oid_array) as (
    select
@@ -2093,10 +2093,10 @@ where
             logger.warning('Unable to generate verify file for {}'.format(filename))
 
 
-# Test to check if there are tables that use both legacy opclass/non legacy opclass
-# in distribution policy
-def checkMixDistPolicy() :
- 
+# Check if there are both type tables that use legacy or modern opclass as
+# their distribution policy in one database
+def checkMixDistPolicy():
+
     qry = '''
         with legacy_opclass_oids(oid_array) as (
         select
@@ -2122,7 +2122,7 @@ def checkMixDistPolicy() :
        ),
        all_hash_ops(dc) as (
         select
-          distinct unnest(distclass :: oid[]) 
+          distinct unnest(distclass :: oid[])
         from
           gp_distribution_policy
         )
@@ -2150,15 +2150,16 @@ def checkMixDistPolicy() :
 
                 if n_legacy_dist_class > 0 and n_total_dist_class > n_legacy_dist_class :
                     generateDistPolicyQueryFile()
-                    #if this condition is true then we have mix distribution Policy
+                    #if this condition is true then we have mix distribution policy
+                    setError(ERROR_NOREPAIR)
                     myprint(
-                        '[ERROR]: Found tables created using both legacy and non legacy hashops'
-                        ' in distribution policy.'
+                        '[ERROR]: Found both type tables that use legacy or modern hashops'
+                        ' as their distribution policy in one database.\n'
                         'Please run the gpcheckcat.distpolicy.sql file to list the tables.'
                     )
                 else:
                     if (n_legacy_dist_class == 0 or n_legacy_dist_class == n_total_dist_class):
-                    #if this condition is true then we dont have mix distribution policy
+                        #if this condition is true then we don't have mix distribution policy
                         gp_use_legacy_hashops = fetch_guc_value("gp_use_legacy_hashops")
                         printDistPolicyMsg(gp_use_legacy_hashops,
                                          n_legacy_dist_class,
@@ -2176,6 +2177,7 @@ def printDistPolicyMsg(gp_use_legacy_hashops,n_legacy_dist_class, n_total_dist_c
     GV.checkStatus = True
 
     if n_total_dist_class - n_legacy_dist_class > 0  and gp_use_legacy_hashops == "on":
+        setError(ERROR_NOREPAIR)
         myprint(
             '[ERROR]: GUC gp_use_legacy_hashops is on.'
             ' all newly created tables will use legacy hash ops by default for hash distributed table, '
@@ -2188,6 +2190,7 @@ def printDistPolicyMsg(gp_use_legacy_hashops,n_legacy_dist_class, n_total_dist_c
         GV.checkStatus = True
 
     elif n_legacy_dist_class > 0 and gp_use_legacy_hashops == "off" :
+        setError(ERROR_NOREPAIR)
         myprint(
             '[ERROR]: GUC gp_use_legacy_hashops is off.'
             ' all newly created tables will use non legacy hash ops by default for hash distributed table, '

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -807,7 +807,7 @@ Feature: gpcheckcat tests
         And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -R mix_distribution_policy hashops_db "
-        And gpcheckcat should print "Found both type tables that use legacy or modern hashops as their distribution policy in one database." to stdout
+        And gpcheckcat should print "Found two types of tables within one database, some use legacy hashops, and others use modern hashops as their distribution policies." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
         And gpcheckcat should return a return code of 3
         And the user runs "dropdb hashops_db"
@@ -891,7 +891,7 @@ Feature: gpcheckcat tests
         And the user runs "psql hashops_db2 -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -A -R mix_distribution_policy"
-        And gpcheckcat should print "Found both type tables that use legacy or modern hashops as their distribution policy in one database." to stdout
+        And gpcheckcat should print "Found two types of tables within one database, some use legacy hashops, and others use modern hashops as their distribution policies." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
         And gpcheckcat should return a return code of 3
         Then gpcheckcat should print "Completed 1 test(s) on database 'hashops_db'" to logfile with latest timestamp

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -807,8 +807,9 @@ Feature: gpcheckcat tests
         And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -R mix_distribution_policy hashops_db "
-        And gpcheckcat should print "Found tables created using both legacy and non legacy hashops in distribution policy." to stdout
+        And gpcheckcat should print "Found both type tables that use legacy or modern hashops as their distribution policy in one database." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And gpcheckcat should return a return code of 3
         And the user runs "dropdb hashops_db"
 
     Scenario: Validate if gpcheckcat succeeds and there are no tables
@@ -831,6 +832,7 @@ Feature: gpcheckcat tests
         And gpcheckcat should print "all newly created tables will use legacy hash ops by default for hash distributed table," to stdout
         And gpcheckcat should print "but there are tables using non-legacy hash ops in the cluster." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And gpcheckcat should return a return code of 3
         And the user runs "dropdb hashops_db"
 
       Scenario: Validate if gpcheckcat succeeds when GUC gp_use_legacy_hashops is on and there are legacy tables
@@ -844,6 +846,7 @@ Feature: gpcheckcat tests
         And the user runs "gpstart -a"
         When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
          And gpcheckcat should print "PASSED" to stdout
+         And gpcheckcat should return a return code of 0
         And the user runs "dropdb hashops_db"
 
     Scenario: Validate if gpcheckcat throws error when GUC gp_use_legacy_hashops is off and there are legacy tables
@@ -859,6 +862,7 @@ Feature: gpcheckcat tests
         And gpcheckcat should print "all newly created tables will use non legacy hash ops by default for hash distributed table," to stdout
         And gpcheckcat should print "but there are tables using legacy hash ops in the cluster." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And gpcheckcat should return a return code of 3
         And the user runs "dropdb hashops_db"
 
     Scenario: Validate if gpcheckcat succeeds when GUC gp_use_legacy_hashops is off and there are non legacy tables 
@@ -887,8 +891,9 @@ Feature: gpcheckcat tests
         And the user runs "psql hashops_db2 -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
         Then psql should return a return code of 0
         When the user runs "gpcheckcat -A -R mix_distribution_policy"
-        And gpcheckcat should print "Found tables created using both legacy and non legacy hashops in distribution policy." to stdout
+        And gpcheckcat should print "Found both type tables that use legacy or modern hashops as their distribution policy in one database." to stdout
         And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And gpcheckcat should return a return code of 3
         Then gpcheckcat should print "Completed 1 test(s) on database 'hashops_db'" to logfile with latest timestamp
         Then gpcheckcat should print "Completed 1 test(s) on database 'hashops_db2'" to logfile with latest timestamp
         And the user runs "dropdb hashops_db"

--- a/src/test/regress/sql/gpdist_legacy_opclasses.sql
+++ b/src/test/regress/sql/gpdist_legacy_opclasses.sql
@@ -271,3 +271,7 @@ select * from ctas_from_legacy where col=1;
 select * from ctas_explicit_legacy where col=1;
 select * from ctas_from_nonlegacy where col=1;
 select * from ctas_explicit_nonlegacy where col=1;
+
+-- start_ignore
+drop schema if exists gpdist_legacy_opclasses cascade;
+-- end_ignore


### PR DESCRIPTION
We intentionally created such a database during testing and didn’t drop
it. However, accidentally, gpcheckcat only printed the error without
returning an error code. This commit fixes both behaviors.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
