### PR TITLE
Remove gsutil from gpMgmt/requirements-dev.txt

### DIFF
--- a/gpMgmt/requirements-dev.txt
+++ b/gpMgmt/requirements-dev.txt
@@ -1,4 +1,3 @@
-gsutil
 behave~=1.2.6
 coverage~=4.5
 mock<=5.0.0


### PR DESCRIPTION
It's only used by concourse CI scripts, and the latest version of it
could not be installed on old operating systems.
