### PR TITLE
Fix flaky tests of REINDEX TABLE/INDEX

### DIFF
--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_ao_part_btree.out
@@ -9,7 +9,6 @@ insert into reindex_crtab_part_ao_btree (id, owner, description, property, poli,
 INSERT 0 1000
 create index on reindex_crtab_part_ao_btree(id);
 CREATE INDEX
--- @product_version gpdb: [4.3.4.0 -],4.3.4.0O2
 -- @Description Ensures that a reindex table during reindex index operations is ok
 --
 
@@ -21,44 +20,26 @@ SELECT 12
 BEGIN
 1: LOCK reindex_crtab_part_ao_btree IN ACCESS EXCLUSIVE MODE;
 LOCK TABLE
-2&: REINDEX TABLE  reindex_crtab_part_ao_btree;  <waiting ...>
-3:BEGIN;
+3: BEGIN;
 BEGIN
 3&: reindex index reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx;  <waiting ...>
+2&: REINDEX TABLE reindex_crtab_part_ao_btree;  <waiting ...>
 1: COMMIT;
 COMMIT
 3<:  <... completed>
 REINDEX
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_ao_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_ao_btree%_idx');
-INSERT 0 12
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                           
--------+---------------------------------------------------
- 1     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
- 2     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_ao_btree_id_idx                
-(3 rows)
 3: COMMIT;
 COMMIT
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:  <... completed>
 REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_ao_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_ao_btree%_idx');
 INSERT 0 12
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                           
--------+---------------------------------------------------
- 3     | reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx 
- 2     | reindex_crtab_part_ao_btree_1_prt_p_one_id_idx    
- 1     | reindex_crtab_part_ao_btree_id_idx                
-(3 rows)
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx' group by dbid;
+ count 
+-------
+ 2     
+(1 row)
 
 3: select count(*) from reindex_crtab_part_ao_btree where id = 998;
  count 

--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_aoco_part_btree.out
@@ -20,44 +20,26 @@ SELECT 12
 BEGIN
 1: LOCK reindex_crtab_part_aoco_btree IN ACCESS EXCLUSIVE MODE;
 LOCK TABLE
-2&: REINDEX TABLE  reindex_crtab_part_aoco_btree;  <waiting ...>
 3: BEGIN;
 BEGIN
 3&: reindex index reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx;  <waiting ...>
+2&: REINDEX TABLE reindex_crtab_part_aoco_btree;  <waiting ...>
 1: COMMIT;
 COMMIT
 3<:  <... completed>
 REINDEX
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_aoco_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_aoco_btree%_idx');
-INSERT 0 12
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 2     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
- 1     | reindex_crtab_part_aoco_btree_id_idx                
-(3 rows)
 3: COMMIT;
 COMMIT
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:  <... completed>
 REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_aoco_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_aoco_btree%_idx');
 INSERT 0 12
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_aoco_btree_id_idx                
- 2     | reindex_crtab_part_aoco_btree_1_prt_p_one_id_idx    
- 3     | reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx 
-(3 rows)
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' group by dbid;
+ count 
+-------
+ 2     
+(1 row)
 
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 998;
  count 
@@ -73,4 +55,3 @@ SET
 -------
  2     
 (1 row)
-

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_ao_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_ao_part_btree.sql
@@ -4,7 +4,6 @@ CREATE TABLE reindex_crtab_part_ao_btree ( id INTEGER, owner VARCHAR, descriptio
 insert into reindex_crtab_part_ao_btree (id, owner, description, property, poli, target) select i, 'user' || i, 'Testing GiST Index', '((3, 1300), (33, 1330))','( (22,660), (57, 650), (68, 660) )', '( (76, 76), 76)' from generate_series(1,1000) i ;
 insert into reindex_crtab_part_ao_btree (id, owner, description, property, poli, target) select i, 'user' || i, 'Testing GiST Index', '((3, 1300), (33, 1330))','( (22,660), (57, 650), (68, 660) )', '( (76, 76), 76)' from generate_series(1,1000) i ;
 create index on reindex_crtab_part_ao_btree(id);
--- @product_version gpdb: [4.3.4.0 -],4.3.4.0O2
 -- @Description Ensures that a reindex table during reindex index operations is ok
 -- 
 
@@ -17,26 +16,12 @@ DELETE FROM reindex_crtab_part_ao_btree  WHERE id < 128;
     where relname like 'reindex_crtab_part_ao_btree%_idx');
 1: BEGIN;
 1: LOCK reindex_crtab_part_ao_btree IN ACCESS EXCLUSIVE MODE;
-2&: REINDEX TABLE  reindex_crtab_part_ao_btree;
-3:BEGIN;
+3: BEGIN;
 3&: reindex index reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx;
+2&: REINDEX TABLE reindex_crtab_part_ao_btree;
 1: COMMIT;
 3<:
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes
-   (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
-    where relname like 'reindex_crtab_part_ao_btree%_idx'
-    union all
-    select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
-    where relname like 'reindex_crtab_part_ao_btree%_idx');
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
 3: COMMIT;
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:
 3: insert into old_relfilenodes
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -44,8 +29,8 @@ DELETE FROM reindex_crtab_part_ao_btree  WHERE id < 128;
     union all
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_ao_btree%_idx');
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_ao_btree_1_prt_de_fault_id_idx' group by dbid;
 
 3: select count(*) from reindex_crtab_part_ao_btree where id = 998;
 3: set enable_seqscan=false;

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_aoco_part_btree.sql
@@ -16,26 +16,12 @@ DELETE FROM reindex_crtab_part_aoco_btree  WHERE id < 128;
     where relname like 'reindex_crtab_part_aoco_btree%_idx');
 1: BEGIN;
 1: LOCK reindex_crtab_part_aoco_btree IN ACCESS EXCLUSIVE MODE;
-2&: REINDEX TABLE  reindex_crtab_part_aoco_btree;
 3: BEGIN;
 3&: reindex index reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx;
+2&: REINDEX TABLE reindex_crtab_part_aoco_btree;
 1: COMMIT;
 3<:
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes
-   (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
-    where relname like 'reindex_crtab_part_aoco_btree%_idx'
-    union all
-    select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
-    where relname like 'reindex_crtab_part_aoco_btree%_idx');
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
 3: COMMIT;
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:
 3: insert into old_relfilenodes
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -43,11 +29,10 @@ DELETE FROM reindex_crtab_part_aoco_btree  WHERE id < 128;
     union all
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_aoco_btree%_idx');
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_aoco_btree_1_prt_de_fault_id_idx' group by dbid;
 
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 998;
 3: set enable_seqscan=false;
 3: set enable_indexscan=true;
 3: select count(*) from reindex_crtab_part_aoco_btree where id = 999;
-


### PR DESCRIPTION
These two test cases had two issues, in addition to mismatched comments:

When performing a REINDEX operation on a partitioned table, the partitions are
locked and their indexes are rebuilt sequentially, not all at once.

When two REINDEX commands are executed concurrently in the background, it is
not deterministic which command will first rebuild the index on the "de_fault"
partition in the example.

Prior to the commit referenced below, REINDEX TABLE could be placed within an
explicit transaction. This made it plausible that both commands would run
concurrently, and one could observe the index being rebuilt twice. However,
after that change, the test became flaky for the two issues mentioned above,
as the double rebuild was no longer consistently observable.

	commit 67a7c0f06be0da1cd466e24fb0c33b51308dc1e0
	Author: (Jerome)Junfeng Yang <yjerome@vmware.com>
	Date:   Fri Aug 20 15:37:01 2021 +0800

	    Add support for partitioned tables and indexes in REINDEX

This commit addresses the flakiness by running the two commands in a
roughly concurrent manner and only asserting that the index was
successfully rebuilt, without checking the number of times it occurred.