### PR TITLE
6X: Ensure error detection reliability in the status_check case

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -259,12 +259,13 @@ insert into t1 select generate_series(1,100);
 ---------- Test9: Test parallel retrieve cursor auto-check
 1: drop table if exists t1;
 1: create table t1(a int, b int);
-1: insert into t1 values (generate_series(1,100000), 1);
+-- Do not reduce the data volume — see the comment below.
+1: insert into t1 values (generate_series(1,128000), 1);
 1: insert into t1 values (-1, 1);
 1: BEGIN;
-1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
--- GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT is 10s, we sleep 12 to check all QEs are already finished.
-1: ! sleep 12;
-1: SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
-1: rollback;
+-- Most of the time, the current data volume is sufficient to allow c9 to run
+-- normally at first. Then, any error that occurs on a non-root slice is caught
+-- by GP_PARALLEL_RETRIEVE_CURSOR_CHECK. However, this is not guaranteed, so we
+-- simply check for errors here.
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR SELECT count(*) FROM t1 GROUP BY sqrt(a); ROLLBACK;
 1q:

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -1397,24 +1397,17 @@ END
 DROP
 1: create table t1(a int, b int);
 CREATE
-1: insert into t1 values (generate_series(1,100000), 1);
-INSERT 100000
+-- Do not reduce the data volume — see the comment below.
+1: insert into t1 values (generate_series(1,128000), 1);
+INSERT 128000
 1: insert into t1 values (-1, 1);
 INSERT 1
 1: BEGIN;
 BEGIN
-1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
- count 
--------
- 3     
-(1 row)
--- GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT is 10s, we sleep 12 to check all QEs are already finished.
-1: ! sleep 12;
-
-1: SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
- endpointname | auth_token | hostname | port | state 
---------------+------------+----------+------+-------
-(0 rows)
-1: rollback;
-ERROR:  cannot take square root of a negative number  (seg2 slice1 127.0.1.1:6004 pid=83657)
+-- Most of the time, the current data volume is sufficient to allow c9 to run
+-- normally at first. Then, any error that occurs on a non-root slice is caught
+-- by GP_PARALLEL_RETRIEVE_CURSOR_CHECK. However, this is not guaranteed, so we
+-- simply check for errors here.
+1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR SELECT count(*) FROM t1 GROUP BY sqrt(a); ROLLBACK;
+ERROR:  cannot take square root of a negative number  (seg2 slice1 127.0.0.1:40002 pid=140405)
 1q: ... <quitting>


### PR DESCRIPTION
We cannot guarantee that errors on non-root slices will always surface
in a predictable way. Sometimes the error occurs right at the beginning,
other times it's caught later by GP_PARALLEL_RETRIEVE_CURSOR_CHECK.

Instead of relying on such timing, we now simply check whether the error occurs.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`

