### PR TITLE
Improve workflow run-names with prefixes and commit titles

### DIFF
--- a/.github/workflows/abi-tests.yml
+++ b/.github/workflows/abi-tests.yml
@@ -1,5 +1,12 @@
 name: ABI Tests
 
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && '[ABI] Manual run'
+      || github.event_name == 'pull_request'
+      && format('[ABI] PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
+      || format('[ABI] Push {0}: {1}', github.ref_name, github.event.head_commit.message) }}
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -12,10 +12,10 @@ env:
 
 run-name: >-
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Manual: {0} on {1}', inputs.test_type == 'all' && 'all tests' || inputs.test_type, inputs.el_version == 'all' && 'all EL versions' || format('EL{0}', inputs.el_version))
+      && format('[CI] Manual: {0} on {1}', inputs.test_type == 'all' && 'all tests' || inputs.test_type, inputs.el_version == 'all' && 'all EL versions' || format('EL{0}', inputs.el_version))
       || github.event_name == 'pull_request'
-      && format('PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
-      || format('Push: {0}', github.ref_name) }}
+      && format('[CI] PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
+      || format('[CI] Push {0}: {1}', github.ref_name, github.event.head_commit.message) }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
- Add [CI]/[ABI] prefixes to run-names for easy identification
- Show commit title on push events instead of just branch name
- Add run-name to abi-tests.yml (previously had none)
