### PR TITLE
Fix incorrect join_rel size estimates for anti join and left anti semi join(NOT IN)

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -2870,6 +2870,7 @@ fetch_single_dqa_info(PlannerInfo *root,
 	{
 		arg_sortcl = (SortGroupClause *) lfirst(lc);
 		arg_tle = get_sortgroupref_tle(arg_sortcl->tleSortGroupRef, aggref->args);
+		bool needed = true;
 
 		/* Now find this expression in the sub-path's target list */
 		idx = 0;
@@ -2898,13 +2899,16 @@ fetch_single_dqa_info(PlannerInfo *root,
 		{
 			foreach (lcc, ctx->groupClause)
 			{
-				SortGroupClause *ctx_sortcl = (SortGroupClause *)lfirst(lcc);
+				SortGroupClause *ctx_sortcl = (SortGroupClause *) lfirst(lcc);
 
-				if (!equal(ctx_sortcl, sortcl))
+				if (equal(ctx_sortcl, sortcl))
 				{
-					info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
+					needed = false;
+					break;
 				}
 			}
+			if (needed)
+				info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
 		}
 
 		dqa_group_exprs = lappend(dqa_group_exprs, arg_tle->expr);

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -227,9 +227,11 @@ clauselist_selectivity_simple(PlannerInfo *root,
 	int pos = 0;
 	int i = 0;
 
-	// if the PlannerInfo was created from Orca, we don't care about the selectivity/costing
-	// here and some of the necessary fields may not be populated (eg: glob). Instead return
-	// the default selectivity
+	/*
+	 *if the PlannerInfo was created from Orca, we don't care about the selectivity/costing
+	 * here and some of the necessary fields may not be populated (eg: glob). Instead return
+	 * the default selectivity
+	 */
 	if (root->is_from_orca)
 	{
 		return s1;

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -451,14 +451,7 @@ clauselist_selectivity_simple(PlannerInfo *root,
 	}
 
 	pfree(rgsel);
-	/* 
-	 * For Anti Semi Join, selectivity is determined by the fraction of 
-	 * tuples that do no match 
-	 */
-	if (JOIN_ANTI == jointype || JOIN_LASJ_NOTIN == jointype)
-	{
-		s1 = (1 - s1);
-	}
+
 	return s1;
 }
 


### PR DESCRIPTION
I encountered the $SUBJECT when I did the TPCH benchmark. The 16th query, the join_rel size estimate, has a big gap between the cost estimate and the real execution.
Details are as follows:
The 16th query is:
```
SELECT
    p_brand,
    p_type,
    p_size,
    COUNT(DISTINCT ps_suppkey) AS supplier_cnt
FROM
    part,
    partsupp
WHERE
    p_partkey = ps_partkey
    AND p_brand <> 'Brand#45'
    AND p_type NOT LIKE 'MEDIUM POLISHED%'
    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
    AND ps_suppkey NOT IN (
        SELECT
            s_suppkey
        FROM
            supplier
        WHERE
            s_comment LIKE '%Customer%Complaints%'
    )
GROUP BY
    p_brand,
    p_type,
    p_size
ORDER BY
    supplier_cnt DESC,
    p_brand,
    p_type,
    p_size;
```

The plan created by the Postgres-based planner is as follows:
```
                                                                                         QUERY PLAN                                                                                 
         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=68806.41..68806.70 rows=20 width=44) (actual time=11668.718..11707.579 rows=27840 loops=1)
   Merge Key: (count(DISTINCT partsupp.ps_suppkey)), part.p_brand, part.p_type, part.p_size
   ->  Sort  (cost=68806.41..68806.43 rows=7 width=44) (actual time=10599.432..10601.882 rows=9396 loops=1)
         Sort Key: (count(DISTINCT partsupp.ps_suppkey)) DESC, part.p_brand, part.p_type, part.p_size
         ->  GroupAggregate  (cost=68806.17..68806.32 rows=7 width=44) (actual time=9998.267..10549.516 rows=9396 loops=1)
               Group Key: part.p_brand, part.p_type, part.p_size
               ->  Sort  (cost=68806.17..68806.19 rows=7 width=40) (actual time=9998.137..10215.196 rows=400812 loops=1)
                     Sort Key: part.p_brand, part.p_type, part.p_size
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=48371.50..68806.08 rows=7 width=40) (actual time=4202.299..8506.560 rows=400812 loops=1)
                           Hash Key: part.p_brand, part.p_type, part.p_size
                           ->  Hash Join  (cost=48371.50..68805.94 rows=7 width=40) (actual time=4460.398..6217.312 rows=396062 loops=1)
                                 Hash Cond: (part.p_partkey = partsupp.ps_partkey)
                                 ->  Seq Scan on part  (cost=0.00..20051.67 rows=102056 width=40) (actual time=0.142..593.185 rows=99071 loops=1)
                                       Filter: ((p_brand <> 'Brand#45'::bpchar) AND ((p_type)::text !~~ 'MEDIUM POLISHED%'::text) AND (p_size = ANY ('{49,14,23,45,19,3,36,9}'::integer[])))
                                       Rows Removed by Filter: 566628
                                 ->  Hash  (cost=48371.40..48371.40 rows=8 width=8) (actual time=4192.018..4192.021 rows=2669156 loops=1)
                                       Buckets: 524288 (originally 262144)  Batches: 2 (originally 1)  Memory Usage: 59755kB
                                       ->  Hash Left Anti Semi (Not-In) Join  (cost=600.93..48371.40 rows=8 width=8) (actual time=22.256..2691.610 rows=2669156 loops=1)
                                             Hash Cond: (partsupp.ps_suppkey = supplier.s_suppkey)
                                             ->  Seq Scan on partsupp  (cost=0.00..41103.15 rows=2666715 width=8) (actual time=0.199..1156.450 rows=2670680 loops=1)
                                             ->  Hash  (cost=600.80..600.80 rows=10 width=4) (actual time=19.634..19.635 rows=56 loops=1)
                                                   Buckets: 262144  Batches: 1  Memory Usage: 2050kB
                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..600.80 rows=10 width=4) (actual time=9.768..19.590 rows=56 loops=1)
                                                         ->  Seq Scan on supplier  (cost=0.00..600.67 rows=3 width=4) (actual time=0.933..26.667 rows=22 loops=1)
                                                               Filter: ((s_comment)::text ~~ '%Customer%Complaints%'::text)
                                                               Rows Removed by Filter: 33189
 Optimizer: Postgres-based planner
 Planning Time: 3.316 ms
 Memory used:  128000kB
 Memory wanted:  542599kB
 Execution Time: 11742.974 ms
```

Let's look at the hash left anti-semi join(NOT IN) part of the above plan:
`->  Hash Left Anti Semi (Not-In) Join  (cost=600.93..48371.40 rows=8 width=8) (actual time=22.256..2691.610 rows=2669156 loops=1)`

You can see that the estimated rows are 8, but the real number is 2669156. Why is there such a big gap?
For anti-join or LASJ in this case, the selectivity is determined by the fraction of tuples that do not match. But in the current planner codes,
we have two places that calculate anti-join selectivity.
The first place at the calc_joinrel_size_estimate(), we have below codes:
```
		case JOIN_ANTI:
		case JOIN_LASJ_NOTIN:
			nrows = outer_rows * (1.0 - fkselec * jselec);
			nrows *= pselec;
			break;
```

And the second place at the end of clauselist_selectivity_ext(), we have the following code:
```
       /* 
	 * For Anti Semi Join, selectivity is determined by the fraction of 
	 * tuples that do no match 
	 */
	if (JOIN_ANTI == jointype || JOIN_LASJ_NOTIN == jointype)
	{
		s1 = (1 - s1);
	}
```

I think we should keep the first place just like upstream does; otherwise, the selectivity of the anti-join is the same as that of the inner join.
Because in clauselist_selectivity_ext() we do "s1 = 1 - s1", return from clauselist_selectivity_ext(), in calc_joinrel_size_estimate(),
we do "(1.0 - fkselec*jselec)" again.
In query 16 case, the lasj join clause length is 1, so we return directly in the below code:
```
if (list_length(clauses) == 1)
		return clause_selectivity_ext(root, (Node *) linitial(clauses),
									  varRelid, jointype, sjinfo,
									  use_extended_stats, use_damping);
```

But for pselec, we are not lucky; in this case, pushedquals is null so that it will run the end of clauselist_selectivity_ext(), and return s1=0.
So the join rel size is very small.
With this pr, query 16 plan looks like below:
```
                                                                                                          QUERY PLAN                                                                
                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=129466.82..131671.68 rows=155637 width=44) (actual time=7007.004..7043.549 rows=27840 loops=1)
   Merge Key: (count(partsupp.ps_suppkey)), part.p_brand, part.p_type, part.p_size
   ->  Sort  (cost=129466.82..129596.52 rows=51879 width=44) (actual time=6990.037..6991.899 rows=9396 loops=1)
         Sort Key: (count(partsupp.ps_suppkey)) DESC, part.p_brand, part.p_type, part.p_size
         Sort Method:  quicksort  Memory: 3570kB
         Executor Memory: 2935kB  Segments: 3  Max: 985kB (segment 1)
         ->  HashAggregate  (cost=124885.16..125403.95 rows=51879 width=44) (actual time=6957.837..6961.897 rows=9396 loops=1)
               Group Key: part.p_brand, part.p_type, part.p_size
               Extra Text: (seg0)   hash table(s): 1; chain length 2.0 avg, 3 max; using 9331 of 65536 buckets; total 0 expansions.
 
               Extra Text: (seg2)   hash table(s): 1; chain length 2.0 avg, 3 max; using 9113 of 65536 buckets; total 0 expansions.
 
               ->  HashAggregate  (cost=115924.10..120803.26 rows=408191 width=40) (actual time=5899.845..6499.113 rows=400721 loops=1)
                     Group Key: part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_suppkey, partsupp.ps_suppkey
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=92548.82..105591.78 rows=408191 width=40) (actual time=2086.404..4959.153 rows=400800 loops=1)
                           Hash Key: part.p_brand, part.p_type, part.p_size
                           ->  Streaming HashAggregate  (cost=92548.82..97427.97 rows=408191 width=40) (actual time=2786.927..5287.146 rows=396044 loops=1)
                                 Group Key: part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_suppkey, partsupp.ps_suppkey
                                 ->  Hash Left Anti Semi (Not-In) Join  (cost=21928.29..82216.49 rows=408191 width=40) (actual time=714.377..4151.538 rows=396062 loops=1)
                                       Hash Cond: (partsupp.ps_suppkey = supplier.s_suppkey)
                                       Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 56 of 131072 buckets.
                                       ->  Hash Join  (cost=21327.37..76513.01 rows=408231 width=40) (actual time=675.705..3822.590 rows=396284 loops=1)
                                             Hash Cond: (partsupp.ps_partkey = part.p_partkey)
                                             Extra Text: (seg2)   Hash chain length 1.9 avg, 9 max, using 51185 of 65536 buckets.
                                             ->  Seq Scan on partsupp  (cost=0.00..41103.15 rows=2666715 width=8) (actual time=0.138..1501.295 rows=2670680 loops=1)
                                             ->  Hash  (cost=20051.67..20051.67 rows=102056 width=40) (actual time=675.139..675.140 rows=99071 loops=1)
                                                   Buckets: 65536  Batches: 1  Memory Usage: 7678kB
                                                   ->  Seq Scan on part  (cost=0.00..20051.67 rows=102056 width=40) (actual time=0.121..596.889 rows=99071 loops=1)
                                                         Filter: ((p_brand <> 'Brand#45'::bpchar) AND ((p_type)::text !~~ 'MEDIUM POLISHED%'::text) AND (p_size = ANY ('{49,14,23,45,19,3,36,9}'::integer[])))
                                                         Rows Removed by Filter: 566628
                                       ->  Hash  (cost=600.80..600.80 rows=10 width=4) (actual time=42.621..42.621 rows=56 loops=1)
                                             Buckets: 131072  Batches: 1  Memory Usage: 1026kB
                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..600.80 rows=10 width=4) (actual time=33.428..42.579 rows=56 loops=1)
                                                   ->  Seq Scan on supplier  (cost=0.00..600.67 rows=3 width=4) (actual time=3.175..46.846 rows=22 loops=1)
                                                         Filter: ((s_comment)::text ~~ '%Customer%Complaints%'::text)
                                                         Rows Removed by Filter: 33189
 Optimizer: Postgres-based planner
 Planning Time: 5.197 ms
 Memory used:  128000kB
 Memory wanted:  529473kB
 Execution Time: 7078.125 ms
```

As you can see, this time, the estimate is much more accurate, and the execution time is also 4 seconds faster.
The performance gap will probably be even bigger if the s option becomes bigger. In this case, I choose s = 10(e.g. 10GB).

I also found another issue with the above plan:
```
->  Streaming HashAggregate  (cost=92548.82..97427.97 rows=408191 width=40) (actual time=2786.927..5287.146 rows=396044 loops=1)
        Group Key: part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_suppkey, partsupp.ps_suppkey
```
Why are there three "partsupp.ps_suppkey" in the Group key?
The root cause is fetch_single_dqa_info(). See below codes:
```
            foreach (lcc, ctx->groupClause)
            {
                SortGroupClause *ctx_sortcl = (SortGroupClause *)lfirst(lcc);

                if (!equal(ctx_sortcl, sortcl))
                {
                    info->dqa_group_clause = lappend(info->dqa_group_clause, sortcl);
                }
            }
```
In this case, the ctx->groupClause is p_brand,p_type,p_size, the sortcl is ps_suppkey, which will be appended three times.

I also changed some code comments' style in clausesel.c to be consistent with the upstream.
I don't add new test case in regression, because regression already includes not exists and not in tests.