### PR TITLE
Use LWLock instead of SpinLock at InstrumentationHeader

### DIFF
--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -26,6 +26,7 @@
 #include "storage/shmem.h"
 #include "cdb/cdbdtxcontextinfo.h"
 #include "cdb/cdbtm.h"
+#include "storage/lwlock.h"
 
 BufferUsage pgBufferUsage;
 static BufferUsage save_pgBufferUsage;
@@ -344,7 +345,6 @@ InstrShmemInit(void)
 	/* header points to the first slot */
 	header->head = slot;
 	header->free = number_slots;
-	SpinLockInit(&header->lock);
 
 	/* Each slot points to next one to construct the free list */
 	for (i = 0; i < number_slots - 1; i++)
@@ -434,7 +434,7 @@ pickInstrFromShmem(const Plan *plan, int instrument_options)
 	InstrumentationResownerSet *item;
 
 	/* Lock to protect write to header */
-	SpinLockAcquire(&InstrumentGlobal->lock);
+	LWLockAcquire(InstrumentationSlotHeaderLock, LW_EXCLUSIVE);
 
 	/* Pick the first free slot */
 	slot = InstrumentGlobal->head;
@@ -445,7 +445,7 @@ pickInstrFromShmem(const Plan *plan, int instrument_options)
 		InstrumentGlobal->free--;
 	}
 
-	SpinLockRelease(&InstrumentGlobal->lock);
+	LWLockRelease(InstrumentationSlotHeaderLock);
 
 	if (NULL != slot && SlotIsEmpty(slot))
 	{
@@ -497,7 +497,7 @@ instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit, bool isTopL
 
 	next = slotsOccupied;
 	slotsOccupied = NULL;
-	SpinLockAcquire(&InstrumentGlobal->lock);
+	LWLockAcquire(InstrumentationSlotHeaderLock, LW_EXCLUSIVE);
 	while (next)
 	{
 		curr = next;
@@ -520,7 +520,7 @@ instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit, bool isTopL
 
 		pfree(curr);
 	}
-	SpinLockRelease(&InstrumentGlobal->lock);
+	LWLockRelease(InstrumentationSlotHeaderLock);
 }
 
 /*

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -69,3 +69,4 @@ FTSReplicationStatusLock  		62
 GxidBumpLock		  		63
 ParallelCursorEndpointLock		64
 CommittedGxidArrayLock			65
+InstrumentationSlotHeaderLock		66

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -125,6 +125,8 @@ typedef struct InstrumentationHeader
 {
 	void	   *head;
 	int			free;
+
+	/* GP_ABI_BUMP_FIXME: deprecated field, keep it for ABI, do not use it */
 	slock_t		lock;
 } InstrumentationHeader;
 


### PR DESCRIPTION
### Issue Summary

A crash was observed when acquiring the spinlock `InstrumentGlobal->lock`, 
which was caused by severe lock contention. Further investigation revealed 
deeper structural issues in the locking design.

### Root Cause

In `instrShmemRecycleCallback()`, a large loop performs multiple system calls 
(such as memory reset and free) while holding `InstrumentGlobal->lock`.
This code path can take a significant amount of time under heavy system load, 
preventing other backends from acquiring the same lock.

Moreover, spinlocks must never be held across kernel or blocking calls, as they 
are designed for very short, atomic critical sections. Holding a spinlock while 
performing system calls violates this principle and can easily lead to contention, 
starvation, or deadlocks.

### Resolution

The current use of a spinlock is inappropriate for this scenario.

The fix replaces the spinlock with a lightweight lock (LWLock), which is designed 
for longer critical sections and allows kernel calls within the protected region 
without risking system instability.