### PR TITLE
Bye bye PYTHONPATH

### DIFF
--- a/gpAux/client/scripts/greenplum_clients_path.sh
+++ b/gpAux/client/scripts/greenplum_clients_path.sh
@@ -23,14 +23,12 @@ else
 fi
 
 PATH=${GPHOME_CLIENTS}/bin:${PATH}
-PYTHONPATH=${GPHOME_CLIENTS}/bin/ext:${PYTHONPATH}
 
 # Export GPHOME_LOADERS for GPDB5 compatible
 GPHOME_LOADERS=${GPHOME_CLIENTS}
 export GPHOME_CLIENTS
 export GPHOME_LOADERS
 export PATH
-export PYTHONPATH
 
 # Mac OSX uses a different library path variable
 if [ xDarwin = x`uname -s` ]; then

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -232,7 +232,7 @@ cat <<-EOF
 
 EOF
 
-GPPATH=`find -H $GPHOME -name gpstart| tail -1`
+GPPATH=`find -H $GPHOME -name gpinitsystem | tail -1`
 RETVAL=$?
 
 if [ "$RETVAL" -ne 0 ]; then

--- a/gpAux/gpdemo/probe_config.sh
+++ b/gpAux/gpdemo/probe_config.sh
@@ -16,7 +16,7 @@ else
   GPSEARCH=$GPHOME
 fi
 
-GPPATH=`find $GPSEARCH -name gpstart | tail -1`
+GPPATH=`find $GPSEARCH -name gpinitsystem | tail -1`
 RETVAL=$?
 
 if [ "$RETVAL" -ne 0 ]; then

--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -12,11 +12,12 @@ SUBDIRS += ifaddrs
 
 $(recurse)
 
-PROGRAMS= analyzedb gpactivatestandby gpaddmirrors gpcheckcat gpcheckperf \
+PY_PROGRAMS = analyzedb gpactivatestandby gpaddmirrors gpcheckcat gpcheckperf \
 	gpcheckresgroupimpl gpconfig gpdeletesystem gpexpand gpinitstandby \
-	gpinitsystem gpload gpload.py gplogfilter gpmovemirrors \
+	gpload.py gplogfilter gpmovemirrors \
 	gprecoverseg gpreload gpsync gpsd gpssh gpssh-exkeys gpstart \
 	gpstate gpstop minirepro gpmemwatcher gpmemreport gpcheckresgroupv2impl
+PROGRAMS = gpinitsystem gpload
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/lib'
@@ -25,6 +26,13 @@ installprograms: installdirs
 	for file in $(PROGRAMS); do \
 		$(INSTALL_SCRIPT) $$file '$(DESTDIR)$(bindir)/'$$file ; \
 		$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(bindir)/'$$file ; \
+	done
+	# Put the python executables next to the gppylib, so they can find it.
+	for file in $(PY_PROGRAMS); do \
+		$(INSTALL_SCRIPT) $$file '$(DESTDIR)$(libdir)/python/'$$file ; \
+		$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/'$$file ; \
+		cd $(DESTDIR)$(bindir)/ && $(LN_S) ../lib/python/$$file . ; \
+		cd $(CURDIR) ; \
 	done
 	# Symlink gpcheckcat from bin to bin/lib to maintain backward compatibility
 	if [ ! -L $(DESTDIR)$(bindir)/lib/gpcheckcat  ]; then \
@@ -35,6 +43,10 @@ installprograms: installdirs
 uninstall:
 	for file in $(PROGRAMS); do \
 		rm -f '$(DESTDIR)$(bindir)/'$$file ; \
+	done
+	for file in $(PY_PROGRAMS); do \
+		rm -f '$(DESTDIR)$(bindir)/'$$file ; \
+		rm -f '$(DESTDIR)$(libdir)/python/'$$file ; \
 	done
 	rm -f '$(DESTDIR)$(bindir)/gpload.bat'
 

--- a/gpMgmt/bin/README.md
+++ b/gpMgmt/bin/README.md
@@ -6,14 +6,10 @@ On most distributions, python will compiled with the same gcc and g++ verion ava
 The command `python -VV` will show the compiler used to compile the version of python being used.
 A `make` in from gpMgmt will install the proper libraries provided a gcc and gcc-c++ are present.
 
-To run any of these python scripts, necessary libraries must be installed, and PYTHONPATH must be modified to use the libraries in this path.
+Avoid relying on the `PYTHONPATH` in the script:
 
-```
-PYTHONPATH="\$GPHOME/lib/python:${PYTHONPATH}"
-```
-
-This will be set automatically with a `source $GPHOME/greenplum_path.sh`
-
+- For python executables, put it in `lib/python` next to `gppylib` and make symbolic links in `bin` or `sbin`.
+- For remote python statement execution, create a `PyCommand` object.
 
 ## Python Version
 

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -27,7 +27,6 @@ fi
 EOF
 
 cat <<"EOF"
-PYTHONPATH="${GPHOME}/lib/python"
 PATH="${GPHOME}/bin:${PATH}"
 LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
@@ -37,7 +36,6 @@ fi
 
 export GPHOME
 export PATH
-export PYTHONPATH
 export LD_LIBRARY_PATH
 export OPENSSL_CONF
 

--- a/gpMgmt/bin/gpinitstandby
+++ b/gpMgmt/bin/gpinitstandby
@@ -424,14 +424,15 @@ def create_standby(options):
                                    standby.datadir,
                                    standby.port)
         except Exception as ex:
-            raise GpInitStandbyException('failed to start standby')
+            raise GpInitStandbyException('failed to start standby. '
+                                         + str(ex))
 
     except Exception as ex:
         # Something went wrong.  Based on the current state, we can rollback
         # the operation.
-        logger.error('Failed to create standby')
+        logger.error('Failed to create standby ' + str(ex))
         if g_init_standby_state != INIT_STANDBY_STATE_NOT_STARTED:
-            logger.warn('Trying to rollback changes that have been made...')
+            logger.warning('Trying to rollback changes that have been made...')
 
         if g_init_standby_state == INIT_STANDBY_STATE_UPDATE_CATALOG:
 

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -639,6 +639,19 @@ class SQLCommand(Command):
         if self.cancel_conn:
             self.cancel_conn.cancel()
 
+
+class PyCommand(Command):
+    """
+    Call python interpreter to execute statements through Command interface.
+    """
+
+    def __init__(self, name, py_stmt, ctxt=LOCAL, remoteHost=None):
+        cmd = 'cd "${GPHOME}/lib/python" && ' + \
+                "python3 -c '{stmt}'".format(stmt=py_stmt)
+        Command.__init__(self, name, cmdStr=cmd,
+                         ctxt=ctxt, remoteHost=remoteHost)
+
+
 class CommandNotFoundException(Exception):
     def __init__(self, cmd, paths):
         self.cmd = cmd

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -30,6 +30,7 @@ logger = get_default_logger()
 
 #TODO:  need a better way of managing environment variables.
 GPHOME=os.environ.get('GPHOME')
+GPHOME_PYLIB=GPHOME+"/lib/python"
 
 #Default timeout for segment start
 SEGMENT_TIMEOUT_DEFAULT=600
@@ -1400,13 +1401,14 @@ def start_standbycoordinator(host, datadir, port, era=None,
     logger.info("Starting standby coordinator")
 
     logger.info("Checking if standby coordinator is running on host: %s  in directory: %s" % (host,datadir))
-    cmd = Command("recovery_startup",
-                  ("python3 -c "
-                   "'from gppylib.commands.gp import recovery_startup; "
-                   """recovery_startup("{0}", "{1}")'""").format(
-                       datadir, port),
-                  ctxt=REMOTE, remoteHost=host)
+    stmt = (
+        "from gppylib.commands.gp import recovery_startup; "
+        + """recovery_startup("{0}", "{1}")""".format(datadir, port)
+    )
+    cmd = PyCommand(name="recovery_startup", py_stmt=stmt,
+                    ctxt=REMOTE, remoteHost=host)
     cmd.run()
+
     res = cmd.get_results().stderr
 
     if res:
@@ -1434,11 +1436,12 @@ def start_standbycoordinator(host, datadir, port, era=None,
         # the first few cycles, which we have seen when trying wrapper
         # shell script.
         pid = getPostmasterPID(host, datadir)
-        cmd = Command("get pids",
-                      ("python3 -c "
-                       "'from gppylib.commands import unix; "
-                       "print(unix.getDescendentProcesses({0}))'".format(pid)),
-                      ctxt=REMOTE, remoteHost=host)
+        stmt = (
+            "from gppylib.commands import unix;"
+            + "print(unix.getDescendentProcesses({0}))".format(pid)
+        )
+
+        cmd = PyCommand("get pids", py_stmt=stmt, ctxt=REMOTE, remoteHost=host)
         cmd.run()
         logger.debug(str(cmd))
         result = cmd.get_results()
@@ -1633,10 +1636,13 @@ def get_local_db_mode(coordinator_data_dir):
 ######
 def read_postmaster_pidfile(datadir, host=None):
     if host:
-        cmdStr ="""python3 -c 'from {module} import {func}; print({func}("{args}"))'""".format(module=sys.modules[__name__].__name__,
-                                                                                             func='read_postmaster_pidfile',
-                                                                                             args=datadir)
-        cmd = Command(name='run this method remotely', cmdStr=cmdStr, ctxt=REMOTE, remoteHost=host)
+        stmt = (
+            "from gppylib.commands.gp import read_postmaster_pidfile; "
+            + """print(read_postmaster_pidfile("{args}"))""".format(args=datadir)
+        )
+        cmd = PyCommand(
+            name="run this method remotely", py_stmt=stmt, ctxt=REMOTE, remoteHost=host
+        )
         cmd.run(validateAfter=True)
         return int(cmd.get_results().stdout.strip())
     pid=0

--- a/gpMgmt/bin/gppylib/operations/initstandby.py
+++ b/gpMgmt/bin/gppylib/operations/initstandby.py
@@ -8,7 +8,7 @@ from gppylib.mainUtils import addStandardLoggingAndHelpOptions
 from collections import defaultdict
 from gppylib import gplog
 from gppylib.commands import unix, gp
-from gppylib.commands.base import REMOTE, WorkerPool, Command
+from gppylib.commands.base import REMOTE, WorkerPool, PyCommand
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations import Operation
 
@@ -31,12 +31,17 @@ def create_standby_pg_hba_entries(standby_host, is_hba_hostnames=False):
         standby_pg_hba_info.append('host\tall\t%s\t%s\ttrust\n' % (current_user, address))
     return standby_pg_hba_info
 
-def cleanup_pg_hba_backup(data_dirs_list):
+def cleanup_pg_hba_backup(data_dirs_list, json_input=False):
     """
     cleanup the backup of pg_hba.config created on segments
     """
+    if json_input:
+        data_dirs = json.loads(data_dirs_list)
+    else:
+        data_dirs = data_dirs_list
+
     try:
-        for data_dir in data_dirs_list:
+        for data_dir in data_dirs:
             backup_file = os.path.join(data_dir, PG_HBA_BACKUP)
             if os.path.exists(backup_file):
                 os.remove(backup_file)
@@ -65,11 +70,22 @@ def cleanup_pg_hba_backup_on_segment(gparr, unreachable_hosts=[]):
             if host in unreachable_hosts:
                 continue
             json_data_dirs_list = json.dumps(data_dirs_list)
-            cmdStr = "$GPHOME/lib/python/gppylib/operations/initstandby.py -d '%s' -D" % json_data_dirs_list
-            cmd = Command('Cleanup the pg_hba.conf backups on remote hosts', cmdStr=cmdStr , ctxt=REMOTE, remoteHost=host)
+            stmt = (
+                "from gppylib.operations.initstandby import cleanup_pg_hba_backup;"
+                + 'cleanup_pg_hba_backup("""{0}""", json_input=True)'.format(
+                    json_data_dirs_list
+                )
+            )
+            cmd = PyCommand(
+                "Cleanup the pg_hba.conf backups on remote hosts",
+                py_stmt=stmt,
+                ctxt=REMOTE,
+                remoteHost=host,
+            )
             pool.addCommand(cmd)
 
         pool.join()
+        pool.check_results()
 
         for item in pool.getCompletedItems():
             result = item.get_results()
@@ -82,8 +98,13 @@ def cleanup_pg_hba_backup_on_segment(gparr, unreachable_hosts=[]):
         pool.joinWorkers()
         pool = None
 
-def restore_pg_hba(data_dirs_list):
-    for data_dir in data_dirs_list:
+def restore_pg_hba(data_dirs_list, json_input=False):
+    if json_input:
+        data_dirs = json.loads(data_dirs_list)
+    else:
+        data_dirs = data_dirs_list
+
+    for data_dir in data_dirs:
         logger.info('Restoring pg_hba.conf for %s' % data_dir)
         os.system('mv %s/%s %s/pg_hba.conf' % (data_dir, PG_HBA_BACKUP, data_dir))
 
@@ -104,11 +125,20 @@ def restore_pg_hba_on_segment(gparr):
     try:
         for host, data_dirs_list in list(host_to_seg_map.items()):
             json_data_dirs_list = json.dumps(data_dirs_list)
-            cmdStr = "$GPHOME/lib/python/gppylib/operations/initstandby.py -d '%s' -r" % json_data_dirs_list
-            cmd = Command('Restore the pg_hba.conf on remote hosts', cmdStr=cmdStr , ctxt=REMOTE, remoteHost=host)
+            stmt = (
+                "from gppylib.operations.initstandby import restore_pg_hba;"
+                + 'restore_pg_hba("""{0}""", json_input=True)'.format(json_data_dirs_list)
+            )
+            cmd = PyCommand(
+                "Restore the pg_hba.conf on remote hosts",
+                py_stmt=stmt,
+                ctxt=REMOTE,
+                remoteHost=host,
+            )
             pool.addCommand(cmd)
 
         pool.join()
+        pool.check_results()
 
         for item in pool.getCompletedItems():
             result = item.get_results()
@@ -168,6 +198,9 @@ def create_parser():
 
     return parser
 
+
+# NOTE: The 'main' is not called by management utilities. If it is not used by
+# manual maintenance, then remove it.
 if __name__ == '__main__':
     parser = create_parser()
     (options, args) = parser.parse_args()

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -31,7 +31,7 @@ if [ ${#GPPATH[@]} -eq 0 ];then
 fi
 
 #GP_UNIQUE_COMMAND is used to identify the binary directory
-GP_UNIQUE_COMMAND=gpstart
+GP_UNIQUE_COMMAND=gpinitsystem
 
 
 findCmdInPath() {

--- a/gpMgmt/sbin/Makefile
+++ b/gpMgmt/sbin/Makefile
@@ -9,22 +9,27 @@ PYCS= gpconfig_helper.pyc gpoperation.pyc gpsegstop.pyc gpcleansegmentdir.pyc \
 	gpgetstatususingtransition.pyc gpsegstart.pyc seg_update_pg_hba.pyc \
 	gpsegrecovery.pyc gpsegsetuprecovery.pyc recovery_base.pyc
 
-PROGRAMS= gpconfig_helper.py gpoperation.py gpsegstop.py gpcleansegmentdir.py \
+PY_PROGRAMS= gpconfig_helper.py gpoperation.py gpsegstop.py gpcleansegmentdir.py \
 	gpgetstatususingtransition.py gpsegstart.py packcore seg_update_pg_hba.py \
 	gpsegrecovery.py gpsegsetuprecovery.py recovery_base.py
 
 installdirs:
+	$(MKDIR_P) '$(DESTDIR)$(libdir)/python'
 	$(MKDIR_P) '$(DESTDIR)$(sbindir)'
 
 install: installdirs
-	for file in $(PROGRAMS); do \
-		$(INSTALL_SCRIPT) $$file '$(DESTDIR)$(sbindir)/'$$file ; \
-		$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(sbindir)/'$$file ; \
+	# Put the python executables next to the gppylib, so they can find it.
+	for file in $(PY_PROGRAMS); do \
+		$(INSTALL_SCRIPT) $$file '$(DESTDIR)$(libdir)/python/'$$file ; \
+		$(PERL) $(top_builddir)/putversion '$(DESTDIR)$(libdir)/python/'$$file ; \
+		cd $(DESTDIR)$(sbindir)/ && $(LN_S) ../lib/python/$$file . ; \
+		cd $(CURDIR) ; \
 	done
 
 uninstall:
-	for file in $(PROGRAMS); do \
+	for file in $(PY_PROGRAMS); do \
 		rm -f '$(DESTDIR)$(sbindir)/'$$file ; \
+		rm -f '$(DESTDIR)$(libdir)/python/'$$file ; \
 	done
 
 clean distclean:

--- a/src/pl/plpython/plpy_main.c
+++ b/src/pl/plpython/plpy_main.c
@@ -164,21 +164,6 @@ PLy_initialize(void)
 		ereport(FATAL,
 				(errmsg("multiple Python libraries are present in session"),
 				 errdetail("Only one Python major version can be used in one session.")));
-#if PY_MAJOR_VERSION >= 3
-	/* PYTHONPATH and PYTHONHOME has been set to GPDB's python2.7 in Postmaster when
-	 * gpstart. So for plpython3u, we need to unset PYTHONPATH and PYTHONHOME.
-	 * if user set PYTHONPATH then we set it in the env
-	 */
-	if (plpython3_path && *plpython3_path)
-	{
-		setenv("PYTHONPATH", plpython3_path, 1);
-	}
-	else
-	{
-		unsetenv("PYTHONPATH");
-	}
-	unsetenv("PYTHONHOME");
-#endif
 	/* The rest should only be done once per session */
 	if (inited)
 		return;


### PR DESCRIPTION
`PYTHONPATH` has been used from the beginning of gpdb to setup the python libs for management tools. By source the `greenplum_path.sh`, all the sub-processes will see the `PYTHONPATH`, and it pollutes all the python environments in the sub-processes, including the plpython, pgml, development and etc..

From GP7, the 3rd party libs have been removed which makes `gppylib` a bit cleaner. But it is still a pain in the ass which constantly gives users surprises, e.g.: management tools cannot be called in the plpython UDF since the `PYTHONPATH` was remove from there one purpose.

The python code here is a bit messy, this commit doesn't make a huge improvements. It just removes the ENV by define some principles:

- Python interpreter will try to look for libs in the existence directory of the given python source file.
- `python -c` uses the current working directory.
- All the python executables files should exist in `$GPHOME/lib/python` and make symbolics links in the `bin`/`sbin` directories so they can find `gppylib`.
- When calling a remote python statement, use `PyCommand` which will set the CDW to `GPHOME/lib/python` first to make sure `sys.path` has the right value.
- `greenplum_path.sh` won't touch the ENV anymore, if user still want to set it, then it is user's choice.

P.S.:
- In theory, no python files in the `gppylib` should be executed directly. But no idea why do they have `#!python` in the header.
- Since the ENV is gone, no need to unset it in plpython anymore.
- Some `PYTHONPATH` are not removed like those in the test files. They don't seem to be important, remove them later.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
