### PR TITLE
Fix SIGSEGV in plpython function check_cgroup_io_max caused by missing ctypes function signatures

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -127,7 +127,10 @@ $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
 0: CREATE OR REPLACE FUNCTION check_cgroup_io_max(groupname text, tablespace_name text, parameters text) RETURNS BOOL AS $$ import ctypes import os 
-postgres = ctypes.CDLL(None) get_bdi_of_path = postgres['get_bdi_of_path'] get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_oid = postgres['get_tablespace_oid'] 
+postgres = ctypes.CDLL(None) 
+get_bdi_of_path = postgres['get_bdi_of_path'] get_bdi_of_path.argtypes = [ctypes.c_char_p] get_bdi_of_path.restype = ctypes.c_uint64 
+get_tablespace_path = postgres['get_tablespace_path'] get_tablespace_path.argtypes = [ctypes.c_uint32] get_tablespace_path.restype = ctypes.c_char_p 
+get_tablespace_oid = postgres['get_tablespace_oid'] get_tablespace_oid.argtypes = [ctypes.c_char_p, ctypes.c_bool] get_tablespace_oid.restype = ctypes.c_uint32 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 cgroup_path = "/sys/fs/cgroup/gpdb/%d" % groupid 
 # get path of tablespace spcoid = get_tablespace_oid(tablespace_name.encode('utf-8'), False) location = ctypes.cast(get_tablespace_path(spcoid), ctypes.c_char_p).value 

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -285,7 +285,7 @@ $$ LANGUAGE plpython3u;
 
     get_tablespace_path = postgres['get_tablespace_path']
     get_tablespace_path.argtypes = [ctypes.c_uint32]
-    get_tablespace_path.restype = ctypes.c_char_p
+    get_tablespace_path.restype = ctypes.c_void_p
 
     get_tablespace_oid = postgres['get_tablespace_oid']
     get_tablespace_oid.argtypes = [ctypes.c_char_p, ctypes.c_bool]

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -278,9 +278,18 @@ $$ LANGUAGE plpython3u;
     import os
 
     postgres = ctypes.CDLL(None)
+
     get_bdi_of_path = postgres['get_bdi_of_path']
+    get_bdi_of_path.argtypes = [ctypes.c_char_p]
+    get_bdi_of_path.restype = ctypes.c_uint64
+
     get_tablespace_path = postgres['get_tablespace_path']
+    get_tablespace_path.argtypes = [ctypes.c_uint32]
+    get_tablespace_path.restype = ctypes.c_char_p
+
     get_tablespace_oid = postgres['get_tablespace_oid']
+    get_tablespace_oid.argtypes = [ctypes.c_char_p, ctypes.c_bool]
+    get_tablespace_oid.restype = ctypes.c_uint32
 
     # get group oid
     sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname


### PR DESCRIPTION
On 64-bit systems, `get_tablespace_path()` returns a pointer that was 
truncated to 32-bit due to default `c_int` restype, resulting in invalid 
memory access:

```bash
6-04-08 12:03:21.262229 CST,,,p1316159,th0,,,2026-04-08 12:03:21 CST,0,con8,cmd6,seg-1,,,,,"PANIC","XX000","Unexpected internal error: Master process received signal SIGSEGV",,,,,,,0,,,,"1    0x577c3313e04c postgres StandardHandlerForSigillSigsegvSigbus_OnMainThread + 0x209
2    0x577c32f57550 postgres <symbol not found> + 0x32f57550
3    0x577c33260372 postgres <symbol not found> + 0x33260372
4    0x751076445330 libc.so.6 <symbol not found> + 0x76445330
5    0x7510683e556d ??:0
6    0x7510683e4c48 ??:0
7    0x75106831ad72 ??:0
8    0x7510684a091f ??:0
9    0x751073f0314e ??:0
10   0x751073effcaa ??:0
11   0x751073f03cab ??:0
12   0x577c32c47f3a postgres <symbol not found> + 0x32c47f3a
13   0x577c32c4a495 postgres ExecInterpExprStillValid + 0x5b
14   0x577c32ca9d11 postgres <symbol not found> + 0x32ca9d11
15   0x577c32ca9d89 postgres <symbol not found> + 0x32ca9d89
16   0x577c32caa0ee postgres <symbol not found> + 0x32caa0ee
17   0x577c32c62ff2 postgres <symbol not found> + 0x32c62ff2
18   0x577c32c62e86 postgres <symbol not found> + 0x32c62e86
19   0x577c32c53db4 postgres <symbol not found> + 0x32c53db4
20   0x577c32c58a25 postgres <symbol not found> + 0x32c58a25
21   0x577c32c559c0 postgres standard_ExecutorRun + 0x56e
22   0x577c32c553de postgres ExecutorRun + 0xec
23   0x577c32f5d811 postgres <symbol not found> + 0x32f5d811
24   0x577c32f5d3dd postgres PortalRun + 0x2d0
25   0x577c32f5460e postgres <symbol not found> + 0x32f5460e
26   0x577c32f5a0b2 postgres PostgresMain + 0xe1e
"
```
