### PR TITLE
[6X] change severity to `WARNING` in ftsprobe.c under certain conditions

### DIFF
--- a/src/backend/cdb/cdbfts.c
+++ b/src/backend/cdb/cdbfts.c
@@ -181,7 +181,7 @@ FtsTestSegmentDBIsDown(SegmentDatabaseDescriptor **segdbDesc, int size)
 
 		if (FtsIsSegmentDown(segInfo))
 		{
-			ereport(LOG, (errmsg_internal("FTS: found fault with segment dbid %d. "
+			ereport(WARNING, (errmsg_internal("FTS: found fault with segment dbid %d. "
 										  "Reconfiguration is in progress", (int) segInfo->config->dbid)));
 			return true;
 		}

--- a/src/backend/fts/ftsmessagehandler.c
+++ b/src/backend/fts/ftsmessagehandler.c
@@ -68,7 +68,7 @@ checkIODataDirectory(void)
 				if (fd < 0)
 				{
 					failure = true;
-					ereport(LOG, (errcode_for_file_access(),
+					ereport(WARNING, (errcode_for_file_access(),
 							errmsg("FTS: could not create file \"%s\": %m",
 								FTS_PROBE_FILE_NAME)));
 				}
@@ -77,7 +77,7 @@ checkIODataDirectory(void)
 					strncpy(dataAligned, FTS_PROBE_MAGIC_STRING, magic_len);
 					if (write(fd, dataAligned, BLCKSZ) != BLCKSZ)
 					{
-						ereport(LOG, (errcode_for_file_access(),
+						ereport(WARNING, (errcode_for_file_access(),
 									  errmsg("FTS: could not write file \"%s\" : %m",
 											 FTS_PROBE_FILE_NAME)));
 						failure = true;
@@ -99,7 +99,7 @@ checkIODataDirectory(void)
 				 * Some other error
 				 */
 				failure = true;
-				ereport(LOG, (errcode_for_file_access(),
+				ereport(WARNING, (errcode_for_file_access(),
 						errmsg("FTS: could not open file \"%s\": %m",
 							FTS_PROBE_FILE_NAME)));
 			}
@@ -109,7 +109,7 @@ checkIODataDirectory(void)
 		int len = read(fd, dataAligned, BLCKSZ);
 		if (len != BLCKSZ)
 		{
-			ereport(LOG, (errcode_for_file_access(),
+			ereport(WARNING, (errcode_for_file_access(),
 					errmsg("FTS: could not read file \"%s\" "
 						"(actual bytes read %d, required: %d): %m",
 						FTS_PROBE_FILE_NAME, len, BLCKSZ)));
@@ -119,14 +119,14 @@ checkIODataDirectory(void)
 
 		if (strncmp(dataAligned, FTS_PROBE_MAGIC_STRING, magic_len) != 0)
 		{
-			ereport(LOG, (errmsg("FTS: Read corrupted data from \"%s\" file", FTS_PROBE_FILE_NAME)));
+			ereport(WARNING, (errmsg("FTS: Read corrupted data from \"%s\" file", FTS_PROBE_FILE_NAME)));
 			failure = true;
 			break;
 		}
 
 		if (lseek(fd, (off_t) 0, SEEK_SET) < 0)
 		{
-			ereport(LOG, (errcode_for_file_access(),
+			ereport(WARNING, (errcode_for_file_access(),
 					errmsg("FTS: could not seek in file \"%s\" to offset zero: %m",
 					FTS_PROBE_FILE_NAME)));
 			failure = true;
@@ -138,7 +138,7 @@ checkIODataDirectory(void)
 		 */
 		if (write(fd, dataAligned, BLCKSZ) != BLCKSZ)
 		{
-			ereport(LOG, (errcode_for_file_access(),
+			ereport(WARNING, (errcode_for_file_access(),
 					errmsg("FTS: could not write file \"%s\" : %m",
 					FTS_PROBE_FILE_NAME)));
 			failure = true;
@@ -164,7 +164,7 @@ checkIODataDirectory(void)
 		if (failure)
 		{
 			if (unlink(FTS_PROBE_FILE_NAME) < 0)
-				ereport(LOG,
+				ereport(WARNING,
 				(errcode_for_file_access(),
 				errmsg("could not unlink file \"%s\": %m", FTS_PROBE_FILE_NAME)));
 		}

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -176,7 +176,7 @@ ftsConnectStart(fts_segment_info *ftsInfo)
 	}
 	if (ftsInfo->conn->status == CONNECTION_BAD)
 	{
-		elog(LOG, "FTS: cannot establish libpq connection to "
+		elog(WARNING, "FTS: cannot establish libpq connection to "
 			 "(content=%d, dbid=%d): %s",
 			 ftsInfo->primary_cdbinfo->config->segindex, ftsInfo->primary_cdbinfo->config->dbid,
 			 PQerrorMessage(ftsInfo->conn));
@@ -365,7 +365,7 @@ ftsConnect(fts_context *context)
 						case PGRES_POLLING_FAILED:
 							ftsInfo->state = nextFailedState(ftsInfo->state);
 							checkIfFailedDueToNormalRestart(ftsInfo);
-							elog(LOG, "FTS: cannot establish libpq connection "
+							elog(WARNING, "FTS: cannot establish libpq connection "
 								 "(content=%d, dbid=%d): %s, retry_count=%d",
 								 ftsInfo->primary_cdbinfo->config->segindex,
 								 ftsInfo->primary_cdbinfo->config->dbid,
@@ -418,7 +418,7 @@ ftsCheckTimeout(fts_segment_info *ftsInfo, pg_time_t now)
 	if (!IsFtsMessageStateSuccess(ftsInfo->state) &&
 		(int) (now - ftsInfo->startTime) > gp_fts_probe_timeout)
 	{
-		elog(LOG,
+		elog(WARNING,
 			 "FTS timeout detected for (content=%d, dbid=%d) "
 			 "state=%d, retry_count=%d,",
 			 ftsInfo->primary_cdbinfo->config->segindex,
@@ -498,7 +498,7 @@ ftsPoll(fts_context *context)
 			else if (ftsInfo->poll_revents & (POLLHUP | POLLERR))
 			{
 				ftsInfo->state = nextFailedState(ftsInfo->state);
-				elog(LOG,
+				elog(WARNING,
 					 "FTS poll failed (revents=%d, events=%d) for "
 					 "(content=%d, dbid=%d) state=%d, retry_count=%d, "
 					 "libpq status=%d, asyncStatus=%d",
@@ -511,7 +511,7 @@ ftsPoll(fts_context *context)
 			else if (ftsInfo->poll_revents)
 			{
 				ftsInfo->state = nextFailedState(ftsInfo->state);
-				elog(LOG,
+				elog(WARNING,
 					 "FTS unexpected events (revents=%d, events=%d) for "
 					 "(content=%d, dbid=%d) state=%d, retry_count=%d, "
 					 "libpq status=%d, asyncStatus=%d",
@@ -588,7 +588,7 @@ ftsSend(fts_context *context)
 				}
 				else
 				{
-					elog(LOG,
+					elog(WARNING,
 						 "FTS: failed to send %s to segment (content=%d, "
 						 "dbid=%d) state=%d, retry_count=%d, "
 						 "conn->asyncStatus=%d %s", message,
@@ -681,7 +681,7 @@ ftsReceive(fts_context *context)
 				/* Read the response that has arrived. */
 				if (!PQconsumeInput(ftsInfo->conn))
 				{
-					elog(LOG, "FTS: failed to read from (content=%d, dbid=%d)"
+					elog(WARNING, "FTS: failed to read from (content=%d, dbid=%d)"
 						 " state=%d, retry_count=%d, conn->asyncStatus=%d %s",
 						 ftsInfo->primary_cdbinfo->config->segindex,
 						 ftsInfo->primary_cdbinfo->config->dbid,
@@ -707,7 +707,7 @@ ftsReceive(fts_context *context)
 
 				if (!result || PQstatus(ftsInfo->conn) == CONNECTION_BAD)
 				{
-					elog(LOG, "FTS: error getting results from (content=%d, "
+					elog(WARNING, "FTS: error getting results from (content=%d, "
 						 "dbid=%d) state=%d, retry_count=%d, "
 						 "conn->asyncStatus=%d conn->status=%d %s",
 						 ftsInfo->primary_cdbinfo->config->segindex,
@@ -722,7 +722,7 @@ ftsReceive(fts_context *context)
 
 				if (PQresultStatus(result) != PGRES_TUPLES_OK)
 				{
-					elog(LOG, "FTS: error response from (content=%d, dbid=%d)"
+					elog(WARNING, "FTS: error response from (content=%d, dbid=%d)"
 						 " state=%d, retry_count=%d, conn->asyncStatus=%d %s",
 						 ftsInfo->primary_cdbinfo->config->segindex,
 						 ftsInfo->primary_cdbinfo->config->dbid,
@@ -741,7 +741,7 @@ ftsReceive(fts_context *context)
 					 * XXX: Investigate: including conn->asyncStatus generated
 					 * a format string warning at compile time.
 					 */
-					elog(LOG, "FTS: invalid response from (content=%d, dbid=%d)"
+					elog(WARNING, "FTS: invalid response from (content=%d, dbid=%d)"
 						 " state=%d, retry_count=%d, expected %d tuple with "
 						 "%d fields, got %d tuples with %d fields",
 						 ftsInfo->primary_cdbinfo->config->segindex,
@@ -781,7 +781,7 @@ retryForFtsFailed(fts_segment_info *ftsInfo, pg_time_t now)
 {
 	if (ftsInfo->retry_count == gp_fts_probe_retries)
 	{
-		elog(LOG, "FTS max (%d) retries exhausted "
+		elog(WARNING, "FTS max (%d) retries exhausted "
 			"(content=%d, dbid=%d) state=%d",
 			ftsInfo->retry_count,
 			ftsInfo->primary_cdbinfo->config->segindex,


### PR DESCRIPTION
Backport #70 to 6X_STABLE

---

In cases such as failures or reaching the maximum number of retries, the log level 
should be raised from `LOG` to `WARNING`. These log messages should not be 
controlled by the `gp_log_fts` GUC.
