### PR TITLE
Don't report zlib/zstd reloptions error if not validating

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -975,10 +975,11 @@ validate_and_adjust_options(StdRdOptions *result,
 			(pg_strcasecmp(result->compresstype, "zlib") == 0))
 		{
 #ifndef HAVE_LIBZ
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("zlib compression is not supported by this build"),
-					 errhint("Compile without --without-zlib to use zlib compression.")));
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("zlib compression is not supported by this build"),
+						 errhint("Compile without --without-zlib to use zlib compression.")));
 #endif
 			if (result->compresslevel > 9)
 			{
@@ -996,10 +997,11 @@ validate_and_adjust_options(StdRdOptions *result,
 			(pg_strcasecmp(result->compresstype, "zstd") == 0))
 		{
 #ifndef USE_ZSTD
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("Zstandard library is not supported by this build"),
-					 errhint("Compile with --with-zstd to use Zstandard compression.")));
+			if (validate)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("Zstandard library is not supported by this build"),
+						 errhint("Compile with --with-zstd to use Zstandard compression.")));
 #endif
 			if (result->compresslevel > 19)
 			{

--- a/src/test/regress/expected/reloptions.out
+++ b/src/test/regress/expected/reloptions.out
@@ -234,13 +234,24 @@ SELECT reloptions FROM pg_class WHERE oid = 'reloptions_test_idx3'::regclass;
 CREATE TABLE ao_reloptions_t1 (c1 INT) USING ao_row WITH (compresstype=zstd);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE ao_reloptions_t2 (c1 INT) USING ao_row WITH (compresstype=zstd);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SET allow_system_table_mods = on;
-UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zzzz}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zlib,compresslevel=3}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zzzz,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
 SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t1';
-         reloptions          
------------------------------
- {foo=bar,compresstype=zzzz}
+                 reloptions                  
+---------------------------------------------
+ {foo=bar,compresstype=zlib,compresslevel=3}
 (1 row)
 
-SET allow_system_table_mods = on;
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t2';
+                 reloptions                  
+---------------------------------------------
+ {foo=bar,compresstype=zzzz,compresslevel=3}
+(1 row)
+
+SET allow_system_table_mods = off;
 DROP TABLE ao_reloptions_t1;
+DROP TABLE ao_reloptions_t2;

--- a/src/test/regress/sql/reloptions.sql
+++ b/src/test/regress/sql/reloptions.sql
@@ -133,8 +133,12 @@ SELECT reloptions FROM pg_class WHERE oid = 'reloptions_test_idx3'::regclass;
 
 -- DROP TABLE with invalid reloptions
 CREATE TABLE ao_reloptions_t1 (c1 INT) USING ao_row WITH (compresstype=zstd);
+CREATE TABLE ao_reloptions_t2 (c1 INT) USING ao_row WITH (compresstype=zstd);
 SET allow_system_table_mods = on;
-UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zzzz}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zlib,compresslevel=3}' WHERE relname = 'ao_reloptions_t1';
+UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zzzz,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
 SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t1';
-SET allow_system_table_mods = on;
+SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t2';
+SET allow_system_table_mods = off;
 DROP TABLE ao_reloptions_t1;
+DROP TABLE ao_reloptions_t2;


### PR DESCRIPTION
```
CREATE TABLE ao_reloptions_t2 (c1 INT) USING ao_row WITH (compresstype=zstd);
SET allow_system_table_mods = on;
UPDATE pg_class SET reloptions = '{foo=bar,compresstype=zlib,compresslevel=3}' WHERE relname = 'ao_reloptions_t2';
SELECT reloptions FROM pg_class WHERE relname = 'ao_reloptions_t2';
                 reloptions
---------------------------------------------
 {foo=bar,compresstype=zlib,compresslevel=3}
(1 row)

DROP TABLE ao_reloptions_t2;
ERROR:  zlib compression is not supported by this build
HINT:  Compile without --without-zlib to use zlib compression.
```

The last commit fixing `validate_and_adjust_options()` missed the error if not building with zlib or zstd. This commit completes the fix and test case.

	commit 2629212bfe848e1701f97db3a9d441f4c39b0547
	Author: Adam Lee <adam8157@gmail.com>
	Date:   Fri Oct 31 10:48:26 2025 +0800

	    Don't report compresstype error if not validating