### PR TITLE
Fix NULL pointer in COPY (SELECT) TO option validation

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1642,7 +1642,7 @@ ProcessCopyOptions(ParseState *pstate,
 						 errmsg("conflicting or redundant options")));
 			cstate->skip_foreign_partitions = true;
 		}
-		else if (!rel_is_external_table(cstate->rel->rd_id))
+		else if (!cstate->rel || !rel_is_external_table(cstate->rel->rd_id))
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
 					 errmsg("option \"%s\" not recognized",

--- a/src/test/regress/expected/copyselect.out
+++ b/src/test/regress/expected/copyselect.out
@@ -153,3 +153,8 @@ select * from test3;
 (2 rows)
 
 drop table test3;
+-- invalid option
+copy (select * from pg_class) to '/dev/null' with (heater);
+ERROR:  option "heater" not recognized
+LINE 1: copy (select * from pg_class) to '/dev/null' with (heater);
+                                                           ^

--- a/src/test/regress/sql/copyselect.sql
+++ b/src/test/regress/sql/copyselect.sql
@@ -94,3 +94,6 @@ select 0\; copy test3 from stdin\; copy test3 from stdin\; select 1; -- 1
 \.
 select * from test3;
 drop table test3;
+
+-- invalid option
+copy (select * from pg_class) to '/dev/null' with (heater);


### PR DESCRIPTION
COPY checks if the relation is an external table and skips option
validation since external tables may define their own options.

However, `COPY (SELECT) TO` has no relation (cstate->rel) at all, which
leads to a NULL pointer dereference. This fixes it.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`