### PR TITLE
Don't sort the in-memory tuples when it's already been interrupted

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -116,6 +116,7 @@
 #include "utils/dynahash.h"
 
 #include "utils/faultinjector.h"
+#include "utils/memdebug.h"
 
 
 /* sort-type codes for sort__start probes */
@@ -2031,7 +2032,7 @@ tuplesort_gettuple_common(Tuplesortstate *state, bool forward,
 	 * No output if we are told to finish execution.
 	 *
 	 * Note that the sort operation might (or might not) have been interrupted by
-	 * QueryFinishPending previously (see the code of checking 
+	 * QueryFinishPending previously (see the code of checking
 	 * QueryFinishPending), so there might not be valid tuples to be returned for
 	 * now. Return false to indicate "no more tuples" anyway.
 	 */
@@ -3141,6 +3142,13 @@ dumptuples(Tuplesortstate *state, bool alltuples)
 #endif
 
 	/*
+	 * Don't run into this for the in-memory data again, if the following
+	 * WRITETUP() has already been skipped.
+	 */
+	if (QueryFinishPending)
+		return;
+
+	/*
 	 * Sort all tuples accumulated within the allowed amount of memory for
 	 * this run using quicksort
 	 */
@@ -3172,6 +3180,18 @@ dumptuples(Tuplesortstate *state, bool alltuples)
 
 		if (QueryFinishPending)
 		{
+			/*
+			 * The whole sort should be skipped if QueryFinishPending, but
+			 * problematic code paths went into this function and sorted the
+			 * in-memory data again.
+			 *
+			 * Wipe the SortTuple structure in debug builds to make the bug
+			 * reproducible.
+			 */
+#ifdef CLOBBER_FREED_MEMORY
+			wipe_mem(state->memtuples, state->memtupsize * sizeof(SortTuple));
+#endif
+
 			break;
 		}
 		WRITETUP(state, state->tp_tapenum[state->destTape],


### PR DESCRIPTION
```
\#0  0x00007f412040382f in raise () from /home/gpadmin/***/sdw28/packcore-core-postgres-11-500-500-3740538-1761517823/lib64/libpthread.so.0
\#1  0x0000000000cf56a8 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5104
\#2  <signal handler called>
\#3  0x0000000000d4fb36 in comparetup_heap (a=0x7f40f51fc050, b=<optimized out>, state=0x340b600) at tuplesort.c:3748
\#4  0x0000000000d4ac02 in qsort_tuple (a=0x7f40f51fc050, n=630421, cmp_tuple=0xd4faf0 <comparetup_heap>, state=state@entry=0x340b600) at qsort_tuple.c:112
\#5  0x0000000000d4de8e in tuplesort_sort_memtuples (state=0x340b600) at tuplesort.c:3536
\#6  dumptuples (state=state@entry=0x340b600, alltuples=alltuples@entry=true) at tuplesort.c:3147
\#7  0x0000000000d52751 in tuplesort_performsort (state=state@entry=0x340b600) at tuplesort.c:1967
\#8  0x000000000098e9a4 in ExecSort (pstate=0x32c2378) at nodeSort.c:164
```

External sort runs in multiple execution phases. During the spill phase, if the process is interrupted by QueryFinishPending, the entire sort should be skipped. However, before this fix, the sort would still proceed to call dumptuples to sort in-memory data after the interruption. Since the previous flow had already been interrupted, the in-memory data could be inconsistent, leading to a SEGV.

This commit adds an additional QueryFinishPending check to ensure the whole sort is skipped when interrupted. It also proactively clears leftover state in debug builds to make this bug reproducible in problematic code paths.

Reported-by: Himanshu Pandey <himanshu.pandey@enterprisedb.com>