### PR TITLE
Fix buffer over-read at TranslateDXLDatumGenericToScalar()

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -1956,23 +1956,10 @@ CTranslatorDXLToScalar::TranslateDXLDatumGenericToScalar(CDXLDatum *datum_dxl)
 	{
 		constant->constvalue = (Datum) 0;
 	}
-	else if (constant->constbyval)
-	{
-		// if it is a by-value constant, the value is stored in the datum.
-		GPOS_ASSERT(constant->constlen >= 0);
-		GPOS_ASSERT((ULONG) constant->constlen <= sizeof(Datum));
-		memcpy(&constant->constvalue, datum_generic_dxl->GetByteArray(),
-			   sizeof(Datum));
-	}
 	else
 	{
-		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
-		ULONG length = (ULONG) gpdb::DatumSize(val, false, constant->constlen);
-
-		CHAR *str = (CHAR *) gpdb::GPDBAlloc(length + 1);
-		memcpy(str, datum_generic_dxl->GetByteArray(), length);
-		str[length] = '\0';
-		constant->constvalue = gpdb::DatumFromPointer(str);
+		constant->constvalue = CTranslatorUtils::CreateDatumFromCDXLDatumGeneric(
+			constant->constbyval, constant->constlen, datum_generic_dxl);
 	}
 
 	return constant;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2478,7 +2478,6 @@ CTranslatorUtils::CreateDatumFromCDXLDatumGeneric(BOOL passed_by_val, ULONG leng
 	Datum result = 0;
 	if (passed_by_val)
 	{
-		GPOS_ASSERT(length >= 0);
 		GPOS_ASSERT(length <= sizeof(Datum));
 		// make sure the length passed in equals to the result of datum_generic_dxl->Length()
 		GPOS_ASSERT(length == datum_generic_dxl->Length());
@@ -2487,9 +2486,9 @@ CTranslatorUtils::CreateDatumFromCDXLDatumGeneric(BOOL passed_by_val, ULONG leng
 	else
 	{
 		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
-		length = (ULONG) gpdb::DatumSize(val, false, length);
-		BYTE *buffer = (BYTE *) gpdb::GPDBAlloc(length);
-		memcpy(buffer, datum_generic_dxl->GetByteArray(), length);
+		ULONG new_length = (ULONG) gpdb::DatumSize(val, false, length);
+		BYTE *buffer = (BYTE *) gpdb::GPDBAlloc(new_length);
+		memcpy(buffer, datum_generic_dxl->GetByteArray(), new_length);
 		result = gpdb::DatumFromPointer(buffer);
 	}
 	return result;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2487,8 +2487,9 @@ CTranslatorUtils::CreateDatumFromCDXLDatumGeneric(BOOL passed_by_val, ULONG leng
 	{
 		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
 		ULONG new_length = (ULONG) gpdb::DatumSize(val, false, length);
-		BYTE *buffer = (BYTE *) gpdb::GPDBAlloc(new_length);
+		CHAR *buffer = (CHAR *) gpdb::GPDBAlloc(new_length + 1);
 		memcpy(buffer, datum_generic_dxl->GetByteArray(), new_length);
+		buffer[new_length] = '\0';
 		result = gpdb::DatumFromPointer(buffer);
 	}
 	return result;

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -2470,4 +2470,28 @@ CTranslatorUtils::RelContainsForeignPartitions(const IMDRelation *rel,
 	}
 	return false;
 }
+
+Datum
+CTranslatorUtils::CreateDatumFromCDXLDatumGeneric(BOOL passed_by_val, ULONG length,
+												  const CDXLDatumGeneric *datum_generic_dxl)
+{
+	Datum result = 0;
+	if (passed_by_val)
+	{
+		GPOS_ASSERT(length >= 0);
+		GPOS_ASSERT(length <= sizeof(Datum));
+		// make sure the length passed in equals to the result of datum_generic_dxl->Length()
+		GPOS_ASSERT(length == datum_generic_dxl->Length());
+		memcpy(&result, datum_generic_dxl->GetByteArray(), length);
+	}
+	else
+	{
+		Datum val = gpdb::DatumFromPointer(datum_generic_dxl->GetByteArray());
+		length = (ULONG) gpdb::DatumSize(val, false, length);
+		BYTE *buffer = (BYTE *) gpdb::GPDBAlloc(length);
+		memcpy(buffer, datum_generic_dxl->GetByteArray(), length);
+		result = gpdb::DatumFromPointer(buffer);
+	}
+	return result;
+}
 // EOF

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #include "gpopt/translate/CMappingVarColId.h"
 #include "naucrates/dxl/CIdGenerator.h"
+#include "naucrates/dxl/operators/CDXLDatumGeneric.h"
 #include "naucrates/dxl/operators/CDXLIndexDescr.h"
 #include "naucrates/dxl/operators/CDXLLogicalSetOp.h"
 #include "naucrates/dxl/operators/CDXLLogicalTVF.h"
@@ -386,6 +387,10 @@ public:
 	// check if rel contains foreign partitions
 	static BOOL RelContainsForeignPartitions(const IMDRelation *rel,
 											 CMDAccessor *md_accessor);
+
+	// create a datum from CDXLDatumGeneric
+	static Datum CreateDatumFromCDXLDatumGeneric(BOOL passed_by_val, ULONG length,
+												 const CDXLDatumGeneric *datum_generic_dxl);
 };
 }  // namespace gpdxl
 


### PR DESCRIPTION
For scalar values, the length of the buffer returned by `GetByteArray()` 
is less than or equal to `sizeof(Datum)`, as the assertion said:

```
GPOS_ASSERT((ULONG) constant->constlen <= sizeof(Datum));
```

So we should use `constlen`(smaller value) to determine the buffer
length.