### PR TITLE
Fix deprecated python pipes module

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -22,7 +22,7 @@ import tempfile
 import time
 from datetime import datetime, timedelta
 from contextlib import closing
-import pipes  # for shell-quoting, pipes.quote()
+import shlex  # for shell-quoting, shlex.quote()
 import fcntl
 import itertools
 import psycopg2
@@ -949,7 +949,7 @@ class AnalyzeDb(Operation):
 
 # Create a Command object that executes a query using psql.
 def create_psql_command(dbname, query):
-    psql_cmd = """psql %s -c %s""" % (pipes.quote(dbname), pipes.quote(query))
+    psql_cmd = """psql %s -c %s""" % (shlex.quote(dbname), shlex.quote(query))
     return Command(query, psql_cmd)
 
 

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -16,6 +16,7 @@ import os
 import sys
 import re
 import psutil
+import shlex
 from psycopg2 import DatabaseError
 try:
     from gppylib.gpparseopts import OptParser, OptChecker
@@ -382,7 +383,7 @@ def do_change(options):
 
     # Replace literal empty strings with empty quotes, or it will look like the
     # user passed in an incorrect argument, which would be misleading
-    params = [pipes.quote(arg) for arg in sys.argv[1:]]
+    params = [shlex.quote(arg) for arg in sys.argv[1:]]
     params = " ".join(params)
     if failure:
         LOGGER.error("finished with errors, parameter string '%s'" % params)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -12,7 +12,6 @@ import base64
 import pickle
 import shlex
 import os.path
-import pipes
 import subprocess
 
 import re, socket
@@ -923,7 +922,7 @@ class ConfigureNewSegment(Command):
                  batchSize=None, verbose=False,ctxt=LOCAL, remoteHost=None, validationOnly=False, writeGpIdFileOnly=False,
                  forceoverwrite=False):
 
-        cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, pipes.quote(logdir))
+        cmdStr = '$GPHOME/bin/lib/gpconfigurenewsegment -c \"%s\" -l %s' % (confinfo, shlex.quote(logdir))
 
         if newSegments:
             cmdStr += ' -n'
@@ -1025,7 +1024,7 @@ class GpSegRecovery(Command):
 
 
 def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite, era=None, maxRate=None):
-    cmdStr = '$GPHOME/sbin/{}.py -c {} -l {}'.format(wrapper_filename, pipes.quote(confinfo), pipes.quote(logdir))
+    cmdStr = '$GPHOME/sbin/{}.py -c {} -l {}'.format(wrapper_filename, shlex.quote(confinfo), shlex.quote(logdir))
 
     if verbose:
         cmdStr += ' -v'

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -4,7 +4,7 @@
 #
 
 import os
-import pipes
+import shlex
 
 from gppylib.gplog import *
 from gppylib.gparray import *
@@ -329,7 +329,7 @@ class PgRewind(Command):
         # pg_rewind prints progress updates to stdout, but it also prints
         # errors relating to relevant failures(like it will not rewind due to
         # a corrupted pg_control file) to stderr.
-        rewind_cmd = rewind_cmd + " > {} 2>&1".format(pipes.quote(progress_file))
+        rewind_cmd = rewind_cmd + " > {} 2>&1".format(shlex.quote(progress_file))
         self.cmdStr = rewind_cmd
 
         Command.__init__(self, name, self.cmdStr, LOCAL)
@@ -408,7 +408,7 @@ class PgBaseBackup(Command):
         cmd_tokens.append('--verbose')
 
         if progress_file:
-            cmd_tokens.append('> %s 2>&1' % pipes.quote(progress_file))
+            cmd_tokens.append('> %s 2>&1' % shlex.quote(progress_file))
 
         cmd_str = ' '.join(cmd_tokens)
 

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -13,7 +13,7 @@ import shlex
 import socket
 import signal
 import uuid
-import pipes
+import shlex
 import re
 from pkg_resources import parse_version
 
@@ -613,7 +613,7 @@ class Rsync(Command):
         # Combines output streams, uses 'sed' to find lines with 'kB/s' or 'MB/s' and appends ':%s' as suffix to the end
         # of each line and redirects it to progress_file
         if progress_file:
-            cmd_tokens.append('2>&1 | tr "\\r" "\\n" |sed -E "/[0-9]+%/ s/$/ :{0}/" > {1}' .format(name, pipes.quote(progress_file)))
+            cmd_tokens.append('2>&1 | tr "\\r" "\\n" |sed -E "/[0-9]+%/ s/$/ :{0}/" > {1}' .format(name, shlex.quote(progress_file)))
 
         cmdStr = ' '.join(cmd_tokens)
         cmdStr = "set -o pipefail; {}".format(cmdStr)

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -1,6 +1,6 @@
 from contextlib import closing
 import os
-import pipes
+import shlex
 import signal
 import time
 import re
@@ -531,13 +531,13 @@ class GpMirrorListToBuild:
 
                 cmd_str = (
                     "set -o pipefail; touch -a {0}; tail -3 {0} | sed -n -e '/:Syncing.*dbid/p; /error:/p; /total/p' | tr '\\r' '\\n' | tail -1"
-                    .format(pipes.quote(progressFile))
+                    .format(shlex.quote(progressFile))
                 )
             else:
                 # For full and incremental recovery, simply tail the last line.
                 cmd_str = (
                     "set -o pipefail; touch -a {0}; tail -1 {0} | tr '\\r' '\\n' | tail -1"
-                    .format(pipes.quote(progressFile))
+                    .format(shlex.quote(progressFile))
                 )
 
             progress_command = GpMirrorListToBuild.ProgressCommand(
@@ -551,7 +551,7 @@ class GpMirrorListToBuild:
         return None
 
     def _get_remove_cmd(self, remove_file, target_host):
-        return base.Command("remove file", "find {} -name {} -delete".format(gplog.get_logger_dir(), pipes.quote(remove_file)), ctxt=base.REMOTE, remoteHost=target_host)
+        return base.Command("remove file", "find {} -name {} -delete".format(gplog.get_logger_dir(), shlex.quote(remove_file)), ctxt=base.REMOTE, remoteHost=target_host)
 
     def __runWaitAndCheckWorkerPoolForErrorsAndClear(self, cmds, suppressErrorCheck=False, progressCmds=[]):
         for cmd in cmds:

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4,7 +4,7 @@ import glob
 import json
 import os
 import re
-import pipes
+import shlex
 import shutil
 import socket
 import tempfile
@@ -1424,7 +1424,7 @@ def stop_segments(context, where_clause):
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
         subprocess.check_call(['ssh', seg.getSegmentHostName(),
                                'source %s/greenplum_path.sh && pg_ctl stop -m fast -D %s -w -t 120' % (
-                                   pipes.quote(os.environ.get("GPHOME")), pipes.quote(seg.getSegmentDataDirectory()))
+                                   shlex.quote(os.environ.get("GPHOME")), shlex.quote(seg.getSegmentDataDirectory()))
                                ])
 
 
@@ -1458,7 +1458,7 @@ def stop_segments_immediate(context, where_clause):
         # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
         subprocess.check_call(['ssh', seg.getSegmentHostName(),
                                'source %s/greenplum_path.sh && pg_ctl stop -m immediate -D %s -w' % (
-                                   pipes.quote(os.environ.get("GPHOME")), pipes.quote(seg.getSegmentDataDirectory()))
+                                   shlex.quote(os.environ.get("GPHOME")), shlex.quote(seg.getSegmentDataDirectory()))
                                ])
 
 @given('user can start transactions')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -958,8 +958,8 @@ def impl(context):
 
     hosts_list = GpArray.initFromCatalog(dbconn.DbURL()).getHostList()
     for host in hosts_list:
-        run_cmd('ssh %s mkdir -p %s' % (pipes.quote(host),  "/tmp/gpmovemirrors_disk"))
-        run_cmd('ssh %s %s ' %(pipes.quote(host), cmdStr))
+        run_cmd('ssh %s mkdir -p %s' % (shlex.quote(host),  "/tmp/gpmovemirrors_disk"))
+        run_cmd('ssh %s %s ' %(shlex.quote(host), cmdStr))
 
     context.mirror_context.working_directory.append("/tmp/gpmovemirrors_disk")
     context.umount_required = True
@@ -969,6 +969,6 @@ def impl(context):
     cmdStr = "sudo umount /tmp/gpmovemirrors_disk"
     hosts_list = GpArray.initFromCatalog(dbconn.DbURL()).getHostList()
     for host in hosts_list:
-        run_cmd('ssh %s %s ' % (pipes.quote(host), cmdStr))
-        run_cmd('ssh %s rm -rf %s' % (pipes.quote(host), "/tmp/gpmovemirrors_disk"))
+        run_cmd('ssh %s %s ' % (shlex.quote(host), cmdStr))
+        run_cmd('ssh %s rm -rf %s' % (shlex.quote(host), "/tmp/gpmovemirrors_disk"))
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -1,4 +1,4 @@
-import pipes
+import shlex
 import tempfile
 import os
 
@@ -22,7 +22,7 @@ class Tablespace:
 
         gparray = GpArray.initFromCatalog(dbconn.DbURL())
         for host in gparray.getHostList():
-            run_cmd('ssh %s mkdir -p %s' % (pipes.quote(host), pipes.quote(self.path)))
+            run_cmd('ssh %s mkdir -p %s' % (shlex.quote(host), shlex.quote(self.path)))
 
         conn = dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)
         dbconn.execSQL(conn, "CREATE TABLESPACE %s LOCATION '%s'" % (self.name, self.path))
@@ -56,7 +56,7 @@ class Tablespace:
 
         gparray = GpArray.initFromCatalog(dbconn.DbURL())
         for host in gparray.getHostList():
-            run_cmd('ssh %s rm -rf %s' % (pipes.quote(host), pipes.quote(self.path)))
+            run_cmd('ssh %s rm -rf %s' % (shlex.quote(host), shlex.quote(self.path)))
 
     def verify(self, hostname=None, port=0):
         """

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import fileinput
 import os
-import pipes
+import shlex
 import re
 import signal
 import stat
@@ -230,7 +230,7 @@ def stop_primary(context, content_id):
     # Thus, need to add pg_ctl to the path when ssh'ing to a demo cluster.
     subprocess.check_call(['ssh', seg_host,
                            'source %s/greenplum_path.sh && pg_ctl stop -m fast -D %s' % (
-                               pipes.quote(os.environ.get("GPHOME")), pipes.quote(seg_data_dir))
+                               shlex.quote(os.environ.get("GPHOME")), shlex.quote(seg_data_dir))
                            ])
 
 

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -36,7 +36,6 @@ try:
 except:
     import subprocess
 import threading
-import pipes  # for shell-quoting, pipes.quote()
 import os
 from collections import defaultdict
 import psycopg2


### PR DESCRIPTION
'pipes' module has been deprecated since python 3.11 and removed in
3.13. See https://peps.python.org/pep-0594/ .

'pipes.quotes()' has been deprecated even earlier since python 2.7,
and it can be simply replaced by 'shlex.quotes()'.

Tests using 'pipes.Template()' are rewritten by 'subprocess'.
