### PR TITLE
Fix pg_waldump flaky case

### DIFF
--- a/src/bin/pg_waldump/t/001_basic.pl
+++ b/src/bin/pg_waldump/t/001_basic.pl
@@ -101,8 +101,11 @@ $node->command_checks_all(['pg_waldump', '-p', "$pgdata/pg_wal/", '-t', '1','--l
 my $header_size1 = 32*1024;
 open my $fh1, '>', $corrupt_wal_file or die "Cannot open WAL file $corrupt_wal_file: $!";
 
-# Simulate corrupt header
+# Simulate corrupt header, but fill xlp_seg_size position with DEFAULT_XLOG_SEG_SIZE.
+# Otherwise, the below command may report fatal as above case when set WalSegSz.
 my $corrupt_header1 = "\x00" x $header_size1; # Filling the header with null bytes
+my $value = 64 * 1024 * 1024;
+substr($corrupt_header1, 32, 4) = pack("V", $value);
 print $fh1 $corrupt_header1;
 close $fh1;
 


### PR DESCRIPTION
The test manually creates a WAL file with a corrupt header and a size of
32 KB. Its purpose is to verify that `pg_waldump --last-valid-walname`
correctly skips this invalid file.

Before processing the file name provided to `--last-valid-walname`,
pg_waldump first scans the target directory. During this directory
scan, `search_directory()` may pick any file whose name matches a valid
WAL file pattern. It then reads the file to determine `WalSegSz` and
validates that the size is acceptable. If the corrupt test file reports
an invalid segment size, pg_waldump errors out before
`LastValidWalSegment` is even reached.

This commit avoids that premature failure by writing
`DEFAULT_XLOG_SEG_SIZE` into the xlp_seg_size field of the corrupt WAL
file’s header, ensuring the initial directory scan does not abort
before the tool can evaluate the file properly with
LastValidWalSegment.