### PR TITLE
doc: fix a wrong link in Linux guide, plus fix it md lint

### DIFF
--- a/README.Linux.md
+++ b/README.Linux.md
@@ -1,25 +1,28 @@
-## For RHEL/Rocky8:
+## For RHEL/Rocky8
 
-  - For EL versions (> 8.0):
-    - Install git
+- For EL versions (> 8.0):
+  - Install git
+
       ```bash
       sudo yum install git
       ```
-  - Install dependencies using README.Rhel-Rocky.bash script.
-       ```bash
-       ./README.Rhel-Rocky.bash
-       ```
 
+- Install dependencies using README.Rhel-Rocky.bash script.
 
-## Common Platform Tasks:
+   ```bash
+   ./README.Rhel-Rocky.bash
+   ```
+
+## Common Platform Tasks
 
 Make sure that you add `/usr/local/lib` to `/etc/ld.so.conf`,
 then run command `ldconfig`.
+
 1. Create gpadmin and setup ssh keys
 
-   manually create ssh keys so you can do ssh localhost without a password, e.g., 
-   
-   ```
+   manually create ssh keys so you can do ssh localhost without a password, e.g.,
+
+   ```cli
    ssh-keygen
    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
    chmod 600 ~/.ssh/authorized_keys
@@ -31,6 +34,4 @@ then run command `ldconfig`.
    ssh <hostname of your machine>  # e.g., ssh briarwood (You can use `hostname` to get the hostname of your machine.)
    ```
 
-1. Set up your system configuration by following the installation guide on [docs.warehousepg.org](https://docs.warehousepg.org)
-
-
+1. Set up your system configuration by following the installation guide on [warehousepg.org](https://warehouse-pg.io/docs/7x/)


### PR DESCRIPTION
## Here are some reminders before you submit the pull request

as diff and since https://warehouse-pg.io/docs/ is 404 and no redirect so default choose 7x

and also fix some md lint for this file

- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
