### PR TITLE
Allow parallel workers to get combo cid and distributed snapshot from DSM.

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -377,7 +377,14 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		SerializeGUCState(guc_len, gucspace);
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_GUC, gucspace);
 
-		/* CDB: Serialize DtxContextInfo */
+		/*
+		 * CDB: Serialize DtxContextInfo
+		 * QEs use DtxContextInfo to keep distributed transaction consistency with QD.
+		 * QD dispatches DtxContextInfo to QEs, including Writer and Reader QE.
+		 * However, parallel workers can't get dispatched information from QD.
+		 * So the leader QE needs to serialize its DtxContextInfo into DSM.
+		 * When parallel workers are created, they get DtxContextInfo from DSM.
+		 */
 		dtxspace = shm_toc_allocate(pcxt->toc, sizeof(uint32) + dtxlen);
 		*((uint32 *) dtxspace) = (uint32) dtxlen;
 		DtxContextInfo_Serialize(dtxspace + sizeof(uint32), &QEDtxContextInfo);
@@ -1447,7 +1454,11 @@ ParallelWorkerMain(Datum main_arg)
 	uint32 dtx_len = *((uint32 *) dtxspace);
 	DtxContextInfo_Deserialize(dtxspace + sizeof(uint32), (int) dtx_len, &QEDtxContextInfo);
 
-	/* CDB: Set DistributedTransactionContext */
+	/*
+	 * CDB: Set DistributedTransactionContext for Parallel workers.
+	 * Parallel workers behaves as Reader QEs, their DistributedTransactionContext
+	 * needs to be set since it is referenced when check tuple visibility.
+	 */
 	if (QEDtxContextInfo.haveDistributedSnapshot)
 	{
 		if (IS_QUERY_DISPATCHER())

--- a/src/backend/utils/time/combocid.c
+++ b/src/backend/utils/time/combocid.c
@@ -238,7 +238,7 @@ GetComboCommandId(CommandId cmin, CommandId cmax)
 	 * Dispatcher and Writer QE dump combo cid into shared memory by dumpSharedComboCommandIds(),
 	 * Entrydb and QE reader load combo cid by loadSharedComboCommandIds().
 	 *
-	 * Before parallel workers are created, combo cid are serialize by SerializeComboCIDState(),
+	 * Before parallel workers are created, combo cid are serialized by SerializeComboCIDState(),
 	 * Parallel workers can get combo cid from dynamic shared memory segment
 	 * by RestoreComboCIDState(), so that parallel workers can share combo cid with their leader.
 	 */

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -2316,11 +2316,7 @@ EstimateSnapshotSpace(Snapshot snap)
 	{
 		DistributedSnapshot *ds = &snap->distribSnapshotWithLocalMapping.ds;
 		if (ds->count > 0)
-		{
-			size = MAXALIGN(size);
-			size = add_size(size,
-							mul_size(ds->count, sizeof(DistributedTransactionId)));
-		}
+			size = add_size(size, mul_size(ds->count, sizeof(DistributedTransactionId)));
 	}
 
 	return size;
@@ -2405,11 +2401,11 @@ SerializeSnapshot(Snapshot snapshot, char *start_address)
 	/* Copy inProgressXidArray in distributed snapshot */
 	if (snapshot->haveDistribSnapshot && serialized_snapshot.ds.count > 0)
 	{
-		char *xidoff = (char *) MAXALIGN((uintptr_t)(start_address +
+		char *dxipoff = start_address +
 						sizeof(SerializedSnapshotData) +
 						snapshot->xcnt * sizeof(TransactionId) +
-						serialized_snapshot.subxcnt * sizeof(TransactionId)));
-		memcpy(xidoff,
+						serialized_snapshot.subxcnt * sizeof(TransactionId);
+		memcpy(dxipoff,
 			   snapshot->distribSnapshotWithLocalMapping.ds.inProgressXidArray,
 			   serialized_snapshot.ds.count * sizeof(DistributedTransactionId));
 	}
@@ -2442,10 +2438,7 @@ RestoreSnapshot(char *start_address)
 
 	/* If distributed snapshot exists, add space for inProgressXidArray */
 	if (serialized_snapshot.haveDistribSnapshot && serialized_snapshot.ds.count > 0)
-	{
-		size = MAXALIGN(size);
 		size += serialized_snapshot.ds.count * sizeof(DistributedTransactionId);
-	}
 
 	/* Copy all required fields */
 	snapshot = (Snapshot) MemoryContextAlloc(TopTransactionContext, size);
@@ -2484,7 +2477,6 @@ RestoreSnapshot(char *start_address)
 	if (snapshot->haveDistribSnapshot)
 	{
 		DistributedSnapshot *ds = &snapshot->distribSnapshotWithLocalMapping.ds;
-
 		ds->xminAllDistributedSnapshots = serialized_snapshot.ds.xminAllDistributedSnapshots;
 		ds->distribSnapshotId = serialized_snapshot.ds.distribSnapshotId;
 		ds->xmin = serialized_snapshot.ds.xmin;
@@ -2493,17 +2485,16 @@ RestoreSnapshot(char *start_address)
 
 		if (ds->count > 0)
 		{
-			char *xidoff = (char *)MAXALIGN((uintptr_t)(start_address +
-														sizeof(SerializedSnapshotData) +
-														serialized_snapshot.xcnt * sizeof(TransactionId) +
-														serialized_snapshot.subxcnt * sizeof(TransactionId)));
+			char *dxipoff = start_address +
+							sizeof(SerializedSnapshotData) +
+							serialized_snapshot.xcnt * sizeof(TransactionId) +
+							serialized_snapshot.subxcnt * sizeof(TransactionId);
 
-			ds->inProgressXidArray = (DistributedTransactionId *) (char *) MAXALIGN(
-									 (uintptr_t)((char *)(snapshot + 1) +
+			ds->inProgressXidArray = (DistributedTransactionId*)((char *)(snapshot + 1) +
 									 serialized_snapshot.xcnt * sizeof(TransactionId) +
-									 serialized_snapshot.subxcnt * sizeof(TransactionId)));
+									 serialized_snapshot.subxcnt * sizeof(TransactionId));
 
-			memcpy(ds->inProgressXidArray, xidoff,
+			memcpy(ds->inProgressXidArray, dxipoff,
 				   ds->count * sizeof(DistributedTransactionId));
 		}
 		else


### PR DESCRIPTION
When use parallel worker to create hnsw index for heap partitioned tables, pgvector reports an error: ERROR:  Reader qExec tried to allocate a Combo Command Id (combocid.c:241) (combocid.c:241)  (seg0 127.0.0.1:7002 pid=115876) (combocid.c:241)

The reason is, function ParallelWorkerMain calls RestoreComboCIDStateto restore Combo CID from dynamic shared memory segment. Combo CID is put into dynamic shared memory segment by function InitializeParallelDSM as Writer QE. RestoreComboCIDStateto calls GetComboCommandId to build a local hashtable. The function GetComboCommandId is assumed to work for QE writer. So the error happened. 

However in fact, parallel workers(with Gp_role GP_ROLE_EXECUTE,  Gp_is_writer is false) should also be able to get a combo cid, this is how PostgreSQL parallel workers behave. 

The reason why there is error for partitioned heap table and no error for heap table is, 

- for partitioned heap table parallel index creation, the combo cid is generated due to some dealing for parent and child tables, 
- but for non-partitioned heap table, no combo cid is generated. So GetComboCommandId is not called because num_elements is zero. 

We can know a process is a parallel worker or not by MyProc->lockGroupLeader, parallel workers has a lock group leader, which is the QE process who forked them. After a parallel worker is forked, it will call BecomeLockGroupMember to become a member of group locking, with its parent process as leader.

In this PR, we allow parallel workers to get combo cid from dynamic shared memory segment and build a local hashtable for it. But they won't dump combo cid into DSM.

In this PR, I also serialize and deserialize distributed snapshot for parallel workers, so that they can get correct snapshot from QE(their leader).

This PR won't affect the built-in index of WarehousePG. It will take effect on 3rd party index which use parallel workers to build index. 