### PR TITLE
Fix the flaky explain_format case

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -41,6 +41,9 @@ begin
         -- Ignore text-mode "Planning:" line because whether it's output
         -- varies depending on the system state
         CONTINUE WHEN (ln = 'Planning:');
+        -- Ignore text-mode "Extra Text:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln ~ 'Extra Text:');
         return next ln;
     end loop;
 end;
@@ -677,11 +680,9 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
   ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a
         Planned Partitions: N
-        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
         ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Group Key: a, b
-              Extra Text: (segN)   hash table(s): N; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
               ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
@@ -691,7 +692,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(18 rows)
+(16 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
@@ -704,7 +705,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
   ->  Finalize HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a, b, (GROUPINGSET_ID())
         Planned Partitions: N
-        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Hash Key: a, b, (GROUPINGSET_ID())
@@ -712,7 +712,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
                     Hash Key: a
                     Hash Key: b
                     Planned Partitions: N
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
                     ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
@@ -723,7 +722,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(23 rows)
+(21 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -698,16 +698,32 @@ SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-	SELECT explain_filter(
-		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Finalize HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        Group Key: a, b, (GROUPINGSET_ID())
+        Planned Partitions: N
+        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+        ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              Hash Key: a, b, (GROUPINGSET_ID())
+              ->  Partial HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Hash Key: a
+                    Hash Key: b
+                    Planned Partitions: N
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: Postgres-based planner
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(23 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -41,6 +41,9 @@ begin
         -- Ignore text-mode "Planning:" line because whether it's output
         -- varies depending on the system state
         CONTINUE WHEN (ln = 'Planning:');
+        -- Ignore text-mode "Extra Text:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln ~ 'Extra Text:');
         return next ln;
     end loop;
 end;
@@ -620,12 +623,10 @@ explain_filter
 Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a
-        Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
         ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Group Key: a, b
               Planned Partitions: N
-              Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
               ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
@@ -635,7 +636,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(18 rows)
+(16 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
@@ -650,7 +651,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
         ->  Append  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                     Group Key: share0_ref2.b
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                           Hash Key: share0_ref2.b
@@ -659,7 +659,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
               ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                     Group Key: share0_ref3.a
                     Planned Partitions: N
-                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
 
                     ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
@@ -670,7 +669,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(27 rows)
+(25 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -641,16 +641,36 @@ CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-	SELECT explain_filter(
-		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
-explain_info
-Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
-(2 rows)
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Sequence  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Append  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Group Key: share0_ref2.b
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                          Hash Key: share0_ref2.b
+                          ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                                ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                    Group Key: share0_ref3.a
+                    Planned Partitions: N
+                    Extra Text: (segN)   hash table(s): N; N groups total in N batches, N spill partitions; disk usage: NKB; chain length N.N avg, N max; using N of N buckets; total N expansions.
+
+                    ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+Optimizer: GPORCA
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+* (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max, NK bytes wanted.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
+Memory wanted:  NkB
+Execution Time: N.N ms
+(27 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -44,6 +44,9 @@ begin
         -- Ignore text-mode "Planning:" line because whether it's output
         -- varies depending on the system state
         CONTINUE WHEN (ln = 'Planning:');
+        -- Ignore text-mode "Extra Text:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln ~ 'Extra Text:');
         return next ln;
     end loop;
 end;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -161,12 +161,7 @@ select explain_filter('EXPLAIN ANALYZE SELECT a, COUNT(DISTINCT b) AS b FROM tes
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
 -- The planner generates multiple hash tables but ORCA uses Shared Scan.
-WITH query_plan (et) AS
-(
-	SELECT explain_filter(
-		'EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));')
-)
-SELECT BTRIM(et) as explain_info FROM query_plan WHERE et like '%Extra Text%' limit 2;
+select explain_filter('EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));');
 
 RESET optimizer_enable_hashagg;
 RESET statement_mem;


### PR DESCRIPTION
```
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /home/runner/gpdb_src/src/test/regress/expected/explain_format.out /home/runner/gpdb_src/src/test/regress/results/explain_format.out
--- /home/runner/gpdb_src/src/test/regress/expected/explain_format.out	2025-08-19 12:09:49.057298453 +0000
+++ /home/runner/gpdb_src/src/test/regress/results/explain_format.out	2025-08-19 12:09:49.079298391 +0000
@@ -874,6 +874,7 @@
 Gather Motion N:N  (sliceN; segments: N) (actual time=N.N..N.N rows=N loops=N)
   ->  Hash Join (actual time=N.N..N.N rows=N loops=N)
         Hash Cond: (s2.b = s1.b)
+        Extra Text: (segN)   Hash chain length N.N avg, N max, using N of N buckets.
         ->  Seq Scan on stat_io_timing s2 (never executed)
         ->  Hash (actual time=N.N..N.N rows=N loops=N)
               Buckets: N  Batches: N  Memory Usage: NkB
@@ -887,7 +888,7 @@
   (sliceN)    Executor memory: NK bytes (segN).
 Memory used:  NkB
 Execution Time: N.N ms
-(16 rows)
+(17 rows)
 -- Test Bitmap Heap Scan block accounting
 SET enable_seqscan = 0;
 SET enable_bitmapscan = 1;
```

For instance in the Hash Join node, `Extra Text` is only printed when a
spill occurs, which heavily depends on the system state. Simply lowering
`statement_mem` does not reliably trigger a spill when the data set is
small.

So instead of checking `Extra Text` output in this case, we can skip
it, since we already have sufficient coverage for it in other tests.