### PR TITLE
add new syntax `ALTER RESOURCE GROUP <old_name> SET name <new_name>`

### DIFF
--- a/doc/src/sgml/ref/alter_resource_group.sgml
+++ b/doc/src/sgml/ref/alter_resource_group.sgml
@@ -22,15 +22,168 @@ PostgreSQL documentation
  <refsynopsisdiv>
 <synopsis>
 
-ALTER RESOURCE GROUP name SET group_attribute value
-where group_attribute is one of:
-   CONCURRENCY integer
-   CPU_MAX_PERCENT integer
-   CPU_WEIGHT integer
-   CPUSET tuple
-   MEMORY_QUOTA integer
+ALTER RESOURCE GROUP <replaceable class="parameter">name</replaceable> SET group_attribute <replaceable class="parameter">value</replaceable>
+
+<phrase>where <replaceable class="parameter">group_attribute</replaceable> is one of:</phrase>
+
+    CONCURRENCY <replaceable class="parameter">integer</replaceable>
+    CPU_MAX_PERCENT <replaceable class="parameter">integer</replaceable>
+    CPU_WEIGHT <replaceable class="parameter">integer</replaceable>
+    CPUSET <replaceable class="parameter">tuple</replaceable>
+    MEMORY_QUOTA <replaceable class="parameter">integer</replaceable>
+    MIN_COST <replaceable class="parameter">integer</replaceable>
+    IO_LIMIT <replaceable class="parameter">string</replaceable>
+    NAME <replaceable class="parameter">new_name</replaceable>
 
 </synopsis>
  </refsynopsisdiv>
+
+ <refsect1>
+  <title>Description</title>
+
+  <para>
+   <command>ALTER RESOURCE GROUP</command> changes the limits of a resource group.
+  </para>
+ </refsect1>
+
+ <refsect1>
+  <title>Parameters</title>
+
+  <variablelist>
+   <varlistentry>
+    <term><replaceable class="parameter">name</replaceable></term>
+    <listitem>
+     <para>
+      The name of the resource group to alter.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>CONCURRENCY</literal> <replaceable class="parameter">integer</replaceable></term>
+    <listitem>
+     <para>
+      The maximum number of concurrent transactions permitted in the resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>CPU_MAX_PERCENT</literal> <replaceable class="parameter">integer</replaceable></term>
+    <listitem>
+     <para>
+      The maximum percentage of CPU resources available to this resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>CPU_WEIGHT</literal> <replaceable class="parameter">integer</replaceable></term>
+    <listitem>
+     <para>
+      The CPU weight for this resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>CPUSET</literal> <replaceable class="parameter">tuple</replaceable></term>
+    <listitem>
+     <para>
+      The CPU cores to be used by this resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>MEMORY_QUOTA</literal> <replaceable class="parameter">integer</replaceable></term>
+    <listitem>
+     <para>
+      The memory quota for this resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>MIN_COST</literal> <replaceable class="parameter">integer</replaceable></term>
+    <listitem>
+     <para>
+      The minimum cost threshold for queries to be managed by this resource group.
+      Queries with an estimated cost below this value bypass resource group limits.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>IO_LIMIT</literal> <replaceable class="parameter">string</replaceable></term>
+    <listitem>
+     <para>
+      The I/O limit specification for this resource group. The format is a
+      tablespace-specific limit string that controls read and write bandwidth
+      and IOPS.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>NAME</literal> <replaceable class="parameter">new_name</replaceable></term>
+    <listitem>
+     <para>
+      The new name for the resource group.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1>
+  <title>Examples</title>
+
+  <para>
+   Change the concurrency limit of a resource group:
+<programlisting>
+ALTER RESOURCE GROUP mygroup SET CONCURRENCY 20;
+</programlisting>
+  </para>
+
+  <para>
+   Rename a resource group:
+<programlisting>
+ALTER RESOURCE GROUP oldname SET NAME newname;
+</programlisting>
+  </para>
+
+  <para>
+   Set the minimum cost threshold:
+<programlisting>
+ALTER RESOURCE GROUP mygroup SET MIN_COST 500;
+</programlisting>
+  </para>
+
+  <para>
+   Set I/O limits for a resource group:
+<programlisting>
+ALTER RESOURCE GROUP mygroup SET IO_LIMIT 'pg_default:rbps=1000,wbps=1000,riops=100,wiops=100';
+</programlisting>
+  </para>
+ </refsect1>
+
+ <refsect1>
+  <title>Compatibility</title>
+
+  <para>
+   There is no <command>ALTER RESOURCE GROUP</command> statement in the SQL
+   standard.
+  </para>
+ </refsect1>
+
+ <refsect1>
+  <title>See Also</title>
+
+  <simplelist type="inline">
+   <member><xref linkend="sql-createresourcegroup"/></member>
+   <member><xref linkend="sql-dropresourcegroup"/></member>
+  </simplelist>
+ </refsect1>
 
 </refentry>

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -81,6 +81,7 @@ static void createResgroupCallback(XactEvent event, void *arg);
 static void dropResgroupCallback(XactEvent event, void *arg);
 static void alterResgroupCallback(XactEvent event, void *arg);
 static void checkCpusetSyntax(const char *cpuset);
+static void updateResgroupName(Relation rel, Oid groupId, const char *newname);
 
 /*
  * CREATE RESOURCE GROUP
@@ -398,6 +399,11 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	}
 	else if (limitType == RESGROUP_LIMIT_TYPE_IO_LIMIT)
 		io_limit = defGetString(defel);
+	else if (limitType == RESGROUP_LIMIT_TYPE_NAME)
+	{
+		/* name is handled separately below, just validate it's a string */
+		(void) defGetString(defel);
+	}
 	else
 	{
 		value = getResgroupOptionValue(defel);
@@ -409,6 +415,74 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	 * exists.
 	 */
 	groupid = get_resgroup_oid(stmt->name, false);
+
+	/*
+	 * Handle RENAME separately since it modifies pg_resgroup
+	 * instead of pg_resgroupcapability.
+	 */
+	if (limitType == RESGROUP_LIMIT_TYPE_NAME)
+	{
+		Relation	pg_resgroup_rel;
+		ScanKeyData	scankey;
+		SysScanDesc	sscan;
+		const char *newname = defGetString(defel);
+
+		/* Check for an illegal name ('none' is used to signify no group in ALTER ROLE) */
+		if (strcmp(newname, "none") == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_RESERVED_NAME),
+					 errmsg("resource group name \"none\" is reserved")));
+
+		/* cannot rename default resource groups */
+		if (groupid == DEFAULTRESGROUP_OID ||
+			groupid == ADMINRESGROUP_OID ||
+			groupid == SYSTEMRESGROUP_OID)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot rename default resource group \"%s\"",
+							stmt->name)));
+
+		pg_resgroup_rel = table_open(ResGroupRelationId, RowExclusiveLock);
+
+		/* Check if the new name already exists */
+		ScanKeyInit(&scankey,
+					Anum_pg_resgroup_rsgname,
+					BTEqualStrategyNumber, F_NAMEEQ,
+					CStringGetDatum(newname));
+
+		sscan = systable_beginscan(pg_resgroup_rel, ResGroupRsgnameIndexId, true,
+								   NULL, 1, &scankey);
+
+		if (HeapTupleIsValid(systable_getnext(sscan)))
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("resource group \"%s\" already exists",
+							newname)));
+
+		systable_endscan(sscan);
+
+		/* Update the name in pg_resgroup */
+		updateResgroupName(pg_resgroup_rel, groupid, newname);
+
+		/* Dispatch the statement to segments */
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			MetaTrackUpdObject(ResGroupRelationId,
+				   groupid,
+				   GetUserId(),
+				   "ALTER", "RENAME");
+
+			CdbDispatchUtilityStatement((Node *) stmt,
+										DF_CANCEL_ON_ERROR|
+										DF_WITH_SNAPSHOT|
+										DF_NEED_TWO_PHASE,
+										GetAssignedOidsForDispatch(),
+										NULL);
+		}
+
+		table_close(pg_resgroup_rel, NoLock);
+		return;
+	}
 
 	if (limitType == RESGROUP_LIMIT_TYPE_CONCURRENCY &&
 		value == 0 &&
@@ -865,6 +939,8 @@ getResgroupOptionType(const char* defname)
 		return RESGROUP_LIMIT_TYPE_MIN_COST;
 	else if (strcmp(defname, "io_limit") == 0)
 		return RESGROUP_LIMIT_TYPE_IO_LIMIT;
+	else if (strcmp(defname, "name") == 0)
+		return RESGROUP_LIMIT_TYPE_NAME;
 	else
 		return RESGROUP_LIMIT_TYPE_UNKNOWN;
 }
@@ -1269,6 +1345,53 @@ updateResgroupCapabilityEntry(Relation rel,
 
 	isnull[Anum_pg_resgroupcapability_value - 1] = false;
 	repl[Anum_pg_resgroupcapability_value - 1]  = true;
+
+	newTuple = heap_modify_tuple(oldTuple, RelationGetDescr(rel),
+								 values, isnull, repl);
+
+	CatalogTupleUpdate(rel, &oldTuple->t_self, newTuple);
+
+	systable_endscan(sscan);
+}
+
+/*
+ * Update the name of a resource group in pg_resgroup.
+ *
+ * Caller must have already verified that the new name doesn't conflict
+ * with existing resource groups.
+ */
+static void
+updateResgroupName(Relation rel, Oid groupId, const char *newname)
+{
+	HeapTuple	oldTuple;
+	HeapTuple	newTuple;
+	SysScanDesc	sscan;
+	ScanKeyData	scankey;
+	Datum		values[Natts_pg_resgroup];
+	bool		isnull[Natts_pg_resgroup];
+	bool		repl[Natts_pg_resgroup];
+
+	ScanKeyInit(&scankey,
+				Anum_pg_resgroup_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(groupId));
+
+	sscan = systable_beginscan(rel, ResGroupOidIndexId, true,
+							   NULL, 1, &scankey);
+
+	oldTuple = systable_getnext(sscan);
+	if (!HeapTupleIsValid(oldTuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("resource group %u does not exist", groupId)));
+
+	MemSet(values, 0, sizeof(values));
+	MemSet(isnull, false, sizeof(isnull));
+	MemSet(repl, false, sizeof(repl));
+
+	values[Anum_pg_resgroup_rsgname - 1] =
+		DirectFunctionCall1(namein, CStringGetDatum(newname));
+	repl[Anum_pg_resgroup_rsgname - 1] = true;
 
 	newTuple = heap_modify_tuple(oldTuple, RelationGetDescr(rel),
 								 values, isnull, repl);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -1663,6 +1663,10 @@ OptResourceGroupElem:
 				{
 					$$ = makeDefElem("io_limit", (Node *) makeString($2), @1);
 				}
+			| NAME_P name
+				{
+					$$ = makeDefElem("name", (Node *) makeString($2), @1);
+				}
 		;
 
 /*****************************************************************************

--- a/src/include/catalog/pg_resgroup.h
+++ b/src/include/catalog/pg_resgroup.h
@@ -60,6 +60,9 @@ typedef enum ResGroupLimitType
 	RESGROUP_LIMIT_TYPE_IO_LIMIT,			/* io_limit */
 
 	RESGROUP_LIMIT_TYPE_COUNT,
+
+	/* not stored in pg_resgroupcapability, used for ALTER only */
+	RESGROUP_LIMIT_TYPE_NAME,			/* name (for rename) */
 } ResGroupLimitType;
 
 #endif   /* PG_RESGROUP_H */

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -557,6 +557,113 @@ DROP ROLE
 DROP RESOURCE GROUP rg_test_group;
 DROP RESOURCE GROUP
 
+-- ----------------------------------------------------------------------
+-- Test: rename a resource group
+-- ----------------------------------------------------------------------
+
+-- positive: basic rename
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     
+---------------
+ rg_test_group 
+(1 row)
+ALTER RESOURCE GROUP rg_test_group SET name rg_test_group_renamed;
+ALTER RESOURCE GROUP
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname 
+-----------
+(0 rows)
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group_renamed';
+ groupname             
+-----------------------
+ rg_test_group_renamed 
+(1 row)
+DROP RESOURCE GROUP rg_test_group_renamed;
+DROP RESOURCE GROUP
+
+-- positive: rename and verify capabilities are preserved
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=20, concurrency=5, cpu_weight=200);
+CREATE RESOURCE GROUP
+SELECT groupname,concurrency,cpu_max_percent,cpu_weight FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_max_percent | cpu_weight 
+---------------+-------------+-----------------+------------
+ rg_test_group | 5           | 20              | 200        
+(1 row)
+ALTER RESOURCE GROUP rg_test_group SET name rg_new_name;
+ALTER RESOURCE GROUP
+SELECT groupname,concurrency,cpu_max_percent,cpu_weight FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_new_name';
+ groupname   | concurrency | cpu_max_percent | cpu_weight 
+-------------+-------------+-----------------+------------
+ rg_new_name | 5           | 20              | 200        
+(1 row)
+DROP RESOURCE GROUP rg_new_name;
+DROP RESOURCE GROUP
+
+-- positive: rename and verify role assignment still works
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+CREATE ROLE
+SELECT rolname, groupname FROM pg_roles, gp_toolkit.gp_resgroup_config WHERE pg_roles.rolresgroup = gp_toolkit.gp_resgroup_config.groupid AND rolname = 'rg_test_role';
+ rolname      | groupname     
+--------------+---------------
+ rg_test_role | rg_test_group 
+(1 row)
+ALTER RESOURCE GROUP rg_test_group SET name rg_renamed_group;
+ALTER RESOURCE GROUP
+-- role should still be associated with the renamed group
+SELECT rolname, groupname FROM pg_roles, gp_toolkit.gp_resgroup_config WHERE pg_roles.rolresgroup = gp_toolkit.gp_resgroup_config.groupid AND rolname = 'rg_test_role';
+ rolname      | groupname        
+--------------+------------------
+ rg_test_role | rg_renamed_group 
+(1 row)
+DROP ROLE rg_test_role;
+DROP ROLE
+DROP RESOURCE GROUP rg_renamed_group;
+DROP RESOURCE GROUP
+
+-- negative: rename to an existing resource group name
+CREATE RESOURCE GROUP rg_test_group1 WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+CREATE RESOURCE GROUP rg_test_group2 WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+ALTER RESOURCE GROUP rg_test_group1 SET name rg_test_group2;
+ERROR:  resource group "rg_test_group2" already exists
+DROP RESOURCE GROUP rg_test_group1;
+DROP RESOURCE GROUP
+DROP RESOURCE GROUP rg_test_group2;
+DROP RESOURCE GROUP
+
+-- negative: rename to reserved name 'none'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+ALTER RESOURCE GROUP rg_test_group SET name none;
+ERROR:  resource group name "none" is reserved
+DROP RESOURCE GROUP rg_test_group;
+DROP RESOURCE GROUP
+
+-- negative: rename default resource groups
+ALTER RESOURCE GROUP default_group SET name new_default_group;
+ERROR:  cannot rename default resource group "default_group"
+ALTER RESOURCE GROUP admin_group SET name new_admin_group;
+ERROR:  cannot rename default resource group "admin_group"
+ALTER RESOURCE GROUP system_group SET name new_system_group;
+ERROR:  cannot rename default resource group "system_group"
+
+-- negative: rename non-existent resource group
+ALTER RESOURCE GROUP non_existent_group SET name new_name;
+ERROR:  resource group "non_existent_group" does not exist
+
+-- negative: rename to the same name (should still check conflict)
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP
+ALTER RESOURCE GROUP rg_test_group SET name rg_test_group;
+ERROR:  resource group "rg_test_group" already exists
+DROP RESOURCE GROUP rg_test_group;
+DROP RESOURCE GROUP
+
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -275,6 +275,64 @@ DROP TABLE rg_test_group_table;
 DROP ROLE rg_test_role;
 DROP RESOURCE GROUP rg_test_group;
 
+-- ----------------------------------------------------------------------
+-- Test: rename a resource group
+-- ----------------------------------------------------------------------
+
+-- positive: basic rename
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ALTER RESOURCE GROUP rg_test_group SET name rg_test_group_renamed;
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group_renamed';
+DROP RESOURCE GROUP rg_test_group_renamed;
+
+-- positive: rename and verify capabilities are preserved
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=20, concurrency=5, cpu_weight=200);
+SELECT groupname,concurrency,cpu_max_percent,cpu_weight FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ALTER RESOURCE GROUP rg_test_group SET name rg_new_name;
+SELECT groupname,concurrency,cpu_max_percent,cpu_weight FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_new_name';
+DROP RESOURCE GROUP rg_new_name;
+
+-- positive: rename and verify role assignment still works
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+CREATE ROLE rg_test_role RESOURCE GROUP rg_test_group;
+SELECT rolname, groupname FROM pg_roles, gp_toolkit.gp_resgroup_config
+WHERE pg_roles.rolresgroup = gp_toolkit.gp_resgroup_config.groupid
+  AND rolname = 'rg_test_role';
+ALTER RESOURCE GROUP rg_test_group SET name rg_renamed_group;
+-- role should still be associated with the renamed group
+SELECT rolname, groupname FROM pg_roles, gp_toolkit.gp_resgroup_config
+WHERE pg_roles.rolresgroup = gp_toolkit.gp_resgroup_config.groupid
+  AND rolname = 'rg_test_role';
+DROP ROLE rg_test_role;
+DROP RESOURCE GROUP rg_renamed_group;
+
+-- negative: rename to an existing resource group name
+CREATE RESOURCE GROUP rg_test_group1 WITH (cpu_max_percent=10);
+CREATE RESOURCE GROUP rg_test_group2 WITH (cpu_max_percent=10);
+ALTER RESOURCE GROUP rg_test_group1 SET name rg_test_group2;
+DROP RESOURCE GROUP rg_test_group1;
+DROP RESOURCE GROUP rg_test_group2;
+
+-- negative: rename to reserved name 'none'
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+ALTER RESOURCE GROUP rg_test_group SET name none;
+DROP RESOURCE GROUP rg_test_group;
+
+-- negative: rename default resource groups
+ALTER RESOURCE GROUP default_group SET name new_default_group;
+ALTER RESOURCE GROUP admin_group SET name new_admin_group;
+ALTER RESOURCE GROUP system_group SET name new_system_group;
+
+-- negative: rename non-existent resource group
+ALTER RESOURCE GROUP non_existent_group SET name new_name;
+
+-- negative: rename to the same name (should still check conflict)
+CREATE RESOURCE GROUP rg_test_group WITH (cpu_max_percent=10);
+ALTER RESOURCE GROUP rg_test_group SET name rg_test_group;
+DROP RESOURCE GROUP rg_test_group;
+
 -- test set cpu_max_percent to high value when gp_resource_group_cpu_limit is low
 -- start_ignore
 !\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;


### PR DESCRIPTION
## Add RENAME support for ALTER RESOURCE GROUP                                                                                                                                                                       
 This PR adds the ability to rename a resource group using the 
`ALTER RESOURCE GROUP` command with a new name option.

Syntax:
```sql
ALTER RESOURCE GROUP <old_name> SET name <new_name>;
```

### Changes

1. New Enum Type (src/include/catalog/pg_resgroup.h)
Added `RESGROUP_LIMIT_TYPE_NAME` to the `ResGroupLimitType` enum. 
This new type is placed after `RESGROUP_LIMIT_TYPE_COUNT` since it is not 
stored in `pg_resgroupcapability` table - it only modifies the `pg_resgroup` table.                     
   
```cpp
  RESGROUP_LIMIT_TYPE_COUNT,                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  /* not stored in pg_resgroupcapability, used for ALTER only */
  RESGROUP_LIMIT_TYPE_NAME,           /* name (for rename) */            
```                                                                                                                                                                   
                                                                                                                                                                                                                                            
2. Grammar Rule (`src/backend/parser/gram.y`)
                                                                                                                                                                                                                                            
Added a new grammar rule for the name option in `OptResourceGroupElem`:

```
  | NAME_P name
      {
          $$ = makeDefElem("name", (Node *) makeString($2), @1);
      }
```

3. Command Implementation (`src/backend/commands/resgroupcmds.c`)                                                                                                                                                                           
   
  - `getResgroupOptionType()`: Added handling for "name" option to return 
  `RESGROUP_LIMIT_TYPE_NAME`.                                                                                                                                           
  - `AlterResourceGroup()`: Added a dedicated branch for `RESGROUP_LIMIT_TYPE_NAME` that:
    - Validates the new name is not the reserved name "none"                                                                                                                                                                                
    - Prevents renaming default resource groups (default_group, admin_group, system_group)                                                                                                                                                  
    - Checks for name conflicts with existing resource groups                                                                                                                                                                               
    - Updates the `pg_resgroup` catalog table                                                                                                                                                                                                 
    - Dispatches the statement to segments                                                                                                                                                                                                  
  - updateResgroupName(): New helper function (similar to `updateResgroupCapabilityEntry`) 
 that encapsulates the logic for updating the resource group name in `pg_resgroup` table.
                                                                                                                                                                                                                                            
  4. Test Cases (`src/test/isolation2/sql/resgroup/resgroup_syntax.sql`)
                                                                                                                                                                                                                                            
  Added comprehensive tests covering:

  Positive cases:
  - Basic rename functionality
  - Verify capabilities are preserved after rename
  - Verify role assignments remain valid after rename

  Negative cases:                                                                                                                                                                                                                           
  - Rename to an existing resource group name (conflict check)
  - Rename to reserved name "none"                                                                                                                                                                                                          
  - Rename default resource groups (default_group, admin_group, system_group)
  - Rename non-existent resource group                                                                                                                                                                                                      
  - Rename to the same name (self-conflict)

### Design Decisions
 
  1. Consistent with existing patterns: The implementation follows the same code patterns 
used for other ALTER RESOURCE GROUP SET options (cpuset, io_limit, etc.), making the 
code maintainable and consistent.
  2. Helper function: `updateResgroupName()` is extracted as a separate function following 
the same style as updateResgroupCapabilityEntry(), promoting code reuse and separation 
of concerns.                                                
  3. Validation order: Validates in this order - reserved name check → default group check → 
open table → conflict check → update. This ensures early failure for obvious errors before 
acquiring locks.                                    
   
### Example Usage                                                                                                                                                                                                                             
```sql
-- Create a resource group
CREATE RESOURCE GROUP rg_old_name WITH (cpu_max_percent=10);

-- Rename it
ALTER RESOURCE GROUP rg_old_name SET name rg_new_name;

-- Verify
SELECT groupname FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_new_name';
```                                                                                                                                                                                                                
