### PR TITLE
Fix extra blank lines in EXPLAIN

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -3657,6 +3657,8 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	{
 		/* Allocate string buffer. */
 		aggstate->ss.ps.cdbexplainbuf = makeStringInfo();
+
+		/* Request a callback at end of query. */
 		aggstate->ss.ps.cdbexplainfun = ExecAggExplainEnd;
 	}
 
@@ -5262,8 +5264,8 @@ ReuseHashTable(AggState *node)
  * ExecAggExplainEnd
  *      Called before ExecutorEnd to finish EXPLAIN ANALYZE reporting.
  *
- * Check cdbexplain_depositStatsToNode(), Greenplum only saves extra
- * message text for the most interesting winning qExecs.
+ * Check cdbexplain_depositStatsToNode(), it only saves extra extra text for
+ * the most interesting winning qExecs.
  */
 static void
 ExecAggExplainEnd(PlanState *planstate, struct StringInfoData *buf)

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -489,7 +489,7 @@ static int	find_compatible_pertrans(AggState *aggstate, Aggref *newagg,
 
 static void ExecEagerFreeAgg(AggState *node);
 
-void agg_hash_explain_extra_message(AggState *aggstate);
+static void ExecAggExplainEnd(PlanState *planstate, struct StringInfoData *buf);
 
 /*
  * Select the current grouping set; affects current_set and
@@ -2336,13 +2336,6 @@ ExecAgg(PlanState *pstate)
 			return result;
 	}
 
-	/* Save statistics into the cdbexplainbuf for EXPLAIN ANALYZE */
-	if (node->ss.ps.instrument &&
-			(node->ss.ps.instrument)->need_cdb &&
-			(node->phase->aggstrategy == AGG_HASHED ||
-			node->phase->aggstrategy == AGG_MIXED))
-		agg_hash_explain_extra_message(node);
-
 	return NULL;
 }
 
@@ -3657,14 +3650,15 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	ExecInitResultTupleSlotTL(&aggstate->ss.ps, &TTSOpsVirtual);
 	ExecAssignProjectionInfo(&aggstate->ss.ps, NULL);
 
-    /*
-     * CDB: Offer extra info for EXPLAIN ANALYZE.
-     */
-    if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
-    {
-        /* Allocate string buffer. */
-        aggstate->ss.ps.cdbexplainbuf = makeStringInfo();
-    }
+	/*
+	 * CDB: Offer extra info for EXPLAIN ANALYZE.
+	 */
+	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
+	{
+		/* Allocate string buffer. */
+		aggstate->ss.ps.cdbexplainbuf = makeStringInfo();
+		aggstate->ss.ps.cdbexplainfun = ExecAggExplainEnd;
+	}
 
 	/*
 	 * initialize child expressions
@@ -5265,16 +5259,22 @@ ReuseHashTable(AggState *node)
 }
 
 /*
- * Save statistics into the cdbexplainbuf for EXPLAIN ANALYZE
+ * ExecAggExplainEnd
+ *      Called before ExecutorEnd to finish EXPLAIN ANALYZE reporting.
+ *
+ * Check cdbexplain_depositStatsToNode(), Greenplum only saves extra
+ * message text for the most interesting winning qExecs.
  */
-void
-agg_hash_explain_extra_message(AggState *aggstate)
+static void
+ExecAggExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 {
-	/*
-	 * Check cdbexplain_depositStatsToNode(), Greenplum only saves extra
-	 * message text for the most interesting winning qExecs.
-	 */
-	StringInfo hbuf = aggstate->ss.ps.cdbexplainbuf;
+	AggState   *aggstate = castNode(AggState, planstate);
+
+	if (!aggstate->ss.ps.instrument
+		|| !(aggstate->ss.ps.instrument)->need_cdb
+		|| (aggstate->phase->aggstrategy != AGG_HASHED && aggstate->phase->aggstrategy != AGG_MIXED))
+		return;
+
 	uint64	sum_num_expansions = 0;
 	uint64	sum_output_groups = 0;
 	uint64	sum_spill_parts = 0;
@@ -5284,9 +5284,9 @@ agg_hash_explain_extra_message(AggState *aggstate)
 	uint64	sum_bucket_used = 0;
 	uint64	sum_bucket_total = 0;
 
-	Assert(hbuf);
+	Assert(buf);
 
-	appendStringInfo(hbuf, "hash table(s): %d", aggstate->num_hashes);
+	appendStringInfo(buf, "hash table(s): %d", aggstate->num_hashes);
 
 	/* Scan all perhashs and collect statistic info */
 	for (int setno = 0; setno < aggstate->num_hashes; setno++)
@@ -5315,7 +5315,7 @@ agg_hash_explain_extra_message(AggState *aggstate)
 
 	if (aggstate->hash_ever_spilled)
 	{
-		appendStringInfo(hbuf,
+		appendStringInfo(buf,
 			"; " UINT64_FORMAT " groups total in %d batches, " UINT64_FORMAT
 			" spill partitions; disk usage: " INT64_FORMAT "KB",
 			sum_output_groups,
@@ -5326,10 +5326,10 @@ agg_hash_explain_extra_message(AggState *aggstate)
 
 	if (sum_chain_count > 0)
 	{
-		appendStringInfo(hbuf,
+		appendStringInfo(buf,
 				"; chain length %.1f avg, %d max;"
 				" using " INT64_FORMAT " of " INT64_FORMAT " buckets;"
-				" total " INT64_FORMAT " expansions.\n",
+				" total " INT64_FORMAT " expansions.",
 				(double)sum_chain_length_total / sum_chain_count,
 				chain_length_max,
 				sum_bucket_used,

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -2529,7 +2529,7 @@ ExecHashTableExplainEnd(PlanState *planstate, struct StringInfoData *buf)
 		appendStringInfo(buf,
 						 "Work file set: %u files (%u compressed), "
 						 "avg file size %lu, "
-						 "compression buffer size %lu bytes \n",
+						 "compression buffer size %lu bytes.\n",
 						 hashtable->workset_num_files,
 						 hashtable->workset_num_files_compressed,
 						 hashtable->workset_avg_file_size,

--- a/src/test/isolation2/expected/.gitignore
+++ b/src/test/isolation2/expected/.gitignore
@@ -6,6 +6,7 @@
 /pg_basebackup_with_tablespaces.out
 /pt_io_in_progress_deadlock.out
 /distributed_snapshot.out
+/hot_standby/query_conflict.out
 
 # ignores including sub-directories
 autovacuum-analyze.out

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -680,10 +680,8 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
   ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a
         Planned Partitions: N
-
         ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Group Key: a, b
-
               ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
 Planning Time: N.N ms
@@ -692,7 +690,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(16 rows)
+(14 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
@@ -705,14 +703,12 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
   ->  Finalize HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a, b, (GROUPINGSET_ID())
         Planned Partitions: N
-
         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Hash Key: a, b, (GROUPINGSET_ID())
               ->  Partial HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                     Hash Key: a
                     Hash Key: b
                     Planned Partitions: N
-
                     ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres-based planner
 Planning Time: N.N ms
@@ -722,7 +718,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(21 rows)
+(19 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -623,11 +623,9 @@ explain_filter
 Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Group Key: a
-
         ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Group Key: a, b
               Planned Partitions: N
-
               ->  Seq Scan on test_src_tbl  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
 Planning Time: N.N ms
@@ -636,7 +634,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(16 rows)
+(14 rows)
 -- Hashagg with grouping sets
 CREATE TABLE test_hashagg_groupingsets AS
 SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
@@ -651,7 +649,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
         ->  Append  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                     Group Key: share0_ref2.b
-
                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                           Hash Key: share0_ref2.b
                           ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
@@ -659,7 +656,6 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
               ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                     Group Key: share0_ref3.a
                     Planned Partitions: N
-
                     ->  Shared Scan (share slice:id N:N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: GPORCA
 Planning Time: N.N ms
@@ -669,7 +665,7 @@ Planning Time: N.N ms
 Memory used:  NkB
 Memory wanted:  NkB
 Execution Time: N.N ms
-(25 rows)
+(23 rows)
 RESET optimizer_enable_hashagg;
 RESET statement_mem;
 -- Check EXPLAIN format output with BUFFERS enabled


### PR DESCRIPTION
On CI we observed that EXPLAIN produces blank lines, sometimes it produces multiple blank lines causing instability. The root cause was an earlier commit that printed an extra newline. When multiple "Extra Text" lines are present, this results in multiple blank lines.

That commit also did not use the `cdbexplainfun` callback as other nodes, making the issue harder to trace. This patch fixes both problems.

```
  ->  HashAggregate  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
        Group Key: share0_ref2.b

+
        ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
              Hash Key: share0_ref2.b
              ->  Result  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
```

```
regression=# EXPLAIN ANALYZE SELECT a, avg(b) AS b FROM test_src_tbl GROUP BY grouping sets ((a), (b));
                                                                                                      QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1299.51 rows=19980 width=12) (actual time=12.980..24.696 rows=20000 loops=1)
   ->  Sequence  (cost=0.00..1298.62 rows=6660 width=12) (actual time=13.764..24.940 rows=6771 loops=1)
         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.61 rows=16667 width=1) (actual time=0.000..3.632 rows=0 loops=1)
               ->  Seq Scan on test_src_tbl  (cost=0.00..431.35 rows=16667 width=8) (actual time=0.033..1.232 rows=16930 loops=1)
         ->  Append  (cost=0.00..866.93 rows=6660 width=12) (actual time=10.380..21.208 rows=6771 loops=1)
               ->  HashAggregate  (cost=0.00..433.40 rows=3330 width=8) (actual time=10.378..13.653 rows=3385 loops=1)
                     Group Key: share0_ref2.b
                     Extra Text: (seg1)   hash table(s): 1; 3385 groups total in 15 batches, 53496 spill partitions; disk usage: 1152KB; chain length 2.1 avg, 4 max; using 3385 of 32768 buckets; total 0 expansions.

                     Extra Text: (seg2)   hash table(s): 1; 3247 groups total in 8 batches, 50728 spill partitions; disk usage: 1152KB; chain length 2.2 avg, 4 max; using 3247 of 18432 buckets; total 0 expansions.

                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.37 rows=16667 width=4) (actual time=0.854..6.850 rows=16925 loops=1)
                     ...
```

	commit c22b4a3558666654efb674b4f2d4686a981298fb
	Author: Yao Wang <wayao@vmware.com>
	Date:   Thu Aug 24 15:36:41 2023 +0800

	    Add explain analyze detailed info of hash agg (#15917)
