### PR TITLE
Fix missed flaky test case of REINDEX TABLE/INDEX

### DIFF
--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_part_btree.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_part_btree.out
@@ -20,44 +20,26 @@ SELECT 12
 BEGIN
 1: LOCK reindex_crtab_part_heap_btree IN ACCESS EXCLUSIVE MODE;
 LOCK TABLE
-2&: REINDEX TABLE  reindex_crtab_part_heap_btree;  <waiting ...>
 3: BEGIN;
 BEGIN
 3&: reindex index reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx;  <waiting ...>
+2&: REINDEX TABLE reindex_crtab_part_heap_btree;  <waiting ...>
 1: COMMIT;
 COMMIT
 3<:  <... completed>
 REINDEX
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_heap_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_heap_btree%_idx');
-INSERT 0 12
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_heap_btree_id_idx                
- 2     | reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx 
- 1     | reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    
-(3 rows)
 3: COMMIT;
 COMMIT
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:  <... completed>
 REINDEX
 3: insert into old_relfilenodes (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'reindex_crtab_part_heap_btree%_idx' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'reindex_crtab_part_heap_btree%_idx');
 INSERT 0 12
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
- count | relname                                             
--------+-----------------------------------------------------
- 1     | reindex_crtab_part_heap_btree_id_idx                
- 3     | reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx 
- 2     | reindex_crtab_part_heap_btree_1_prt_p_one_id_idx    
-(3 rows)
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' group by dbid;
+ count 
+-------
+ 2     
+(1 row)
 
 3: select count(*) from reindex_crtab_part_heap_btree where id = 998;
  count 

--- a/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_heap_part_btree.sql
+++ b/src/test/isolation2/sql/reindex/reindextable_while_reindex_idx_heap_part_btree.sql
@@ -16,26 +16,12 @@ DELETE FROM reindex_crtab_part_heap_btree  WHERE id < 128;
     where relname like 'reindex_crtab_part_heap_btree%_idx');
 1: BEGIN;
 1: LOCK reindex_crtab_part_heap_btree IN ACCESS EXCLUSIVE MODE;
-2&: REINDEX TABLE  reindex_crtab_part_heap_btree;
 3: BEGIN;
 3&: reindex index reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx;
+2&: REINDEX TABLE reindex_crtab_part_heap_btree;
 1: COMMIT;
 3<:
--- Session 2 has not committed yet.  Session 3 should see effects of
--- its own reindex command above in pg_class.  The following query
--- validates that reindex command in session 3 indeed generates new
--- relfilenode for the index.
-3: insert into old_relfilenodes
-   (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
-    where relname like 'reindex_crtab_part_heap_btree%_idx'
-    union all
-    select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
-    where relname like 'reindex_crtab_part_heap_btree%_idx');
--- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
 3: COMMIT;
--- After session 3 commits, session 2 could complete, the relfilenode it assigned to the
--- "1_prt_de_fault" index is visible to session 3.
 2<:
 3: insert into old_relfilenodes
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -43,8 +29,8 @@ DELETE FROM reindex_crtab_part_heap_btree  WHERE id < 128;
     union all
     select gp_segment_id as dbid, relfilenode, oid, relname from pg_class
     where relname like 'reindex_crtab_part_heap_btree%_idx');
--- Expect three distinct relfilenodes per segment for "1_prt_de_fault" index.
-3: select distinct count(distinct relfilenode), relname from old_relfilenodes group by dbid, relname;
+-- Expect two distinct relfilenodes for one segment in old_relfilenodes table.
+3: select distinct count(distinct relfilenode) from old_relfilenodes where relname = 'reindex_crtab_part_heap_btree_1_prt_de_fault_id_idx' group by dbid;
 
 3: select count(*) from reindex_crtab_part_heap_btree where id = 998;
 3: set enable_seqscan=false;


### PR DESCRIPTION
	commit 2ab75d6f7d5cc5eaf8ff1db9de07bbfb69aecb3e
	Author: Adam Lee <adam.lee@enterprisedb.com>
	Date:   Thu Aug 14 15:15:30 2025 +0800

	    Fix flaky tests of REINDEX TABLE/INDEX

The previous commit missed one case, which is fixed here. I double-checked and
there should be no more.

The root cause is the same as before: after a legitimate functional change,
REINDEX TABLE on partitioned tables can no longer be run inside an explicit
transaction block, which prevented the tests from working as intended and
caused them to be flaky.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`

