### PR TITLE
Insert WAL record uncompressed if compression fails

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -30,6 +30,7 @@
 #include "replication/origin.h"
 #include "storage/bufmgr.h"
 #include "storage/proc.h"
+#include "utils/faultinjector.h"
 #include "utils/memutils.h"
 #include "pg_trace.h"
 
@@ -859,6 +860,11 @@ XLogCompressBackupBlock(char *page, uint16 hole_offset, uint16 hole_length,
 							dest, BLCKSZ,
 							source, orig_len,
 							COMPRESS_LEVEL);
+
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("xlog_compression_fail") == FaultInjectorTypeSkip)
+		len = -1;
+#endif
 
 	if (ZSTD_isError(len))
 		len = -1; /* failure */

--- a/src/test/regress/expected/wal_compression.out
+++ b/src/test/regress/expected/wal_compression.out
@@ -1,0 +1,29 @@
+-- start_ignore
+DROP TABLE IF EXISTS wal_compression_fail;
+NOTICE:  table "wal_compression_fail" does not exist, skipping
+-- end_ignore
+SET wal_compression = on;
+SELECT gp_inject_fault('xlog_compression_fail', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+CREATE TABLE wal_compression_fail(c1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO wal_compression_fail SELECT generate_series(1,100);
+DROP TABLE IF EXISTS wal_compression_fail;
+SELECT gp_inject_fault('xlog_compression_fail', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+RESET wal_compression;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -297,6 +297,7 @@ test: ao_checksum_corruption AOCO_Compression AORO_Compression table_statistics
 test: session_reset
 # below test(s) inject faults so each of them need to be in a separate group
 test: fts_error
+test: wal_compression
 
 test: psql_gp_commands pg_resetwal dropdb_check_shared_buffer_cache gp_upgrade_cornercases
 

--- a/src/test/regress/sql/wal_compression.sql
+++ b/src/test/regress/sql/wal_compression.sql
@@ -1,0 +1,10 @@
+-- start_ignore
+DROP TABLE IF EXISTS wal_compression_fail;
+-- end_ignore
+SET wal_compression = on;
+SELECT gp_inject_fault('xlog_compression_fail', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p';
+CREATE TABLE wal_compression_fail(c1 int);
+INSERT INTO wal_compression_fail SELECT generate_series(1,100);
+DROP TABLE IF EXISTS wal_compression_fail;
+SELECT gp_inject_fault('xlog_compression_fail', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+RESET wal_compression;


### PR DESCRIPTION
We observed errors such as: "compression failed: Destination buffer is too
small uncompressed len 32760 (xloginsert.c:865)"

This typically occurs when the "compressed" output is larger than the original
input. Regardless of the exact cause, it is always safe to insert the
uncompressed WAL record instead of failing.
