### PR TITLE
Check MergeAppend node in share input mutator

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1801,6 +1801,14 @@ shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
 			foreach(cell, app->appendplans)
 				shareinput_walker(f, (Node *) lfirst(cell), root);
 		}
+		else if (IsA(node, MergeAppend))
+		{
+			ListCell   *cell;
+			MergeAppend *app = (MergeAppend *) node;
+
+			foreach(cell, app->mergeplans)
+				shareinput_walker(f, (Node *) lfirst(cell), root);
+		}
 		else if (IsA(node, ModifyTable))
 		{
 			ListCell   *cell;

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -284,3 +284,56 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- Test a reproducer which used to fail an assertion while merging two sorted
+-- subplans containing a share input scan node
+CREATE TABLE merge_append_test (
+    grouping_col_1    VARCHAR(64)   ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_2    VARCHAR(1020) ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_3    TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_4    DATE          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_1      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_2      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_3      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_4      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_5      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3)
+)
+WITH (appendonly='true', compresstype=zstd, compresslevel='3', orientation='column')
+DISTRIBUTED BY (grouping_col_1);
+SELECT
+    grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_2) / COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_4),
+    COUNT(DISTINCT metric_col_4) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_3),
+    COUNT(DISTINCT metric_col_3) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_1)
+FROM merge_append_test
+GROUP BY 1, 2, 3
+UNION ALL
+SELECT
+    NULL::DATE AS grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    NULL,
+    NULL,
+    NULL,
+    COUNT(DISTINCT metric_col_4),
+    1.0,
+    NULL,
+    1.0,
+    NULL,
+    1.0,
+    COUNT(DISTINCT metric_col_5) * 1.0
+FROM merge_append_test
+GROUP BY 1, 2, 3
+ORDER BY 1;
+ grouping_col_4 | grouping_col_2 | grouping_col_3 | count | count | ?column? | count | ?column? | count | ?column? | count | ?column? | ?column? 
+----------------+----------------+----------------+-------+-------+----------+-------+----------+-------+----------+-------+----------+----------
+(0 rows)
+

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -297,3 +297,56 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- Test a reproducer which used to fail an assertion while merging two sorted
+-- subplans containing a share input scan node
+CREATE TABLE merge_append_test (
+    grouping_col_1    VARCHAR(64)   ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_2    VARCHAR(1020) ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_3    TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_4    DATE          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_1      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_2      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_3      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_4      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_5      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3)
+)
+WITH (appendonly='true', compresstype=zstd, compresslevel='3', orientation='column')
+DISTRIBUTED BY (grouping_col_1);
+SELECT
+    grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_2) / COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_4),
+    COUNT(DISTINCT metric_col_4) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_3),
+    COUNT(DISTINCT metric_col_3) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_1)
+FROM merge_append_test
+GROUP BY 1, 2, 3
+UNION ALL
+SELECT
+    NULL::DATE AS grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    NULL,
+    NULL,
+    NULL,
+    COUNT(DISTINCT metric_col_4),
+    1.0,
+    NULL,
+    1.0,
+    NULL,
+    1.0,
+    COUNT(DISTINCT metric_col_5) * 1.0
+FROM merge_append_test
+GROUP BY 1, 2, 3
+ORDER BY 1;
+ grouping_col_4 | grouping_col_2 | grouping_col_3 | count | count | ?column? | count | ?column? | count | ?column? | count | ?column? | ?column? 
+----------------+----------------+----------------+-------+-------+----------+-------+----------+-------+----------+-------+----------+----------
+(0 rows)
+

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -137,3 +137,56 @@ select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(d
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+
+-- Test a reproducer which used to fail an assertion while merging two sorted
+-- subplans containing a share input scan node
+CREATE TABLE merge_append_test (
+    grouping_col_1    VARCHAR(64)   ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_2    VARCHAR(1020) ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_3    TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    grouping_col_4    DATE          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_1      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_2      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_3      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_4      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3),
+    metric_col_5      TEXT          ENCODING (compresstype=zstd, blocksize=32768, compresslevel=3)
+)
+WITH (appendonly='true', compresstype=zstd, compresslevel='3', orientation='column')
+DISTRIBUTED BY (grouping_col_1);
+
+SELECT
+    grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_2) / COUNT(DISTINCT metric_col_1),
+    COUNT(DISTINCT metric_col_4),
+    COUNT(DISTINCT metric_col_4) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_3),
+    COUNT(DISTINCT metric_col_3) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_2),
+    COUNT(DISTINCT metric_col_5) * 1.0 / COUNT(DISTINCT metric_col_1)
+FROM merge_append_test
+GROUP BY 1, 2, 3
+
+UNION ALL
+
+SELECT
+    NULL::DATE AS grouping_col_4,
+    grouping_col_2,
+    grouping_col_3,
+    NULL,
+    NULL,
+    NULL,
+    COUNT(DISTINCT metric_col_4),
+    1.0,
+    NULL,
+    1.0,
+    NULL,
+    1.0,
+    COUNT(DISTINCT metric_col_5) * 1.0
+FROM merge_append_test
+GROUP BY 1, 2, 3
+ORDER BY 1;


### PR DESCRIPTION
This fixes incorrect plan processing, leading to assertion failures or segfaults

repro:
```

CREATE TABLE tt (
    col1 character varying(64) ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    col2 character varying(1020) ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    col3 text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    col4 date ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    u_w_s text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    u_w_r text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    u_w_rej text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    u_w_a text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    u_w_c text ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
)
WITH (appendonly='true', compresstype=zstd, compresslevel='3', orientation='column')
 DISTRIBUTED BY (col1);


explain analyze SELECT
    col4
    , col2
    , col3
    , COUNT(DISTINCT u_w_s) AS TRAFFIC
    , COUNT(DISTINCT u_w_r) AS CLICKS
    , COUNT(DISTINCT u_w_r) / COUNT(DISTINCT u_w_s) AS CR_TRAFFIC_CLICK
    , COUNT(DISTINCT u_w_a) AS APPROVES
    , COUNT(DISTINCT u_w_a) * 1.0 / COUNT(DISTINCT u_w_r) AS CR_CLICK_APPROVE
    , COUNT(DISTINCT u_w_rej) AS REJECTS
    , COUNT(DISTINCT u_w_rej) * 1.0 / COUNT(DISTINCT u_w_r) AS CR_CLICK_REJECT
    , COUNT(DISTINCT u_w_c) AS CONFIRMS
    , COUNT(DISTINCT u_w_c) * 1.0 / COUNT(DISTINCT u_w_r) AS CR_CLICK_CONFIRM
    , COUNT(DISTINCT u_w_c) * 1.0 / COUNT(DISTINCT u_w_s)  AS CR_TRAFFIC_CONFIRM
FROM tt
GROUP BY    1,2,3
union all
select
    NULL::date as col4
    , col2
    , col3
    , NULL AS TRAFFIC
    , NULL AS CLICKS
    , NULL AS CR_TRAFFIC_CLICK
    , COUNT(DISTINCT u_w_a) AS APPROVES
    , 1.0 AS CR_CLICK_APPROVE
    , NULL  AS REJECTS
    , 1.0 AS CR_CLICK_REJECT
    , NULL AS CONFIRMS
    , 1.  AS CR_CLICK_CONFIRM
    , COUNT(DISTINCT u_w_c) * 1.0 AS CR_TRAFFIC_CONFIRM
FROM tt
GROUP BY   1, 2,3
order by 1
;

```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
