### PR TITLE
Fix flaky tests caused by sequential partition locking in REINDEX TABLE

### DIFF
--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
@@ -21,7 +21,7 @@ SELECT 12
 BEGIN
 1: LOCK reindex_crtab_part_ao_btree IN ACCESS EXCLUSIVE MODE;
 LOCK TABLE
-2&: REINDEX TABLE  reindex_crtab_part_ao_btree;  <waiting ...>
+2&: REINDEX TABLE reindex_crtab_part_ao_btree_1_prt_de_fault;  <waiting ...>
 3:BEGIN;
 BEGIN
 3&: reindex index reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx;  <waiting ...>
@@ -40,8 +40,8 @@ INSERT 0 12
  count | relname                                           
 -------+---------------------------------------------------
  1     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
- 2     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
  1     | reindex_crtab_part_ao_btree_id_idx                
+ 2     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
 (3 rows)
 3: COMMIT;
 COMMIT
@@ -55,8 +55,8 @@ INSERT 0 12
 3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
  count | relname                                           
 -------+---------------------------------------------------
+ 1     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
  3     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
- 2     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
  1     | reindex_crtab_part_ao_btree_id_idx                
 (3 rows)
 

--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
@@ -20,7 +20,7 @@ SELECT 12
 BEGIN
 1: LOCK reindex_crtab_part_aoco_btree IN ACCESS EXCLUSIVE MODE;
 LOCK TABLE
-2&: REINDEX TABLE  reindex_crtab_part_aoco_btree;  <waiting ...>
+2&: REINDEX TABLE reindex_crtab_part_aoco_btree_1_prt_de_fault;  <waiting ...>
 3: BEGIN;
 BEGIN
 3&: reindex index reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx;  <waiting ...>
@@ -38,9 +38,9 @@ INSERT 0 12
 3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
  count | relname                                             
 -------+-----------------------------------------------------
- 2     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
  1     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
  1     | reindex_crtab_part_aoco_btree_id_idx                
+ 2     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
 (3 rows)
 3: COMMIT;
 COMMIT
@@ -54,9 +54,9 @@ INSERT 0 12
 3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
  count | relname                                             
 -------+-----------------------------------------------------
- 1     | reindex_crtab_part_aoco_btree_id_idx                
- 2     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
  3     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
+ 1     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
+ 1     | reindex_crtab_part_aoco_btree_id_idx                
 (3 rows)
 
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 998;

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_ao_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_ao_part_btree.sql
@@ -17,7 +17,7 @@ DELETE FROM reindex_crtab_part_ao_btree  WHERE id < 128;
     where relname like 'reindex_crtab_part_ao_btree%_idx');
 1: BEGIN;
 1: LOCK reindex_crtab_part_ao_btree IN ACCESS EXCLUSIVE MODE;
-2&: REINDEX TABLE  reindex_crtab_part_ao_btree;
+2&: REINDEX TABLE reindex_crtab_part_ao_btree_1_prt_de_fault;
 3:BEGIN;
 3&: reindex index reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx;
 1: COMMIT;

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
@@ -16,7 +16,7 @@ DELETE FROM reindex_crtab_part_aoco_btree  WHERE id < 128;
     where relname like 'reindex_crtab_part_aoco_btree%_idx');
 1: BEGIN;
 1: LOCK reindex_crtab_part_aoco_btree IN ACCESS EXCLUSIVE MODE;
-2&: REINDEX TABLE  reindex_crtab_part_aoco_btree;
+2&: REINDEX TABLE reindex_crtab_part_aoco_btree_1_prt_de_fault;
 3: BEGIN;
 3&: reindex index reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx;
 1: COMMIT;


### PR DESCRIPTION
When PostgreSQL executes REINDEX TABLE on a partitioned table, it locks
each partition in sequence and rebuilds its indexes. These two tests
previously had some uncertainty due to this behavior, causing them to be
flaky.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
