### PR TITLE
Updated test outputs after FDW rescan changes

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
@@ -3796,11 +3796,9 @@ ORDER BY ref_0."C 1";
                ->  Index Scan using t1_pkey on "S 1"."T 1" ref_0
                      Output: ref_0.c2, ref_0."C 1"
                      Index Cond: (ref_0."C 1" < 10)
-         ->  Materialize
-               Output: ref_1.c3, (ref_0.c2)
-               ->  Foreign Scan on public.ft1 ref_1
-                     Output: ref_1.c3, ref_0.c2
-                     Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'::text))
+         ->  Foreign Scan on public.ft1 ref_1
+               Output: ref_1.c3, ref_0.c2
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'::text))
    ->  Materialize
          Output: ref_3.c3
          ->  Foreign Scan on public.ft2 ref_3
@@ -6135,11 +6133,9 @@ UPDATE ft2 SET c3 = 'baz'
                      ->  Foreign Scan on public.ft2
                            Output: ft2.c1, ft2.c2, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.ctid
                            Remote SQL: SELECT "C 1", c2, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" WHERE (("C 1" > 2000)) FOR UPDATE
-                     ->  Materialize
+                     ->  Foreign Scan on public.ft4
                            Output: ft4.*, ft4.c1, ft4.c2, ft4.c3
-                           ->  Foreign Scan on public.ft4
-                                 Output: ft4.*, ft4.c1, ft4.c2, ft4.c3
-                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
+                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
          ->  Hash
                Output: ft5.*, ft5.c1, ft5.c2, ft5.c3
                ->  Foreign Scan on public.ft5
@@ -6186,12 +6182,10 @@ DELETE FROM ft2
                            ->  Foreign Scan on public.ft4
                                  Output: ft4.*, ft4.c1
                                  Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
-               ->  Materialize
+               ->  Foreign Scan on public.ft5
                      Output: ft5.*, ft5.c1
-                     ->  Foreign Scan on public.ft5
-                           Output: ft5.*, ft5.c1
-                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
- Optimizer: Postgres query optimizer
+                     Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+ Optimizer: Postgres-based planner
  Settings: optimizer = 'off'
 (28 rows)
 

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -4490,11 +4490,9 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
                ->  Index Scan using t1_pkey on "S 1"."T 1" ref_0
                      Output: ref_0.c2, ref_0."C 1"
                      Index Cond: (ref_0."C 1" < 10)
-         ->  Materialize
-               Output: ref_1.c3, (ref_0.c2)
-               ->  Foreign Scan on public.ft1 ref_1
-                     Output: ref_1.c3, ref_0.c2
-                     Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'::text))
+         ->  Foreign Scan on public.ft1 ref_1
+               Output: ref_1.c3, ref_0.c2
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE ((c3 = '00001'::text))
    ->  Materialize
          Output: ref_3.c3
          ->  Foreign Scan on public.ft2 ref_3
@@ -6932,11 +6930,9 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
                      ->  Foreign Scan on public.ft2
                            Output: ft2.c1, ft2.c2, ft2.c4, ft2.c5, ft2.c6, ft2.c7, ft2.c8, ft2.ctid
                            Remote SQL: SELECT "C 1", c2, c4, c5, c6, c7, c8, ctid FROM "S 1"."T 1" WHERE (("C 1" > 2000)) FOR UPDATE
-                     ->  Materialize
+                     ->  Foreign Scan on public.ft4
                            Output: ft4.*, ft4.c1, ft4.c2, ft4.c3
-                           ->  Foreign Scan on public.ft4
-                                 Output: ft4.*, ft4.c1, ft4.c2, ft4.c3
-                                 Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
+                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
          ->  Hash
                Output: ft5.*, ft5.c1, ft5.c2, ft5.c3
                ->  Foreign Scan on public.ft5
@@ -6986,13 +6982,11 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
                            ->  Foreign Scan on public.ft4
                                  Output: ft4.*, ft4.c1
                                  Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 3"
-               ->  Materialize
+               ->  Foreign Scan on public.ft5
                      Output: ft5.*, ft5.c1
-                     ->  Foreign Scan on public.ft5
-                           Output: ft5.*, ft5.c1
-                           Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
- Optimizer: Postgres query optimizer
-(27 rows)
+                     Remote SQL: SELECT c1, c2, c3 FROM "S 1"."T 4"
+ Optimizer: Postgres-based planner
+(25 rows)
 
 DELETE FROM ft2
   USING ft4 INNER JOIN ft5 ON (ft4.c1 === ft5.c1)

--- a/src/test/fdw/expected/no_rescan_test.out
+++ b/src/test/fdw/expected/no_rescan_test.out
@@ -303,6 +303,8 @@ NOTICE:  no_rescan_test_fdw: EndForeignScan - scanned 10 of 10 rows
 -- Reset planner settings
 RESET enable_hashjoin;
 RESET enable_mergejoin;
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_mergejoin;
 RESET enable_material;
 RESET enable_nestloop;
 -- Cleanup

--- a/src/test/fdw/expected/no_rescan_test_optimizer.out
+++ b/src/test/fdw/expected/no_rescan_test_optimizer.out
@@ -323,6 +323,8 @@ NOTICE:  no_rescan_test_fdw: EndForeignScan - scanned 10 of 10 rows
 -- Reset planner settings
 RESET enable_hashjoin;
 RESET enable_mergejoin;
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_mergejoin;
 RESET enable_material;
 RESET enable_nestloop;
 -- Cleanup

--- a/src/test/fdw/sql/no_rescan_test.sql
+++ b/src/test/fdw/sql/no_rescan_test.sql
@@ -171,6 +171,8 @@ ORDER BY l.id;
 -- Reset planner settings
 RESET enable_hashjoin;
 RESET enable_mergejoin;
+RESET optimizer_enable_hashjoin;
+RESET optimizer_enable_mergejoin;
 RESET enable_material;
 RESET enable_nestloop;
 


### PR DESCRIPTION
The previous commit adjusted the FDW rescan behavior, which caused
changes in several test outputs. This updates the missed expected
results accordingly.

Additionally, reset the GUC we modified explicitly in its own test to
avoid side effects.