### PR TITLE
Fix mirror promotion failure due to WAL segment rename

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8130,6 +8130,73 @@ StartupXLOG(void)
 			CreateCheckPoint(CHECKPOINT_END_OF_RECOVERY | CHECKPOINT_IMMEDIATE);
 	}
 
+	/*
+	 * Preallocate additional log files, if wanted.
+	 */
+	PreallocXlogFiles(EndOfLog);
+
+	/*
+	 * Okay, we're officially UP.
+	 */
+	InRecovery = false;
+
+	SIMPLE_FAULT_INJECTOR("out_of_recovery_in_startupxlog");
+
+	/* start the archive_timeout timer and LSN running */
+	XLogCtl->lastSegSwitchTime = (pg_time_t) time(NULL);
+	XLogCtl->lastSegSwitchLSN = EndOfLog;
+
+	/* also initialize latestCompletedXid, to nextXid - 1 */
+	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
+	ShmemVariableCache->latestCompletedXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
+	ShmemVariableCache->latestCompletedGxid = ShmemVariableCache->nextGxid;
+	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
+	if (IsNormalProcessingMode())
+		elog(LOG, "latest completed transaction id is %u and next transaction id is %u",
+			 ShmemVariableCache->latestCompletedXid,
+			 XidFromFullTransactionId(ShmemVariableCache->nextFullXid));
+	LWLockRelease(ProcArrayLock);
+
+	/*
+	 * Start up the commit log and subtrans, if not already done for hot
+	 * standby.  (commit timestamps are started below, if necessary.)
+	 */
+	if (standbyState == STANDBY_DISABLED)
+	{
+		StartupCLOG();
+		StartupSUBTRANS(oldestActiveXID);
+		DistributedLog_Startup(oldestActiveXID,
+							   XidFromFullTransactionId(ShmemVariableCache->nextFullXid));
+	}
+
+	/*
+	 * Perform end of recovery actions for any SLRUs that need it.
+	 */
+	TrimCLOG();
+	TrimMultiXact();
+
+	/* Reload shared-memory state for prepared transactions */
+	RecoverPreparedTransactions();
+
+	/* Greenplum extra logging */
+	if (IsNormalProcessingMode())
+		ereport(LOG, (errmsg("database system is ready")));
+
+	/* Shut down xlogreader */
+	if (readFile >= 0)
+	{
+		close(readFile);
+		readFile = -1;
+	}
+	XLogReaderFree(xlogreader);
+
+	/*
+	 * If any of the critical GUCs have changed, log them before we allow
+	 * backends to write WAL.
+	 */
+	LocalSetXLogInsertAllowed();
+	XLogReportParameters();
+
 	if (ArchiveRecoveryRequested)
 	{
 		/*
@@ -8212,18 +8279,6 @@ StartupXLOG(void)
 	}
 
 	/*
-	 * Preallocate additional log files, if wanted.
-	 */
-	PreallocXlogFiles(EndOfLog);
-
-	/*
-	 * Okay, we're officially UP.
-	 */
-	InRecovery = false;
-
-	SIMPLE_FAULT_INJECTOR("out_of_recovery_in_startupxlog");
-
-	/*
 	 * If we are a standby with contentid -1 and undergoing promotion,
 	 * update ourselves as the new coordinator in catalog.  This does not
 	 * apply to a mirror (standby of a GPDB segment) because it is
@@ -8231,61 +8286,6 @@ StartupXLOG(void)
 	 */
 	bool needToPromoteCatalog = (IS_QUERY_DISPATCHER() &&
 								 ControlFile->state == DB_IN_ARCHIVE_RECOVERY);
-
-	/* start the archive_timeout timer and LSN running */
-	XLogCtl->lastSegSwitchTime = (pg_time_t) time(NULL);
-	XLogCtl->lastSegSwitchLSN = EndOfLog;
-
-	/* also initialize latestCompletedXid, to nextXid - 1 */
-	LWLockAcquire(ProcArrayLock, LW_EXCLUSIVE);
-	ShmemVariableCache->latestCompletedXid = XidFromFullTransactionId(ShmemVariableCache->nextFullXid);
-	ShmemVariableCache->latestCompletedGxid = ShmemVariableCache->nextGxid;
-	TransactionIdRetreat(ShmemVariableCache->latestCompletedXid);
-	if (IsNormalProcessingMode())
-		elog(LOG, "latest completed transaction id is %u and next transaction id is %u",
-			 ShmemVariableCache->latestCompletedXid,
-			 XidFromFullTransactionId(ShmemVariableCache->nextFullXid));
-	LWLockRelease(ProcArrayLock);
-
-	/*
-	 * Start up the commit log and subtrans, if not already done for hot
-	 * standby.  (commit timestamps are started below, if necessary.)
-	 */
-	if (standbyState == STANDBY_DISABLED)
-	{
-		StartupCLOG();
-		StartupSUBTRANS(oldestActiveXID);
-		DistributedLog_Startup(oldestActiveXID,
-							   XidFromFullTransactionId(ShmemVariableCache->nextFullXid));
-	}
-
-	/*
-	 * Perform end of recovery actions for any SLRUs that need it.
-	 */
-	TrimCLOG();
-	TrimMultiXact();
-
-	/* Reload shared-memory state for prepared transactions */
-	RecoverPreparedTransactions();
-
-	/* Greenplum extra logging */
-	if (IsNormalProcessingMode())
-		ereport(LOG, (errmsg("database system is ready")));
-
-	/* Shut down xlogreader */
-	if (readFile >= 0)
-	{
-		close(readFile);
-		readFile = -1;
-	}
-	XLogReaderFree(xlogreader);
-
-	/*
-	 * If any of the critical GUCs have changed, log them before we allow
-	 * backends to write WAL.
-	 */
-	LocalSetXLogInsertAllowed();
-	XLogReportParameters();
 
 	/*
 	 * Local WAL inserts enabled, so it's time to finish initialization of

--- a/src/test/isolation2/expected/segwalrep/startup_rename_prepared_xlog.out
+++ b/src/test/isolation2/expected/segwalrep/startup_rename_prepared_xlog.out
@@ -1,0 +1,244 @@
+-- ## Bug Description ##
+-- This test targets a bug where a primary segment, during crash recovery, renames the last
+-- WAL (XLOG) segment to end with a '.partial' suffix *before* recovering the prepared
+-- transactions contained within it. This premature renaming can lead to a segfault when the
+-- recovery process (specifically, `RecoverPreparedTransactions`) attempts to read from the
+-- no-longer-existing WAL file. This scenario is described in detail on the PostgreSQL hackers
+-- mailing list: https://www.postgresql.org/message-id/743b9b45a2d4013bd90b6a5cba8d6faeb717ee34.camel%40cybertec.at
+--
+-- ## Greenplum/WarehousePG-Specific Challenge ##
+-- In the version of PostgreSQL that WarehousePG is based on, this bug is masked by an internal
+-- caching mechanism for the last opened WAL segment. To reliably trigger the bug, we must
+-- create a more complex scenario: creating unfinished prepared transactions across TWO
+-- different WAL segments. The final prepared transaction must reside in the very last
+-- WAL segment that will be renamed to '.partial' upon failover.
+--
+-- ## Test Strategy ##
+-- 1. **Setup**: Configure the cluster to enable `archive_mode`, which is a prerequisite for
+--    the WAL segment renaming behavior. Also, increase gang creation retry settings to make
+--    the test more robust against timing issues during segment recovery.
+-- 2. **Create First Prepared TX**: Inject a fault to suspend a 2PC transaction after the PREPARE
+--    phase, creating an "in-doubt" prepared transaction.
+-- 3. **Switch WAL**: Manually switch the WAL file. This isolates the first transaction's
+--    PREPARE record in a now-closed WAL segment.
+-- 4. **Create Second Prepared TX**: Create another "in-doubt" prepared transaction. Its
+--    PREPARE record will be in the new, current, and *last* WAL segment.
+-- 5. **Trigger Failover**: Crash the primary segment to initiate a failover. The mirror will be
+--    promoted and begin recovery. This is the critical moment where the bug could manifest.
+-- 6. **Verification**: After the new primary is up, verify that it did not crash and that both
+--    prepared transactions were successfully recovered and can be committed.
+-- 7. **Cleanup**: Restore the cluster to its original state.
+
+
+-- =================================================================
+-- STEP 1: Test Environment Setup
+-- =================================================================
+
+-- Increase retry counts for gang creation. This prevents test failures on busy systems
+-- where mirror promotion might take longer, by allowing the coordinator to wait longer for
+-- segments to become fully ready after recovery.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+(exited with code 0)
+
+-- The '.partial' renaming of the last WAL segment only occurs when archive_mode is enabled.
+!\retcode gpconfig -c archive_mode -v on;
+(exited with code 0)
+!\retcode gpconfig -c archive_command -v '/bin/true';
+(exited with code 0)
+
+-- Restart the cluster to apply the configuration changes.
+!\retcode gpstop -rai;
+(exited with code 0)
+
+1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE EXTENSION
+1: CREATE TABLE t_rename1 (a INT);
+CREATE TABLE
+1: CREATE TABLE t_rename2 (a INT);
+CREATE TABLE
+
+
+-- =================================================================
+-- STEP 2: Create Two In-Doubt Transactions in Separate WAL Segments
+-- =================================================================
+
+-- Create the first orphaned prepared transaction in the CURRENT WAL segment.
+-- We suspend the transaction right after the coordinator broadcasts PREPARE.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Assume (2), (1) are on different segments and one tuple is on the first segment.
+-- The test will double-check that.
+2&: INSERT INTO t_rename1 VALUES (2), (1);  <waiting ...>
+
+-- Wait for the fault to be triggered on the coordinator, ensuring the transaction is now in the
+-- "prepared" state on the segments.
+1: SELECT gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- This is the CRITICAL step to expose the bug. We force a WAL switch.
+-- Now, the PREPARE record for the first transaction is in a completed, non-last WAL segment.
+-- The next transaction's PREPARE record will be in a new WAL segment.
+-- start_ignore
+0U: SELECT pg_switch_wal();
+ pg_switch_wal 
+---------------
+ 0/14187148    
+(1 row)
+-- end_ignore
+
+-- Now, create a second orphaned prepared transaction in the NEW (and currently LAST) WAL segment.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- This INSERT will also be suspended, with its PREPARE record in the last WAL segment.
+3&: INSERT INTO t_rename2 VALUES (2), (1);  <waiting ...>
+
+-- Wait for the second fault to be triggered.
+1: SELECT gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+
+-- =================================================================
+-- STEP 3: Trigger Segment Failover and Recovery
+-- =================================================================
+
+-- Shutdown the primary segment for content 0 using an immediate shutdown.
+-- This forces the mirror to perform crash recovery from WAL.
+-1U: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c WHERE c.role='p' AND c.content=0), 'stop', 'immediate');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Request the Fault Tolerance Server (FTS) to scan for the downed segment.
+1: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Verify that the mirror has been promoted to the new primary.
+-- The new primary will now be in recovery mode, reading the WAL files. If the bug exists,
+-- it will crash at this stage while trying to recover the second prepared transaction.
+1: SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 0 ORDER BY role;
+ role | preferred_role 
+------+----------------
+ m    | p              
+ p    | m              
+(2 rows)
+
+
+-- =================================================================
+-- STEP 4: Verification
+-- =================================================================
+
+-- Double-check that the original transaction was indeed a 2PC transaction by verifying
+-- that its data is distributed across at least two segments.
+-- This also implicitly confirms that the new primary is responsive, and the
+-- shutdown then recovered segment 0 has data.
+1: INSERT INTO t_rename1 VALUES (2), (1);
+INSERT 0 2
+1: SELECT gp_segment_id, a FROM t_rename1 ORDER BY a;
+ gp_segment_id | a 
+---------------+---
+ 1             | 1 
+ 0             | 2 
+(2 rows)
+
+-- Reset the fault, allowing the coordinator to send the COMMIT PREPARED command for the
+-- two orphaned transactions.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Wait for the background sessions to complete their commits.
+2<:  <... completed>
+INSERT 0 2
+3<:  <... completed>
+INSERT 0 2
+
+-- Confirm that the data from both transactions is now visible, meaning the prepared
+-- transactions were successfully recovered and subsequently committed.
+1: SELECT * FROM t_rename1 ORDER BY a;
+ a 
+---
+ 1 
+ 1 
+ 2 
+ 2 
+(4 rows)
+1: SELECT * FROM t_rename2 ORDER BY a;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+
+
+-- =================================================================
+-- STEP 5: Cluster Restoration and Cleanup
+-- =================================================================
+
+-- Recover the failed segment (which will become the new mirror).
+!\retcode gprecoverseg -a;
+(exited with code 0)
+1: SELECT wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
+
+-- Rebalance the cluster to return the original primary to its preferred role.
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+1: SELECT wait_until_segment_synchronized(0);
+ wait_until_segment_synchronized 
+---------------------------------
+ OK                              
+(1 row)
+
+-- Verify the segment roles are back to their original state.
+1: SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 0 ORDER BY role;
+ role | preferred_role 
+------+----------------
+ m    | m              
+ p    | p              
+(2 rows)
+
+-- Final cleanup.
+1: DROP TABLE t_rename1;
+DROP TABLE
+1: DROP TABLE t_rename2;
+DROP TABLE
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r archive_mode --skipvalidation;
+(exited with code 0)
+!\retcode gpconfig -r archive_command --skipvalidation;
+(exited with code 0)
+!\retcode gpstop -rai;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -284,6 +284,7 @@ test: segwalrep/recoverseg_from_file
 test: segwalrep/mirror_promotion
 test: segwalrep/cancel_commit_pending_replication
 test: segwalrep/twophase_tolerance_with_mirror_promotion
+test: segwalrep/startup_rename_prepared_xlog
 test: segwalrep/failover_with_many_records
 test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby

--- a/src/test/isolation2/sql/segwalrep/startup_rename_prepared_xlog.sql
+++ b/src/test/isolation2/sql/segwalrep/startup_rename_prepared_xlog.sql
@@ -1,0 +1,160 @@
+-- ## Bug Description ##
+-- This test targets a bug where a primary segment, during crash recovery, renames the last
+-- WAL (XLOG) segment to end with a '.partial' suffix *before* recovering the prepared
+-- transactions contained within it. This premature renaming can lead to a segfault when the
+-- recovery process (specifically, `RecoverPreparedTransactions`) attempts to read from the
+-- no-longer-existing WAL file. This scenario is described in detail on the PostgreSQL hackers
+-- mailing list: https://www.postgresql.org/message-id/743b9b45a2d4013bd90b6a5cba8d6faeb717ee34.camel%40cybertec.at
+--
+-- ## Greenplum/WarehousePG-Specific Challenge ##
+-- In the version of PostgreSQL that WarehousePG is based on, this bug is masked by an internal
+-- caching mechanism for the last opened WAL segment. To reliably trigger the bug, we must
+-- create a more complex scenario: creating unfinished prepared transactions across TWO
+-- different WAL segments. The final prepared transaction must reside in the very last
+-- WAL segment that will be renamed to '.partial' upon failover.
+--
+-- ## Test Strategy ##
+-- 1. **Setup**: Configure the cluster to enable `archive_mode`, which is a prerequisite for
+--    the WAL segment renaming behavior. Also, increase gang creation retry settings to make
+--    the test more robust against timing issues during segment recovery.
+-- 2. **Create First Prepared TX**: Inject a fault to suspend a 2PC transaction after the PREPARE
+--    phase, creating an "in-doubt" prepared transaction.
+-- 3. **Switch WAL**: Manually switch the WAL file. This isolates the first transaction's
+--    PREPARE record in a now-closed WAL segment.
+-- 4. **Create Second Prepared TX**: Create another "in-doubt" prepared transaction. Its
+--    PREPARE record will be in the new, current, and *last* WAL segment.
+-- 5. **Trigger Failover**: Crash the primary segment to initiate a failover. The mirror will be
+--    promoted and begin recovery. This is the critical moment where the bug could manifest.
+-- 6. **Verification**: After the new primary is up, verify that it did not crash and that both
+--    prepared transactions were successfully recovered and can be committed.
+-- 7. **Cleanup**: Restore the cluster to its original state.
+
+
+-- =================================================================
+-- STEP 1: Test Environment Setup
+-- =================================================================
+
+-- Increase retry counts for gang creation. This prevents test failures on busy systems
+-- where mirror promotion might take longer, by allowing the coordinator to wait longer for
+-- segments to become fully ready after recovery.
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+
+-- The '.partial' renaming of the last WAL segment only occurs when archive_mode is enabled.
+!\retcode gpconfig -c archive_mode -v on;
+!\retcode gpconfig -c archive_command -v '/bin/true';
+
+-- Restart the cluster to apply the configuration changes.
+!\retcode gpstop -rai;
+
+1: CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+1: CREATE TABLE t_rename1 (a INT);
+1: CREATE TABLE t_rename2 (a INT);
+
+
+-- =================================================================
+-- STEP 2: Create Two In-Doubt Transactions in Separate WAL Segments
+-- =================================================================
+
+-- Create the first orphaned prepared transaction in the CURRENT WAL segment.
+-- We suspend the transaction right after the coordinator broadcasts PREPARE.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Assume (2), (1) are on different segments and one tuple is on the first segment.
+-- The test will double-check that.
+2&: INSERT INTO t_rename1 VALUES (2), (1);
+
+-- Wait for the fault to be triggered on the coordinator, ensuring the transaction is now in the
+-- "prepared" state on the segments.
+1: SELECT gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- This is the CRITICAL step to expose the bug. We force a WAL switch.
+-- Now, the PREPARE record for the first transaction is in a completed, non-last WAL segment.
+-- The next transaction's PREPARE record will be in a new WAL segment.
+-- start_ignore
+0U: SELECT pg_switch_wal();
+-- end_ignore
+
+-- Now, create a second orphaned prepared transaction in the NEW (and currently LAST) WAL segment.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'suspend', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- This INSERT will also be suspended, with its PREPARE record in the last WAL segment.
+3&: INSERT INTO t_rename2 VALUES (2), (1);
+
+-- Wait for the second fault to be triggered.
+1: SELECT gp_wait_until_triggered_fault('dtm_broadcast_prepare', 1, dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+
+-- =================================================================
+-- STEP 3: Trigger Segment Failover and Recovery
+-- =================================================================
+
+-- Shutdown the primary segment for content 0 using an immediate shutdown.
+-- This forces the mirror to perform crash recovery from WAL.
+-1U: SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration c
+    WHERE c.role='p' AND c.content=0), 'stop', 'immediate');
+
+-- Request the Fault Tolerance Server (FTS) to scan for the downed segment.
+1: SELECT gp_request_fts_probe_scan();
+
+-- Verify that the mirror has been promoted to the new primary.
+-- The new primary will now be in recovery mode, reading the WAL files. If the bug exists,
+-- it will crash at this stage while trying to recover the second prepared transaction.
+1: SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 0 ORDER BY role;
+
+
+-- =================================================================
+-- STEP 4: Verification
+-- =================================================================
+
+-- Double-check that the original transaction was indeed a 2PC transaction by verifying
+-- that its data is distributed across at least two segments.
+-- This also implicitly confirms that the new primary is responsive, and the
+-- shutdown then recovered segment 0 has data.
+1: INSERT INTO t_rename1 VALUES (2), (1);
+1: SELECT gp_segment_id, a FROM t_rename1 ORDER BY a;
+
+-- Reset the fault, allowing the coordinator to send the COMMIT PREPARED command for the
+-- two orphaned transactions.
+1: SELECT gp_inject_fault('dtm_broadcast_prepare', 'reset', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Wait for the background sessions to complete their commits.
+2<:
+3<:
+
+-- Confirm that the data from both transactions is now visible, meaning the prepared
+-- transactions were successfully recovered and subsequently committed.
+1: SELECT * FROM t_rename1 ORDER BY a;
+1: SELECT * FROM t_rename2 ORDER BY a;
+
+
+-- =================================================================
+-- STEP 5: Cluster Restoration and Cleanup
+-- =================================================================
+
+-- Recover the failed segment (which will become the new mirror).
+!\retcode gprecoverseg -a;
+1: SELECT wait_until_segment_synchronized(0);
+
+-- Rebalance the cluster to return the original primary to its preferred role.
+!\retcode gprecoverseg -ar;
+1: SELECT wait_until_segment_synchronized(0);
+
+-- Verify the segment roles are back to their original state.
+1: SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 0 ORDER BY role;
+
+-- Final cleanup.
+1: DROP TABLE t_rename1;
+1: DROP TABLE t_rename2;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation;
+!\retcode gpconfig -r archive_mode --skipvalidation;
+!\retcode gpconfig -r archive_command --skipvalidation;
+!\retcode gpstop -rai;


### PR DESCRIPTION
When promoting a mirror after failover, we sometimes hit a fatal error:

```
"FATAL","58P01","requested WAL segment pg_xlog/00000023000071D50000001F has already been removed",,,,,,,0,,"xlogutils.c",580,"Stack
trace:
1    0x557bdb9f09b6 postgres errstart + 0x236
2    0x557bdb5fc6cf postgres <symbol not found> + 0xdb5fc6cf
3    0x557bdb5fd021 postgres read_local_xlog_page + 0x191
4    0x557bdb5fb922 postgres <symbol not found> + 0xdb5fb922
5    0x557bdb5fba11 postgres XLogReadRecord + 0xa1
6    0x557bdb5e7767 postgres RecoverPreparedTransactions + 0xd7
7    0x557bdb5f608b postgres StartupXLOG + 0x2a3b
8    0x557bdb870a89 postgres StartupProcessMain + 0x139
9    0x557bdb62f489 postgres AuxiliaryProcessMain + 0x549
10   0x557bdb86d275 postgres <symbol not found> + 0xdb86d275
11   0x557bdb8704e3 postgres PostmasterMain + 0x1213
12   0x557bdb56a1f7 postgres main + 0x497
13   0x7fded4a61c87 libc.so.6 __libc_start_main + 0xe7
```

Upstream PostgreSQL fixed this in 13 and 14, but the issue never appeared in earlier releases, so it was not backpatched. Discussion here: https://www.postgresql.org/message-id/flat/743b9b45a2d4013bd90b6a5cba8d6faeb717ee34.camel%40cybertec.at

The root cause is that `StartupXLOG()` renames the last WAL segment to .partial but later `RecoverPreparedTransactions()` attempts to read it using the old name.

In PostgreSQL earlier versions, this rarely reproduces because XLogRead() caches the most recent file descriptor, so the renamed file is seldom reopened.

In WarehousePG/Greenplum, however, high load often leaves unfinished 2PC transactions spread across multiple WAL segments. This causes the cached FD to be bypassed, forcing a reopen by the old name, which results in a PANIC and leaves the cluster in double-fault mode.

This patch borrows the upstream fix from 14 (f663b009), with some specific adjustments. It also adds a regression test that reliably segfaults without the fix.