### PR TITLE
Support PL/Python2 testing on WHPG7

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -119,8 +119,12 @@ REGRESS = \
 	plpython_subtransaction \
 	plpython_transaction \
 	plpython_gpdb \
-	plpython3_path_guc \
-	plpython_drop
+
+ifeq ($(python_majorversion),3)
+REGRESS += plpython3_path_guc
+endif
+
+REGRESS += plpython_drop
 
 REGRESS_PLPYTHON3_MANGLE := $(REGRESS)
 

--- a/src/pl/plpython/expected/plpython_subtransaction.out
+++ b/src/pl/plpython/expected/plpython_subtransaction.out
@@ -473,7 +473,7 @@ plpy.execute("select pg_backend_pid()")
 for i in range(0, 5):
     yield (i)
 
-$$ LANGUAGE plpython3u;
+$$ LANGUAGE plpythonu;
 -- inject fault and wait for trigger
 select gp_inject_fault_infinite('begin_internal_sub_transaction', 'error', 1);
  gp_inject_fault_infinite 

--- a/src/pl/plpython/expected/plpython_transaction.out
+++ b/src/pl/plpython/expected/plpython_transaction.out
@@ -229,7 +229,7 @@ select gp_inject_fault('start_prepare', 'reset', dbid) from gp_segment_configura
  Success:
 (1 row)
 
-DO LANGUAGE plpython3u $$
+DO LANGUAGE plpythonu $$
 # this insert will fail during commit:
 plpy.execute("INSERT INTO testfk VALUES (0)")
 plpy.execute("select gp_inject_fault('start_prepare', 'error', dbid) from gp_segment_configuration where role = 'p' and status = 'u' and content = 0")


### PR DESCRIPTION
On WHPG7, PL/Python tests default to Python 2, with additional handling
in the Makefile to allow Python3 testing as well.

This commit maintains that approach, ensuring WHPG7 can build and test
PL/Python2.
