### PR TITLE
Add GitHub Actions CI workflows

### DIFF
--- a/.github/scripts/detect-config.bash
+++ b/.github/scripts/detect-config.bash
@@ -26,7 +26,7 @@ detect_whpg_version() {
     tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
     if [[ -z "$tag" ]]; then
-        echo "::error::No git tag found. Cannot determine WHPG version."
+        echo "::error::No git tag found. Cannot determine WHPG version." >&2
         exit 1
     fi
 
@@ -45,6 +45,12 @@ detect_whpg_version() {
 determine_el_versions() {
     local whpg_major="$1"
     local el_versions
+
+    # Validate WHPG version
+    if [[ "$whpg_major" != "7" && "$whpg_major" != "6" ]]; then
+        echo "::error::Unsupported WHPG major version: $whpg_major. Only 6 and 7 are supported." >&2
+        exit 1
+    fi
 
     if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
         # Dispatch: user-selected el_version

--- a/.github/scripts/detect-config.bash
+++ b/.github/scripts/detect-config.bash
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# Detect WHPG version and test configuration
+# Outputs configuration values for GitHub Actions
+
+set -eo pipefail
+
+# =============================================================================
+# Required inputs (from workflow env)
+# =============================================================================
+: "${EVENT_NAME:?EVENT_NAME not set}"
+: "${BRANCH_NAME:?BRANCH_NAME not set}"
+# INPUT_EL_VERSION and INPUT_INSTALLCHECK_TARGET are optional (only set for workflow_dispatch)
+
+# Required configuration (from workflow env)
+: "${WHPG7_EL_VERSIONS:?WHPG7_EL_VERSIONS not set}"
+: "${WHPG6_EL_VERSIONS:?WHPG6_EL_VERSIONS not set}"
+: "${DEFAULT_EL_VERSION:?DEFAULT_EL_VERSION not set}"
+: "${DEFAULT_INSTALLCHECK_TARGET:?DEFAULT_INSTALLCHECK_TARGET not set}"
+
+# =============================================================================
+# Detect WHPG version from git tags
+# =============================================================================
+detect_whpg_version() {
+    local tag
+    tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+    if [[ -z "$tag" ]]; then
+        echo "::error::No git tag found. Cannot determine WHPG version."
+        exit 1
+    fi
+
+    # Extract major version (first number before dot)
+    local ver
+    ver=$(echo "$tag" | cut -d'.' -f1)
+
+    echo "Found tag: $tag"
+    echo "Detected WHPG major version: $ver"
+    echo "$ver"
+}
+
+# =============================================================================
+# Determine EL versions to test
+# =============================================================================
+determine_el_versions() {
+    local whpg_major="$1"
+    local el_versions
+
+    if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+        # Dispatch: user-selected el_version
+        if [[ "$INPUT_EL_VERSION" == "all" ]]; then
+            # "all" selected - expand based on WHPG version
+            if [[ "$whpg_major" == "7" ]]; then
+                el_versions="$WHPG7_EL_VERSIONS"
+            else
+                el_versions="$WHPG6_EL_VERSIONS"
+            fi
+        else
+            # Specific version selected
+            el_versions="[\"$INPUT_EL_VERSION\"]"
+        fi
+    else
+        # Push/PR: check if main/stable branch for full matrix
+        if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" =~ ^WHPG_.*_STABLE$ ]]; then
+            # Main/stable branch: run all EL versions
+            if [[ "$whpg_major" == "7" ]]; then
+                el_versions="$WHPG7_EL_VERSIONS"
+            else
+                el_versions="$WHPG6_EL_VERSIONS"
+            fi
+        else
+            # Feature branch: run default EL version only
+            el_versions="$DEFAULT_EL_VERSION"
+        fi
+    fi
+
+    echo "EL versions to test: $el_versions"
+    echo "$el_versions"
+}
+
+# =============================================================================
+# Determine installcheck target
+# =============================================================================
+determine_installcheck_target() {
+    local target="$INPUT_INSTALLCHECK_TARGET"
+
+    if [[ -z "$target" ]]; then
+        # For main/stable branches, run full installcheck-world
+        # For feature branches, run quick installcheck-small
+        if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" =~ ^WHPG_.*_STABLE$ ]]; then
+            target="installcheck-world"
+        else
+            target="$DEFAULT_INSTALLCHECK_TARGET"
+        fi
+    fi
+
+    echo "Installcheck target: $target"
+    echo "$target"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "========================================================================"
+    echo "Detecting WHPG version and test configuration"
+    echo "========================================================================"
+    echo "EVENT_NAME: $EVENT_NAME"
+    echo "BRANCH_NAME: $BRANCH_NAME"
+    echo "INPUT_EL_VERSION: $INPUT_EL_VERSION"
+    echo "INPUT_INSTALLCHECK_TARGET: $INPUT_INSTALLCHECK_TARGET"
+    echo "========================================================================"
+
+    # Detect WHPG version
+    local whpg_output
+    whpg_output=$(detect_whpg_version)
+    local whpg_major
+    whpg_major=$(echo "$whpg_output" | tail -1)
+
+    # Determine EL versions
+    local el_output
+    el_output=$(determine_el_versions "$whpg_major")
+    local el_versions
+    el_versions=$(echo "$el_output" | tail -1)
+
+    # Determine installcheck target
+    local target_output
+    target_output=$(determine_installcheck_target)
+    local installcheck_target
+    installcheck_target=$(echo "$target_output" | tail -1)
+
+    # Output to GitHub Actions
+    if [[ -n "$GITHUB_OUTPUT" ]]; then
+        echo "ver=$whpg_major" >> "$GITHUB_OUTPUT"
+        echo "el_versions=$el_versions" >> "$GITHUB_OUTPUT"
+        echo "installcheck_target=$installcheck_target" >> "$GITHUB_OUTPUT"
+    fi
+
+    echo "========================================================================"
+    echo "Configuration detected:"
+    echo "  WHPG Major: $whpg_major"
+    echo "  EL Versions: $el_versions"
+    echo "  Installcheck Target: $installcheck_target"
+    echo "========================================================================"
+}
+
+main "$@"

--- a/.github/scripts/detect-config.bash
+++ b/.github/scripts/detect-config.bash
@@ -34,6 +34,11 @@ detect_whpg_version() {
     local ver
     ver=$(echo "$tag" | cut -d'.' -f1)
 
+    if [[ ! "$ver" =~ ^[0-9]+$ ]]; then
+        echo "::error::Extracted version '$ver' from tag '$tag' is not numeric." >&2
+        exit 1
+    fi
+
     echo "Found tag: $tag"
     echo "Detected WHPG major version: $ver"
     echo "$ver"

--- a/.github/scripts/run-installcheck.bash
+++ b/.github/scripts/run-installcheck.bash
@@ -10,8 +10,6 @@ set -eox pipefail
 : "${MAKE_TEST_COMMAND:?MAKE_TEST_COMMAND not set}"
 : "${GPVERSION:?GPVERSION not set}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # Source common functions
 source "${GPDB_SRC}/concourse/scripts/common.bash"
 
@@ -41,7 +39,8 @@ function look4diffs() {
     diff_files=$(find "${GPDB_SRC}" -name regression.diffs 2>/dev/null || true)
     for diff_file in ${diff_files}; do
         if [ -f "${diff_file}" ]; then
-            diff_file_copy=$(echo "${diff_file#*/gpdb_src/}" | tr '/' '-')
+            # Strip GPDB_SRC prefix and convert slashes to dashes
+            diff_file_copy=$(echo "${diff_file#${GPDB_SRC}/}" | tr '/' '-')
             cp "${diff_file}" "${RESULTS_DIR}/${diff_file_copy}"
 
             cat <<-EOF

--- a/.github/scripts/run-installcheck.bash
+++ b/.github/scripts/run-installcheck.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 
 # Run installcheck tests for WHPG, collecting logs and diffs on failure.
 
@@ -9,6 +9,10 @@ set -eox pipefail
 : "${RESULTS_DIR:?RESULTS_DIR not set}"
 : "${MAKE_TEST_COMMAND:?MAKE_TEST_COMMAND not set}"
 : "${WHPG_MAJORVERSION:?WHPG_MAJORVERSION not set}"
+
+# Source environment explicitly (no login shell / .bash_profile dependency)
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+[ -f ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh ] && source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 
 # Source common functions
 source "${WHPG_SRC}/concourse/scripts/common.bash"
@@ -78,7 +82,6 @@ function run_installcheck() {
     # Set up error trap
     trap look4diffs ERR
 
-    # Environment sourced from ~/.bash_profile (greenplum_path.sh, gpdemo-env.sh)
     cd "${WHPG_SRC}"
 
     # Enable core dumps
@@ -121,15 +124,12 @@ function _main() {
 
 # Run as gpadmin if we're root
 if [ "$(id -u)" = "0" ]; then
-    # Get absolute path since login shell changes working directory
     SCRIPT_PATH="$(realpath ${BASH_SOURCE[0]})"
 
-    # Runtime variables to pass (not in .bash_profile)
-    # Note: Must be on single line for su -c to parse correctly
-    ENV_VARS="RESULTS_DIR='${RESULTS_DIR}' MAKE_TEST_COMMAND='${MAKE_TEST_COMMAND}'"
+    # Export all required variables so they're inherited by the su subshell
+    export RESULTS_DIR MAKE_TEST_COMMAND WHPG_MAJORVERSION WHPG_SRC
 
-    # Use login shell (-) to source .bash_profile (greenplum_path.sh, gpdemo-env.sh, WHPG_SRC, WHPG_MAJORVERSION)
-    su - gpadmin -c "${ENV_VARS} bash ${SCRIPT_PATH}"
+    su gpadmin -c "bash ${SCRIPT_PATH}"
 else
     _main "$@"
 fi

--- a/.github/scripts/run-installcheck.bash
+++ b/.github/scripts/run-installcheck.bash
@@ -5,13 +5,13 @@
 set -eox pipefail
 
 # Required configuration (from workflow env)
-: "${GPDB_SRC:?GPDB_SRC not set}"
+: "${WHPG_SRC:?WHPG_SRC not set}"
 : "${RESULTS_DIR:?RESULTS_DIR not set}"
 : "${MAKE_TEST_COMMAND:?MAKE_TEST_COMMAND not set}"
-: "${GPVERSION:?GPVERSION not set}"
+: "${WHPG_MAJORVERSION:?WHPG_MAJORVERSION not set}"
 
 # Source common functions
-source "${GPDB_SRC}/concourse/scripts/common.bash"
+source "${WHPG_SRC}/concourse/scripts/common.bash"
 
 function setup_results_dir() {
     mkdir -p "${RESULTS_DIR}"
@@ -36,11 +36,11 @@ function look4diffs() {
     fi
 
     # Collect regression.diffs
-    diff_files=$(find "${GPDB_SRC}" -name regression.diffs 2>/dev/null || true)
+    diff_files=$(find "${WHPG_SRC}" -name regression.diffs 2>/dev/null || true)
     for diff_file in ${diff_files}; do
         if [ -f "${diff_file}" ]; then
-            # Strip GPDB_SRC prefix and convert slashes to dashes
-            diff_file_copy=$(echo "${diff_file#${GPDB_SRC}/}" | tr '/' '-')
+            # Strip WHPG_SRC prefix and convert slashes to dashes
+            diff_file_copy=$(echo "${diff_file#${WHPG_SRC}/}" | tr '/' '-')
             cp "${diff_file}" "${RESULTS_DIR}/${diff_file_copy}"
 
             cat <<-EOF
@@ -56,7 +56,7 @@ function look4diffs() {
     done
 
     # Collect coordinator configs and logs
-    local coord_dir="${GPDB_SRC}/gpAux/gpdemo/datadirs/qddir/demoDataDir-1"
+    local coord_dir="${WHPG_SRC}/gpAux/gpdemo/datadirs/qddir/demoDataDir-1"
     if [ -d "${coord_dir}" ]; then
         cp "${coord_dir}"/*.conf "${RESULTS_DIR}/" 2>/dev/null || true
         [ -d "${coord_dir}/log" ] && cp "${coord_dir}"/log/*.* "${RESULTS_DIR}/" 2>/dev/null || true
@@ -69,20 +69,17 @@ function look4diffs() {
 
 function run_installcheck() {
     local test_target="${MAKE_TEST_COMMAND}"
-    local gpversion="${GPVERSION}"
 
     echo "========================================================================"
     echo "Running installcheck: ${test_target}"
-    echo "GPVERSION: ${gpversion}"
+    echo "WHPG_MAJORVERSION: ${WHPG_MAJORVERSION}"
     echo "========================================================================"
 
     # Set up error trap
     trap look4diffs ERR
 
-    # Source environment
-    source /usr/local/greenplum-db-devel/greenplum_path.sh
-    cd "${GPDB_SRC}"
-    source gpAux/gpdemo/gpdemo-env.sh
+    # Environment sourced from ~/.bash_profile (greenplum_path.sh, gpdemo-env.sh)
+    cd "${WHPG_SRC}"
 
     # Enable core dumps
     ulimit -c unlimited
@@ -91,15 +88,15 @@ function run_installcheck() {
     # Determine which directory to run from based on target
     # installcheck-world runs from root, installcheck-small from src/test/regress
     if [[ "${test_target}" == "installcheck-world" ]]; then
-        cd "${GPDB_SRC}"
+        cd "${WHPG_SRC}"
     else
-        cd "${GPDB_SRC}/src/test/regress"
+        cd "${WHPG_SRC}/src/test/regress"
     fi
 
     # Run tests based on version
-    if [[ "${gpversion}" == 6* ]]; then
+    if [[ "${WHPG_MAJORVERSION}" == 6* ]]; then
         # WHPG 6: Test PL/Python3 first
-        make installcheck -C "${GPDB_SRC}/src/pl/plpython" python_majorversion=3 || true
+        make installcheck -C "${WHPG_SRC}/src/pl/plpython" python_majorversion=3 || true
 
         export TEST_PGFDW=1
         make -s ${test_target}
@@ -115,8 +112,8 @@ function run_installcheck() {
 
 function _main() {
     echo "MAKE_TEST_COMMAND: ${MAKE_TEST_COMMAND}"
-    echo "GPVERSION: ${GPVERSION}"
-    echo "GPDB_SRC: ${GPDB_SRC}"
+    echo "WHPG_MAJORVERSION: ${WHPG_MAJORVERSION}"
+    echo "WHPG_SRC: ${WHPG_SRC}"
 
     setup_results_dir
     run_installcheck
@@ -124,8 +121,15 @@ function _main() {
 
 # Run as gpadmin if we're root
 if [ "$(id -u)" = "0" ]; then
-    export RESULTS_DIR MAKE_TEST_COMMAND GPVERSION GPDB_SRC
-    su gpadmin -c "RESULTS_DIR='${RESULTS_DIR}' MAKE_TEST_COMMAND='${MAKE_TEST_COMMAND}' GPVERSION='${GPVERSION}' GPDB_SRC='${GPDB_SRC}' bash ${BASH_SOURCE[0]}"
+    # Get absolute path since login shell changes working directory
+    SCRIPT_PATH="$(realpath ${BASH_SOURCE[0]})"
+
+    # Runtime variables to pass (not in .bash_profile)
+    # Note: Must be on single line for su -c to parse correctly
+    ENV_VARS="RESULTS_DIR='${RESULTS_DIR}' MAKE_TEST_COMMAND='${MAKE_TEST_COMMAND}'"
+
+    # Use login shell (-) to source .bash_profile (greenplum_path.sh, gpdemo-env.sh, WHPG_SRC, WHPG_MAJORVERSION)
+    su - gpadmin -c "${ENV_VARS} bash ${SCRIPT_PATH}"
 else
     _main "$@"
 fi

--- a/.github/scripts/run-installcheck.bash
+++ b/.github/scripts/run-installcheck.bash
@@ -1,0 +1,132 @@
+#!/bin/bash -l
+
+# Run installcheck tests for WHPG, collecting logs and diffs on failure.
+
+set -eox pipefail
+
+# Required configuration (from workflow env)
+: "${GPDB_SRC:?GPDB_SRC not set}"
+: "${RESULTS_DIR:?RESULTS_DIR not set}"
+: "${MAKE_TEST_COMMAND:?MAKE_TEST_COMMAND not set}"
+: "${GPVERSION:?GPVERSION not set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common functions
+source "${GPDB_SRC}/concourse/scripts/common.bash"
+
+function setup_results_dir() {
+    mkdir -p "${RESULTS_DIR}"
+    chown gpadmin:gpadmin "${RESULTS_DIR}"
+    export RESULTS_DIR
+}
+
+function look4diffs() {
+    echo "========================================================================"
+    echo "Test failed - collecting logs and diffs"
+    echo "========================================================================"
+
+    # Collect gpAdminLogs
+    if [ -d /home/gpadmin/gpAdminLogs ]; then
+        pushd /home/gpadmin/gpAdminLogs
+        # Rename files with ':' in name (GitHub artifact upload issue)
+        for f in *:*; do
+            [ -e "$f" ] && mv -v -- "$f" "$(echo $f | tr ':' '-')"
+        done
+        cp -v *.* "${RESULTS_DIR}/" 2>/dev/null || true
+        popd
+    fi
+
+    # Collect regression.diffs
+    diff_files=$(find "${GPDB_SRC}" -name regression.diffs 2>/dev/null || true)
+    for diff_file in ${diff_files}; do
+        if [ -f "${diff_file}" ]; then
+            diff_file_copy=$(echo "${diff_file#*/gpdb_src/}" | tr '/' '-')
+            cp "${diff_file}" "${RESULTS_DIR}/${diff_file_copy}"
+
+            cat <<-EOF
+
+			======================================================================
+			DIFF FILE: ${diff_file}
+			----------------------------------------------------------------------
+
+			$(cat "${diff_file}")
+
+			EOF
+        fi
+    done
+
+    # Collect coordinator configs and logs
+    local coord_dir="${GPDB_SRC}/gpAux/gpdemo/datadirs/qddir/demoDataDir-1"
+    if [ -d "${coord_dir}" ]; then
+        cp "${coord_dir}"/*.conf "${RESULTS_DIR}/" 2>/dev/null || true
+        [ -d "${coord_dir}/log" ] && cp "${coord_dir}"/log/*.* "${RESULTS_DIR}/" 2>/dev/null || true
+        [ -d "${coord_dir}/pg_log" ] && cp "${coord_dir}"/pg_log/*.* "${RESULTS_DIR}/" 2>/dev/null || true
+    fi
+
+    echo "Collected files in ${RESULTS_DIR}:"
+    ls -la "${RESULTS_DIR}/"
+}
+
+function run_installcheck() {
+    local test_target="${MAKE_TEST_COMMAND}"
+    local gpversion="${GPVERSION}"
+
+    echo "========================================================================"
+    echo "Running installcheck: ${test_target}"
+    echo "GPVERSION: ${gpversion}"
+    echo "========================================================================"
+
+    # Set up error trap
+    trap look4diffs ERR
+
+    # Source environment
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+    cd "${GPDB_SRC}"
+    source gpAux/gpdemo/gpdemo-env.sh
+
+    # Enable core dumps
+    ulimit -c unlimited
+    echo "${RESULTS_DIR}/core-%p" | sudo tee /proc/sys/kernel/core_pattern || true
+
+    # Determine which directory to run from based on target
+    # installcheck-world runs from root, installcheck-small from src/test/regress
+    if [[ "${test_target}" == "installcheck-world" ]]; then
+        cd "${GPDB_SRC}"
+    else
+        cd "${GPDB_SRC}/src/test/regress"
+    fi
+
+    # Run tests based on version
+    if [[ "${gpversion}" == 6* ]]; then
+        # WHPG 6: Test PL/Python3 first
+        make installcheck -C "${GPDB_SRC}/src/pl/plpython" python_majorversion=3 || true
+
+        export TEST_PGFDW=1
+        make -s ${test_target}
+    else
+        # WHPG 7+
+        PG_TEST_EXTRA="kerberos ssl" make -s ${test_target}
+    fi
+
+    echo "========================================================================"
+    echo "Installcheck completed successfully"
+    echo "========================================================================"
+}
+
+function _main() {
+    echo "MAKE_TEST_COMMAND: ${MAKE_TEST_COMMAND}"
+    echo "GPVERSION: ${GPVERSION}"
+    echo "GPDB_SRC: ${GPDB_SRC}"
+
+    setup_results_dir
+    run_installcheck
+}
+
+# Run as gpadmin if we're root
+if [ "$(id -u)" = "0" ]; then
+    export RESULTS_DIR MAKE_TEST_COMMAND GPVERSION GPDB_SRC
+    su gpadmin -c "RESULTS_DIR='${RESULTS_DIR}' MAKE_TEST_COMMAND='${MAKE_TEST_COMMAND}' GPVERSION='${GPVERSION}' GPDB_SRC='${GPDB_SRC}' bash ${BASH_SOURCE[0]}"
+else
+    _main "$@"
+fi

--- a/.github/scripts/run-orca-tests.bash
+++ b/.github/scripts/run-orca-tests.bash
@@ -1,0 +1,39 @@
+#!/bin/bash -l
+
+# Run ORCA unit tests for WHPG
+# Wrapper around concourse/scripts/unit_tests_gporca.bash
+
+set -eox pipefail
+
+# Required configuration (from workflow env)
+: "${GPDB_SRC:?GPDB_SRC not set}"
+: "${EL_VERSION:?EL_VERSION not set}"
+: "${WHPG_MAJOR:?WHPG_MAJOR not set}"
+
+function _main() {
+    echo "========================================================================"
+    echo "Running ORCA unit tests"
+    echo "WHPG_MAJOR: ${WHPG_MAJOR}"
+    echo "EL_VERSION: ${EL_VERSION}"
+    echo "GPDB_SRC: ${GPDB_SRC}"
+    echo "========================================================================"
+
+    # Set build architecture
+    export BLD_ARCH="rhel${EL_VERSION}_x86_64"
+    export GPDB_SRC_PATH="${GPDB_SRC}"
+
+    # Create gpdb_src symlink expected by the script
+    if [[ ! -e "${GPDB_SRC}/gpdb_src" ]]; then
+        ln -s . "${GPDB_SRC}/gpdb_src"
+    fi
+
+    # Run the concourse script
+    cd "${GPDB_SRC}"
+    bash concourse/scripts/unit_tests_gporca.bash
+
+    echo "========================================================================"
+    echo "ORCA unit tests completed successfully"
+    echo "========================================================================"
+}
+
+_main "$@"

--- a/.github/scripts/run-orca-tests.bash
+++ b/.github/scripts/run-orca-tests.bash
@@ -18,9 +18,13 @@ function _main() {
     echo "GPDB_SRC: ${GPDB_SRC}"
     echo "========================================================================"
 
-    # Set build architecture
-    export BLD_ARCH="rhel${EL_VERSION}_x86_64"
+    # Source common functions and set build architecture dynamically
+    cd "${GPDB_SRC}"
+    source concourse/scripts/common.bash
+    export BLD_ARCH=$(build_arch)
     export GPDB_SRC_PATH="${GPDB_SRC}"
+
+    echo "BLD_ARCH: ${BLD_ARCH}"
 
     # Create gpdb_src symlink expected by the script
     if [[ ! -e "${GPDB_SRC}/gpdb_src" ]]; then
@@ -28,7 +32,6 @@ function _main() {
     fi
 
     # Run the concourse script
-    cd "${GPDB_SRC}"
     bash concourse/scripts/unit_tests_gporca.bash
 
     echo "========================================================================"

--- a/.github/scripts/run-orca-tests.bash
+++ b/.github/scripts/run-orca-tests.bash
@@ -6,29 +6,29 @@
 set -eox pipefail
 
 # Required configuration (from workflow env)
-: "${GPDB_SRC:?GPDB_SRC not set}"
+: "${WHPG_SRC:?WHPG_SRC not set}"
 : "${EL_VERSION:?EL_VERSION not set}"
-: "${WHPG_MAJOR:?WHPG_MAJOR not set}"
+: "${WHPG_MAJORVERSION:?WHPG_MAJORVERSION not set}"
 
 function _main() {
     echo "========================================================================"
     echo "Running ORCA unit tests"
-    echo "WHPG_MAJOR: ${WHPG_MAJOR}"
+    echo "WHPG_MAJORVERSION: ${WHPG_MAJORVERSION}"
     echo "EL_VERSION: ${EL_VERSION}"
-    echo "GPDB_SRC: ${GPDB_SRC}"
+    echo "WHPG_SRC: ${WHPG_SRC}"
     echo "========================================================================"
 
     # Source common functions and set build architecture dynamically
-    cd "${GPDB_SRC}"
+    cd "${WHPG_SRC}"
     source concourse/scripts/common.bash
     export BLD_ARCH=$(build_arch)
-    export GPDB_SRC_PATH="${GPDB_SRC}"
+    export GPDB_SRC_PATH="${WHPG_SRC}"
 
     echo "BLD_ARCH: ${BLD_ARCH}"
 
     # Create gpdb_src symlink expected by the script
-    if [[ ! -e "${GPDB_SRC}/gpdb_src" ]]; then
-        ln -s . "${GPDB_SRC}/gpdb_src"
+    if [[ ! -e "${WHPG_SRC}/gpdb_src" ]]; then
+        ln -s . "${WHPG_SRC}/gpdb_src"
     fi
 
     # Run the concourse script

--- a/.github/scripts/run-orca-tests.bash
+++ b/.github/scripts/run-orca-tests.bash
@@ -10,9 +10,6 @@ set -eox pipefail
 : "${EL_VERSION:?EL_VERSION not set}"
 : "${WHPG_MAJORVERSION:?WHPG_MAJORVERSION not set}"
 
-# Source environment explicitly (no login shell / .bash_profile dependency)
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-
 function _main() {
     echo "========================================================================"
     echo "Running ORCA unit tests"

--- a/.github/scripts/run-orca-tests.bash
+++ b/.github/scripts/run-orca-tests.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 
 # Run ORCA unit tests for WHPG
 # Wrapper around concourse/scripts/unit_tests_gporca.bash
@@ -9,6 +9,9 @@ set -eox pipefail
 : "${WHPG_SRC:?WHPG_SRC not set}"
 : "${EL_VERSION:?EL_VERSION not set}"
 : "${WHPG_MAJORVERSION:?WHPG_MAJORVERSION not set}"
+
+# Source environment explicitly (no login shell / .bash_profile dependency)
+source /usr/local/greenplum-db-devel/greenplum_path.sh
 
 function _main() {
     echo "========================================================================"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,7 @@
 # WHPG CI Workflows
 
+[![WHPG CI](https://github.com/warehouse-pg/warehouse-pg/actions/workflows/whpg-ci.yml/badge.svg)](https://github.com/warehouse-pg/warehouse-pg/actions/workflows/whpg-ci.yml)
+
 ## Overview
 
 This directory contains GitHub Actions workflows for the Warehouse-PG project.
@@ -14,9 +16,20 @@ Main CI workflow that runs regression tests and ORCA unit tests.
 
 | Trigger | Behavior |
 |---------|----------|
-| **Push** | Runs all tests on any branch |
-| **Pull Request** | Runs all tests on any PR |
+| **Push** | Runs on `main`, `WHPG_*_STABLE`, and `ci/**` branches |
+| **Pull Request** | Runs on PRs targeting `main` and `WHPG_*_STABLE` |
 | **Manual Dispatch** | Run specific tests with custom options |
+
+#### Testing on Feature Branches
+
+To run CI on a feature branch without opening a PR, prefix the branch name with `ci/`:
+
+```bash
+git checkout -b ci/my-feature    # CI will run on push
+git push origin ci/my-feature
+```
+
+Regular feature branches (e.g., `feature/xyz`) do not trigger CI to save resources.
 
 #### Push/PR Behavior
 
@@ -24,8 +37,55 @@ On push or PR, tests run automatically with these defaults:
 
 | Branch Type | Tests | EL Versions | Installcheck Target |
 |-------------|-------|-------------|---------------------|
-| `main` / `WHPG_*_STABLE` | All (installcheck + orca-unit-tests) | All configured | `installcheck-world` |
-| Feature branches | All (installcheck + orca-unit-tests) | Default only | `installcheck-small` |
+| `main` / `WHPG_*_STABLE` (push) | All (installcheck + orca-unit-tests) | All configured | `installcheck-world` |
+| `ci/**` (push) | All (installcheck + orca-unit-tests) | Default only | `installcheck-small` |
+| PRs targeting `main` / `WHPG_*_STABLE` | All (installcheck + orca-unit-tests) | Default only | `installcheck-small` |
+
+> **Note:** Regular feature branch pushes (e.g., `feature/xyz`) do not trigger CI. Use `ci/` prefix or open a pull request.
+
+#### Concurrency
+
+The workflow uses concurrency groups to manage parallel runs:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/WHPG_') }}
+```
+
+| Branch | Behavior |
+|--------|----------|
+| `main` / `WHPG_*_STABLE` | All runs complete (no cancellation) |
+| PR branches | Older runs cancelled when new commits pushed |
+
+#### Caching
+
+The workflow uses multiple caches to speed up builds:
+
+**ccache (compiler cache)**
+- Cache stored per EL version and WHPG version
+- First run: full build (~30 min)
+- Subsequent runs: incremental build (~5 min)
+
+| Component | Build System | ccache |
+|-----------|--------------|--------|
+| WHPG (main) | autotools | ✅ `CC='ccache gcc'` |
+| ORCA | cmake | ✅ `CMAKE_*_LAUNCHER` |
+| xerces | autotools | ✅ `CC/CXX` |
+
+**yum packages**
+- Caches downloaded RPM packages
+- Key based on workflow file hash (invalidates when packages change)
+- Reduces package download time on subsequent runs
+
+#### Job Summary
+
+Each job generates a summary (visible in the GitHub Actions Summary tab) showing:
+- WHPG and EL versions, test target
+- Step-by-step results (✅ passed / ❌ failed / ⏭️ skipped)
+- ccache statistics (hits, misses, hit rate, cache size)
+
+Summaries run with `if: always()` so they are available even when jobs fail.
 
 #### Manual Dispatch Behavior
 
@@ -44,7 +104,15 @@ On manual dispatch, you can customize:
 |-----|-------------|---------|
 | `detect-config` | Detects WHPG version and test configuration | - |
 | `installcheck` | Runs PostgreSQL regression tests | 120 min |
-| `orca-unit-tests` | Runs ORCA optimizer unit tests | 60 min |
+| `orca-unit-tests` | Runs ORCA optimizer unit tests (see below) | 60 min |
+
+**ORCA Unit Tests Details:**
+
+The ORCA unit tests run twice with different build configurations:
+1. **RelWithDebInfo** - Release build with debug info (optimized, for performance validation)
+2. **Debug** - Debug build (unoptimized, for thorough assertion checking)
+
+This dual-build approach ensures the optimizer works correctly in both production-like and debug environments. The underlying script (`concourse/scripts/unit_tests_gporca.bash`) handles both builds automatically.
 
 #### Configuration
 
@@ -62,6 +130,8 @@ env:
 
 When `debug_enabled` is checked during manual dispatch, failed jobs will start a tmate session (30 min timeout) for interactive debugging.
 
+> **Note:** The workflow manually installs tmate via `yum` because `action-tmate` uses `apt-get` internally, which doesn't work on Rocky Linux containers.
+
 ## Scripts
 
 Supporting scripts are located in `.github/scripts/`:
@@ -72,11 +142,28 @@ Supporting scripts are located in `.github/scripts/`:
 | `run-installcheck.bash` | Runs installcheck tests with proper environment setup |
 | `run-orca-tests.bash` | Runs ORCA unit tests using concourse scripts |
 
+### Environment Setup
+
+The `installcheck` job sets up gpadmin's `.bash_profile` with:
+
+```bash
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+[ -f ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh ] && source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+export WHPG_SRC=...
+export WHPG_MAJORVERSION=...
+```
+
+Scripts use `su - gpadmin` (login shell) to automatically source this environment.
+
 ## Container Images
 
 Tests run in pre-built container images from `ghcr.io/warehouse-pg/`:
 
-- `whpg7-rocky8-build` - WHPG 7 on Rocky Linux 8
+| Image Pattern | Example |
+|---------------|---------|
+| `whpg{major}-rocky{el}-build` | `whpg7-rocky8-build` |
+
+The image is automatically selected based on detected WHPG version and matrix EL version.
 
 ## Version Detection
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -144,16 +144,10 @@ Supporting scripts are located in `.github/scripts/`:
 
 ### Environment Setup
 
-The `installcheck` job sets up gpadmin's `.bash_profile` with:
+Scripts source the required environment explicitly rather than relying on `.bash_profile`:
 
-```bash
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-[ -f ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh ] && source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-export WHPG_SRC=...
-export WHPG_MAJORVERSION=...
-```
-
-Scripts use `su - gpadmin` (login shell) to automatically source this environment.
+- `run-installcheck.bash` sources `greenplum_path.sh` and `gpdemo-env.sh` directly
+- Workflow variables (`WHPG_SRC`, `WHPG_MAJORVERSION`, etc.) are passed via `export` + `su gpadmin` (non-login shell)
 
 ## Container Images
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,85 @@
+# WHPG CI Workflows
+
+## Overview
+
+This directory contains GitHub Actions workflows for the Warehouse-PG project.
+
+## Workflows
+
+### WHPG CI (`whpg-ci.yml`)
+
+Main CI workflow that runs regression tests and ORCA unit tests.
+
+#### Triggers
+
+| Trigger | Behavior |
+|---------|----------|
+| **Push** | Runs all tests on any branch |
+| **Pull Request** | Runs all tests on any PR |
+| **Manual Dispatch** | Run specific tests with custom options |
+
+#### Push/PR Behavior
+
+On push or PR, tests run automatically with these defaults:
+
+| Branch Type | Tests | EL Versions | Installcheck Target |
+|-------------|-------|-------------|---------------------|
+| `main` / `WHPG_*_STABLE` | All (installcheck + orca-unit-tests) | All configured | `installcheck-world` |
+| Feature branches | All (installcheck + orca-unit-tests) | Default only | `installcheck-small` |
+
+#### Manual Dispatch Behavior
+
+On manual dispatch, you can customize:
+
+| Option | Choices | Default |
+|--------|---------|---------|
+| Test type | `all`, `installcheck`, `orca-unit-tests` | `all` |
+| Installcheck target | `installcheck-small`, `installcheck-world` | `installcheck-small` |
+| EL version | `all`, `7`, `8`, `9` | `8` |
+| Debug on failure | `true`, `false` | `false` |
+
+#### Jobs
+
+| Job | Description | Timeout |
+|-----|-------------|---------|
+| `detect-config` | Detects WHPG version and test configuration | - |
+| `installcheck` | Runs PostgreSQL regression tests | 120 min |
+| `orca-unit-tests` | Runs ORCA optimizer unit tests | 60 min |
+
+#### Configuration
+
+Configuration is centralized at the top of the workflow file (single source of truth). Scripts require these values from the workflow environment and will fail if not provided.
+
+```yaml
+env:
+  WHPG7_EL_VERSIONS: '["8"]'            # WHPG 7 supported EL versions
+  WHPG6_EL_VERSIONS: '["7", "8", "9"]'  # WHPG 6 supported EL versions
+  DEFAULT_EL_VERSION: '["8"]'           # Default for feature branches
+  DEFAULT_INSTALLCHECK_TARGET: 'installcheck-small'  # Default installcheck target
+```
+
+#### Debugging
+
+When `debug_enabled` is checked during manual dispatch, failed jobs will start a tmate session (30 min timeout) for interactive debugging.
+
+## Scripts
+
+Supporting scripts are located in `.github/scripts/`:
+
+| Script | Description |
+|--------|-------------|
+| `detect-config.bash` | Detects WHPG version and determines test configuration |
+| `run-installcheck.bash` | Runs installcheck tests with proper environment setup |
+| `run-orca-tests.bash` | Runs ORCA unit tests using concourse scripts |
+
+## Container Images
+
+Tests run in pre-built container images from `ghcr.io/warehouse-pg/`:
+
+- `whpg7-rocky8-build` - WHPG 7 on Rocky Linux 8
+
+## Version Detection
+
+WHPG version is detected from git tags using `git describe --tags --abbrev=0`. The major version (first number before the dot) determines which EL versions to test.
+
+Example: Tag `7.2.1` → WHPG major version `7` → Uses `WHPG7_EL_VERSIONS`

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -49,10 +49,20 @@ on:
         type: boolean
   push:
     branches:
-      - '**'
+      - main
+      - 'WHPG_*_STABLE'
+      - 'ci/**'           # Opt-in CI for feature branches (e.g., ci/my-feature)
   pull_request:
     branches:
-      - '**'
+      - main
+      - 'WHPG_*_STABLE'
+
+# Cancel in-progress runs when new commits are pushed to the same branch
+# Exception: main and stable branch runs are never cancelled to ensure every merge is validated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/WHPG_') }}
+
 jobs:
   detect-config:
     name: detect-config
@@ -91,10 +101,10 @@ jobs:
       image: ghcr.io/warehouse-pg/whpg${{ needs.detect-config.outputs.whpg_major }}-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
-      WHPG_MAJOR: ${{ needs.detect-config.outputs.whpg_major }}
+      WHPG_MAJORVERSION: ${{ needs.detect-config.outputs.whpg_major }}
       EL_VERSION: ${{ matrix.el_version }}
       TEST_TARGET: ${{ needs.detect-config.outputs.installcheck_target }}
-      GPDB_SRC: ${{ github.workspace }}
+      WHPG_SRC: ${{ github.workspace }}
       RESULTS_DIR: /tmp/test-results
 
     steps:
@@ -104,32 +114,54 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Container info
+        run: |
+          echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"')"
+          echo "Arch: $(uname -m)"
+          echo "GCC: $(gcc --version | head -1)"
+
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-el${{ matrix.el_version }}-whpg${{ env.WHPG_MAJORVERSION }}-${{ github.sha }}
+          restore-keys: |
+            ccache-el${{ matrix.el_version }}-whpg${{ env.WHPG_MAJORVERSION }}-
+
+      - name: Cache yum packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/dnf
+          key: yum-el${{ matrix.el_version }}-${{ hashFiles('.github/workflows/whpg-ci.yml') }}
+
       - name: Install required packages
         run: |
-          # Base packages aligned with SPEC file
-          INSTALL_PKGS="apr-devel autoconf automake bison bzip2-devel flex gcc gcc-c++ iproute \
-            iputils krb5-devel less libcurl-devel libevent-devel libuuid-devel libuv-devel \
-            libxml2-devel libyaml-devel libzstd-devel make net-tools openldap-devel openssh \
-            openssl-devel pam-devel perl perl-Env perl-ExtUtils-Embed perl-IPC-Run perl-Test-Simple \
-            perl-devel pkgconfig readline-devel rsync sed tar wget which zip zlib-devel libicu-devel \
-            netcat openssl glibc-langpack-en procps lsof krb5-server krb5-workstation llvm-devel clang-devel"
+          # Only install packages NOT already in the container image (see dockerfiles/Dockerfile.rh8)
+          # Most build dependencies are pre-installed in the container
+          INSTALL_PKGS="llvm-devel clang-devel krb5-server krb5-workstation lsof ccache"
 
-          yum install -y $INSTALL_PKGS
+          yum install -y --setopt=keepcache=1 $INSTALL_PKGS
 
-          if [[ "${WHPG_MAJOR}" == "6" ]]; then
-            yum install -y python2-devel
+          if [[ "${WHPG_MAJORVERSION}" == "6" ]]; then
+            yum install -y --setopt=keepcache=1 python2-devel
           else
-            yum install -y xerces-c-devel python3-devel python3-psutil python3-pyyaml python3-psycopg2 python3-lxml python3-pytest
+            # python3-psycopg2 not in container image
+            yum install -y --setopt=keepcache=1 python3-psycopg2
             ln -sf /usr/bin/pytest-3 /usr/bin/pytest || true
           fi
 
-          if ! command -v passwd &>/dev/null; then
-            yum install -y passwd
-          fi
+      - name: Configure ccache
+        run: |
+          ccache --set-config=max_size=1G
+          ccache --set-config=compression=true
+          ccache --zero-stats
 
+      # Note: --with-quicklz, --enable-mapreduce, and --with-pythonsrc-ext are recognized
+      # only in whpg6. They produce "unrecognized options" warnings in whpg7 but don't
+      # fail the build. Kept for compatibility with both versions using a single workflow.
       - name: Configure
         run: |
-          CC='gcc -m64' \
+          CC='ccache gcc -m64' \
           CFLAGS='-O2 -g3' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
           ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
                       --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
@@ -139,35 +171,73 @@ jobs:
                       --mandir=/usr/local/greenplum-db-devel/man
 
       - name: Build
+        id: build
         run: make -j$(nproc)
 
+      - name: Show ccache stats
+        run: ccache --show-stats
+
       - name: Install
-        run: make install
+        id: install
+        run: make install -j$(nproc)
 
       - name: Setup gpadmin user
         run: |
           # Create symlinks for easier navigation
           ln -s . gpdb_src                          # For concourse scripts compatibility
-          ln -s "${GPDB_SRC}" /workspace            # Easy to remember path
-          ln -s "${GPDB_SRC}" /home/gpadmin/gpdb_src  # Accessible from gpadmin home
+          ln -s "${WHPG_SRC}" /workspace            # Easy to remember path
+          ln -s "${WHPG_SRC}" /home/gpadmin/gpdb_src  # Accessible from gpadmin home
           chown -h gpadmin:gpadmin /workspace /home/gpadmin/gpdb_src
 
           export TEST_OS=centos
           ./concourse/scripts/setup_gpadmin_user.bash
           chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
-          chown -R gpadmin:gpadmin "${GPDB_SRC}"
+          chown -R gpadmin:gpadmin "${WHPG_SRC}"
+
+          # Setup gpadmin environment for login shells
+          cat >> /home/gpadmin/.bash_profile << 'EOF'
+          source /usr/local/greenplum-db-devel/greenplum_path.sh
+          [ -f ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh ] && source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+          EOF
+          echo "export WHPG_SRC=${WHPG_SRC}" >> /home/gpadmin/.bash_profile
+          echo "export WHPG_MAJORVERSION=${WHPG_MAJORVERSION}" >> /home/gpadmin/.bash_profile
 
       - name: Create demo cluster
+        id: cluster
         run: |
           source concourse/scripts/common.bash
           export WITH_MIRRORS=false
           make_cluster
 
       - name: Run installcheck tests
+        id: tests
         run: |
           export MAKE_TEST_COMMAND="${TEST_TARGET}"
-          export GPVERSION="${WHPG_MAJOR}"
           bash .github/scripts/run-installcheck.bash
+
+      - name: Installcheck Summary
+        if: always()
+        run: |
+          echo "## Installcheck Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| WHPG Version | ${WHPG_MAJORVERSION} |" >> $GITHUB_STEP_SUMMARY
+          echo "| EL Version | ${EL_VERSION} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Test Target | ${TEST_TARGET} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Step Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | ${{ steps.build.outcome == 'success' && '✅ passed' || '❌ failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Install | ${{ steps.install.outcome == 'success' && '✅ passed' || steps.install.outcome == 'skipped' && '⏭️ skipped' || '❌ failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Demo Cluster | ${{ steps.cluster.outcome == 'success' && '✅ passed' || steps.cluster.outcome == 'skipped' && '⏭️ skipped' || '❌ failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tests | ${{ steps.tests.outcome == 'success' && '✅ passed' || steps.tests.outcome == 'skipped' && '⏭️ skipped' || '❌ failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ccache Statistics" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          { ccache --show-stats 2>/dev/null | grep -E "cache hit|cache miss|hit rate|files in cache|cache size|max cache size" >> $GITHUB_STEP_SUMMARY; } || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results on failure
         if: failure()
@@ -191,12 +261,13 @@ jobs:
             /home/gpadmin/gpAdminLogs/
           if-no-files-found: ignore
 
+      # action-tmate uses apt-get internally which doesn't work on Rocky Linux.
+      # Manual installation via yum is required for this container.
       - name: Install tmate
         if: ${{ failure() && inputs.debug_enabled }}
         run: |
-          # Install tmate on Rocky Linux (EPEL repo)
-          yum install -y epel-release
-          yum install -y tmate
+          yum install -y --setopt=keepcache=1 epel-release
+          yum install -y --setopt=keepcache=1 tmate
 
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug_enabled }}
@@ -219,9 +290,9 @@ jobs:
       image: ghcr.io/warehouse-pg/whpg${{ needs.detect-config.outputs.whpg_major }}-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
-      WHPG_MAJOR: ${{ needs.detect-config.outputs.whpg_major }}
+      WHPG_MAJORVERSION: ${{ needs.detect-config.outputs.whpg_major }}
       EL_VERSION: ${{ matrix.el_version }}
-      GPDB_SRC: ${{ github.workspace }}
+      WHPG_SRC: ${{ github.workspace }}
 
     steps:
       - name: Checkout source
@@ -229,18 +300,76 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Container info
+        run: |
+          echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"')"
+          echo "Arch: $(uname -m)"
+          echo "GCC: $(gcc --version | head -1)"
+          echo "CMake: $(cmake --version | head -1)"
+
+      - name: Setup ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-orca-el${{ matrix.el_version }}-whpg${{ env.WHPG_MAJORVERSION }}-${{ github.sha }}
+          restore-keys: |
+            ccache-orca-el${{ matrix.el_version }}-whpg${{ env.WHPG_MAJORVERSION }}-
+
+      - name: Cache yum packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/dnf
+          key: yum-orca-el${{ matrix.el_version }}-${{ hashFiles('.github/workflows/whpg-ci.yml') }}
+
       - name: Install build dependencies
         run: |
-          yum install -y cmake gcc gcc-c++ make xerces-c-devel
+          # Only ccache is not in the container image
+          # cmake, gcc, gcc-c++, make, xerces-c-devel, python3-devel are pre-installed
+          yum install -y --setopt=keepcache=1 ccache
 
-          if [[ "${WHPG_MAJOR}" == "6" ]]; then
-            yum install -y python2-devel
-          else
-            yum install -y python3-devel
+          if [[ "${WHPG_MAJORVERSION}" == "6" ]]; then
+            yum install -y --setopt=keepcache=1 python2-devel
           fi
 
+      - name: Configure ccache
+        run: |
+          ccache --set-config=max_size=500M
+          ccache --set-config=compression=true
+          ccache --zero-stats
+
       - name: Run ORCA unit tests
+        id: tests
         run: bash .github/scripts/run-orca-tests.bash
+        env:
+          # For cmake builds (ORCA)
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          # For autotools builds (xerces)
+          CC: ccache gcc
+          CXX: ccache g++
+
+      - name: Show ccache stats
+        run: ccache --show-stats
+
+      - name: ORCA Unit Tests Summary
+        if: always()
+        run: |
+          echo "## ORCA Unit Tests Summary 🧪" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| WHPG Version | ${WHPG_MAJORVERSION} |" >> $GITHUB_STEP_SUMMARY
+          echo "| EL Version | ${EL_VERSION} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Step Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| ORCA Unit Tests | ${{ steps.tests.outcome == 'success' && '✅ passed' || '❌ failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ccache Statistics" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          { ccache --show-stats 2>/dev/null | grep -E "cache hit|cache miss|hit rate|files in cache|cache size|max cache size" >> $GITHUB_STEP_SUMMARY; } || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results on failure
         if: failure()
@@ -253,11 +382,13 @@ jobs:
             src/backend/gporca/build*/CMakeFiles/CMakeError.log
           if-no-files-found: ignore
 
+      # action-tmate uses apt-get internally which doesn't work on Rocky Linux.
+      # Manual installation via yum is required for this container.
       - name: Install tmate
         if: ${{ failure() && inputs.debug_enabled }}
         run: |
-          yum install -y epel-release
-          yum install -y tmate
+          yum install -y --setopt=keepcache=1 epel-release
+          yum install -y --setopt=keepcache=1 tmate
 
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug_enabled }}

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -194,13 +194,9 @@ jobs:
           chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
           chown -R gpadmin:gpadmin "${WHPG_SRC}"
 
-          # Setup gpadmin environment for login shells
-          cat >> /home/gpadmin/.bash_profile << 'EOF'
-          source /usr/local/greenplum-db-devel/greenplum_path.sh
-          [ -f ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh ] && source ~/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-          EOF
-          echo "export WHPG_SRC=${WHPG_SRC}" >> /home/gpadmin/.bash_profile
-          echo "export WHPG_MAJORVERSION=${WHPG_MAJORVERSION}" >> /home/gpadmin/.bash_profile
+          # Note: Environment variables (WHPG_SRC, WHPG_MAJORVERSION, etc.) are passed
+          # via export + su (without login shell). Scripts source greenplum_path.sh and
+          # gpdemo-env.sh explicitly rather than relying on .bash_profile.
 
       - name: Create demo cluster
         id: cluster

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -1,0 +1,267 @@
+name: WHPG CI
+
+# =============================================================================
+# Configuration: EL versions for each WHPG major version
+# Change these values to update which EL versions are tested
+# =============================================================================
+env:
+  WHPG7_EL_VERSIONS: '["8"]'            # WHPG 7 supported EL versions
+  WHPG6_EL_VERSIONS: '["7", "8", "9"]'  # WHPG 6 supported EL versions
+  DEFAULT_EL_VERSION: '["8"]'           # Default for feature branches
+  DEFAULT_INSTALLCHECK_TARGET: 'installcheck-small'  # Default installcheck target
+
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('[7x] Manual: {0} on {1}', inputs.test_type == 'all' && 'all tests' || inputs.test_type, inputs.el_version == 'all' && 'all EL versions' || format('el{0}', inputs.el_version))
+      || format('[7x] {0} on {1}', github.event_name, github.ref_name) }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_type:
+        description: 'Which tests to run'
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - installcheck
+          - orca-unit-tests
+      installcheck_target:
+        description: 'Installcheck target (if installcheck selected)'
+        default: 'installcheck-small'
+        type: choice
+        options:
+          - installcheck-small
+          - installcheck-world
+      el_version:
+        description: 'Enterprise Linux version'
+        default: '8'
+        type: choice
+        options:
+          - 'all'
+          - '7'
+          - '8'
+          - '9'
+      debug_enabled:
+        description: 'Enable tmate debugging on failure'
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  detect-config:
+    name: detect-config
+    runs-on: ubuntu-latest
+    outputs:
+      whpg_major: ${{ steps.detect.outputs.ver }}
+      el_versions: ${{ steps.detect.outputs.el_versions }}
+      installcheck_target: ${{ steps.detect.outputs.installcheck_target }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          INPUT_EL_VERSION: ${{ inputs.el_version }}
+          INPUT_INSTALLCHECK_TARGET: ${{ inputs.installcheck_target }}
+          WHPG7_EL_VERSIONS: ${{ env.WHPG7_EL_VERSIONS }}
+          WHPG6_EL_VERSIONS: ${{ env.WHPG6_EL_VERSIONS }}
+          DEFAULT_EL_VERSION: ${{ env.DEFAULT_EL_VERSION }}
+          DEFAULT_INSTALLCHECK_TARGET: ${{ env.DEFAULT_INSTALLCHECK_TARGET }}
+        run: bash .github/scripts/detect-config.bash
+
+  installcheck:
+    name: ${{ needs.detect-config.outputs.installcheck_target }} / EL${{ matrix.el_version }}
+    needs: detect-config
+    if: github.event_name != 'workflow_dispatch' || inputs.test_type == 'all' || inputs.test_type == 'installcheck'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        el_version: ${{ fromJson(needs.detect-config.outputs.el_versions) }}
+    container:
+      image: ghcr.io/warehouse-pg/whpg${{ needs.detect-config.outputs.whpg_major }}-${{ format('rocky{0}', matrix.el_version) }}-build
+      options: --privileged
+    env:
+      WHPG_MAJOR: ${{ needs.detect-config.outputs.whpg_major }}
+      EL_VERSION: ${{ matrix.el_version }}
+      TEST_TARGET: ${{ needs.detect-config.outputs.installcheck_target }}
+      GPDB_SRC: ${{ github.workspace }}
+      RESULTS_DIR: /tmp/test-results
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install required packages
+        run: |
+          # Base packages aligned with SPEC file
+          INSTALL_PKGS="apr-devel autoconf automake bison bzip2-devel flex gcc gcc-c++ iproute \
+            iputils krb5-devel less libcurl-devel libevent-devel libuuid-devel libuv-devel \
+            libxml2-devel libyaml-devel libzstd-devel make net-tools openldap-devel openssh \
+            openssl-devel pam-devel perl perl-Env perl-ExtUtils-Embed perl-IPC-Run perl-Test-Simple \
+            perl-devel pkgconfig readline-devel rsync sed tar wget which zip zlib-devel libicu-devel \
+            netcat openssl glibc-langpack-en procps lsof krb5-server krb5-workstation llvm-devel clang-devel"
+
+          yum install -y $INSTALL_PKGS
+
+          if [[ "${WHPG_MAJOR}" == "6" ]]; then
+            yum install -y python2-devel
+          else
+            yum install -y xerces-c-devel python3-devel python3-psutil python3-pyyaml python3-psycopg2 python3-lxml python3-pytest
+            ln -sf /usr/bin/pytest-3 /usr/bin/pytest || true
+          fi
+
+          if ! command -v passwd &>/dev/null; then
+            yum install -y passwd
+          fi
+
+      - name: Configure
+        run: |
+          CC='gcc -m64' \
+          CFLAGS='-O2 -g3' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
+          ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
+                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
+                      --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
+                      --with-libraries="" --disable-rpath \
+                      --prefix=/usr/local/greenplum-db-devel \
+                      --mandir=/usr/local/greenplum-db-devel/man
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Install
+        run: make install
+
+      - name: Setup gpadmin user
+        run: |
+          # Create symlinks for easier navigation
+          ln -s . gpdb_src                          # For concourse scripts compatibility
+          ln -s "${GPDB_SRC}" /workspace            # Easy to remember path
+          ln -s "${GPDB_SRC}" /home/gpadmin/gpdb_src  # Accessible from gpadmin home
+          chown -h gpadmin:gpadmin /workspace /home/gpadmin/gpdb_src
+
+          export TEST_OS=centos
+          ./concourse/scripts/setup_gpadmin_user.bash
+          chown -R gpadmin:gpadmin /usr/local/greenplum-db-devel
+          chown -R gpadmin:gpadmin "${GPDB_SRC}"
+
+      - name: Create demo cluster
+        run: |
+          source concourse/scripts/common.bash
+          export WITH_MIRRORS=false
+          make_cluster
+
+      - name: Run installcheck tests
+        run: |
+          export MAKE_TEST_COMMAND="${TEST_TARGET}"
+          export GPVERSION="${WHPG_MAJOR}"
+          bash .github/scripts/run-installcheck.bash
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-el${{ matrix.el_version }}
+          path: |
+            /tmp/test-results/
+            src/test/regress/regression.diffs
+            src/test/regress/results/
+          if-no-files-found: ignore
+
+      - name: Upload cluster logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-logs-el${{ matrix.el_version }}
+          path: |
+            gpAux/gpdemo/datadirs/qddir/demoDataDir-1/log/
+            gpAux/gpdemo/datadirs/dbfast*/demoDataDir*/log/
+            /home/gpadmin/gpAdminLogs/
+          if-no-files-found: ignore
+
+      - name: Install tmate
+        if: ${{ failure() && inputs.debug_enabled }}
+        run: |
+          # Install tmate on Rocky Linux (EPEL repo)
+          yum install -y epel-release
+          yum install -y tmate
+
+      - name: Setup tmate session
+        if: ${{ failure() && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+        with:
+          install-dependencies: false
+
+  orca-unit-tests:
+    name: orca-unit-tests / EL${{ matrix.el_version }}
+    needs: detect-config
+    if: github.event_name != 'workflow_dispatch' || inputs.test_type == 'all' || inputs.test_type == 'orca-unit-tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        el_version: ${{ fromJson(needs.detect-config.outputs.el_versions) }}
+    container:
+      image: ghcr.io/warehouse-pg/whpg${{ needs.detect-config.outputs.whpg_major }}-${{ format('rocky{0}', matrix.el_version) }}-build
+      options: --privileged
+    env:
+      WHPG_MAJOR: ${{ needs.detect-config.outputs.whpg_major }}
+      EL_VERSION: ${{ matrix.el_version }}
+      GPDB_SRC: ${{ github.workspace }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          yum install -y cmake gcc gcc-c++ make xerces-c-devel
+
+          if [[ "${WHPG_MAJOR}" == "6" ]]; then
+            yum install -y python2-devel
+          else
+            yum install -y python3-devel
+          fi
+
+      - name: Run ORCA unit tests
+        run: bash .github/scripts/run-orca-tests.bash
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: orca-test-results-el${{ matrix.el_version }}
+          path: |
+            src/backend/gporca/build*/Testing/
+            src/backend/gporca/build*/CMakeFiles/CMakeOutput.log
+            src/backend/gporca/build*/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
+
+      - name: Install tmate
+        if: ${{ failure() && inputs.debug_enabled }}
+        run: |
+          yum install -y epel-release
+          yum install -y tmate
+
+      - name: Setup tmate session
+        if: ${{ failure() && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+        with:
+          install-dependencies: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
     <img alt="WarehousePG" src="logo-warehousepg.png" width="350px">
 </p>
 
+<p align="center">
+    <a href="https://github.com/warehouse-pg/warehouse-pg/actions/workflows/whpg-ci.yml">
+        <img src="https://github.com/warehouse-pg/warehouse-pg/actions/workflows/whpg-ci.yml/badge.svg" alt="CI Status">
+    </a>
+</p>
 
 WarehousePG (WHPG) is an advanced, fully featured, open
 source data warehouse, based on Greenplum® Database and PostgreSQL. 


### PR DESCRIPTION
This PR adds a CI workflow for whpg.
`whpg-ci.yml:` Main CI workflow with installcheck and orca-unit-tests jobs

  Features:
  - Automatic test runs on push and pull requests
  - Full test suite (installcheck-world) on main and WHPG_*_STABLE branches
  - Quick tests (installcheck-small) on feature branches
  - Manual dispatch with configurable test type, EL version, and debug options
  - Version detection from git tags to select appropriate test matrix
  - Artifact upload for test results and logs on failure
  - Optional tmate debugging sessions

  Supporting scripts:
  - detect-config.bash: Detects WHPG version and test configuration
  - run-installcheck.bash: Runs regression tests
  - run-orca-tests.bash: Runs ORCA optimizer unit tests

  Documentation:
  - README.md: Workflow documentation and usage guide

Note :

The workflow currently utilizes the `whpg7-rocky8-build `image. While the CI logic is designed to be generic for multiple Enterprise Linux versions, support for EL7 and EL9 will be enabled in subsequent PRs as those specific container packages become available. Thus, in the whpg7 supported versions only EL8 is listed in the configuration.