### PR TITLE
The return value of gddCtxGetMaxVid() should be DistributedTransactionId

### DIFF
--- a/src/backend/utils/gdd/gdddetector.c
+++ b/src/backend/utils/gdd/gdddetector.c
@@ -22,7 +22,7 @@
 static GddGraph *gddCtxGetGraph(GddCtx *ctx, int segid);
 static GddStat *gddCtxGetGlobalStat(GddCtx *ctx, DistributedTransactionId vid);
 static void gddCtxRemoveVid(GddCtx *ctx, DistributedTransactionId vid);
-static int gddCtxGetMaxVid(GddCtx *ctx);
+static DistributedTransactionId gddCtxGetMaxVid(GddCtx *ctx);
 
 static GddStat *gddStatNew(DistributedTransactionId vid);
 static void gddStatInit(GddStat *stat, DistributedTransactionId vid);
@@ -251,7 +251,7 @@ gddCtxRemoveVid(GddCtx *ctx, DistributedTransactionId vid)
 /*
  * Get the max vert id, return 0 if no vert left at all.
  */
-static int
+static DistributedTransactionId
 gddCtxGetMaxVid(GddCtx *ctx)
 {
 	GddMapIter	graphiter;


### PR DESCRIPTION
The function prototype: `static int gddCtxGetMaxVid(GddCtx *ctx);` but it uses `DistributedTransactionId` value as its return value: https://github.com/warehouse-pg/warehouse-pg/blob/deb5b5d218a0c2aa9f2febf4ca3dd36e94afc902/src/backend/utils/gdd/gdddetector.c#L276

So a "narrowing conversion" happens here. 

When your cluster enables GDD and runs a long time, the GXID may exceed INT_MAX, then it will cause an **infinite loop** here: `maxvid` will be cut down into an invalid int value and add it into `vids` list later.
https://github.com/warehouse-pg/warehouse-pg/blob/deb5b5d218a0c2aa9f2febf4ca3dd36e94afc902/src/backend/utils/gdd/gdddetector.c#L151-L168

As the result: the `vids` list will continue to grow (until an OOM happens). You will find gdd's memory context is very huge in this scenario.

This PR fixes it (with a simple unittest).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
