### PR TITLE
fix(gpconfig): respect gp_resource_group_cgroup_parent when verifying cgroup root

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -2,6 +2,7 @@
 # Copyright (c) 2017, VMware, Inc. or its affiliates.
 
 import os
+import argparse
 from functools import reduce
 
 
@@ -30,7 +31,7 @@ class CgroupValidationVersionTwo(CgroupValidation):
         self.mount_point = self.detect_cgroup_mount_point()
         self.tab = {"r": os.R_OK, "w": os.W_OK, "x": os.X_OK, "f": os.F_OK}
 
-    def validate_all(self):
+    def validate_all(self, cgroup_parent):
         """
         Check the permissions of the toplevel gpdb cgroup dirs.
 
@@ -43,23 +44,23 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
         self.validate_permission("cgroup.procs", "rw")
 
-        self.validate_permission("gpdb/", "rwx")
-        self.validate_permission("gpdb/cgroup.procs", "rw")
+        self.validate_permission("{}/".format(cgroup_parent), "rwx")
+        self.validate_permission("{}/cgroup.procs".format(cgroup_parent), "rw")
 
-        self.validate_permission("gpdb/cpu.max", "rw")
-        self.validate_permission("gpdb/cpu.weight", "rw")
-        self.validate_permission("gpdb/cpu.weight.nice", "rw")
-        self.validate_permission("gpdb/cpu.stat", "r")
+        self.validate_permission("{}/cpu.max".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpu.weight".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpu.weight.nice".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpu.stat".format(cgroup_parent), "r")
 
-        self.validate_permission("gpdb/cpuset.cpus", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.partition", "rw")
-        self.validate_permission("gpdb/cpuset.mems", "rw")
-        self.validate_permission("gpdb/cpuset.cpus.effective", "r")
-        self.validate_permission("gpdb/cpuset.mems.effective", "r")
+        self.validate_permission("{}/cpuset.cpus".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpuset.cpus.partition".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpuset.mems".format(cgroup_parent), "rw")
+        self.validate_permission("{}/cpuset.cpus.effective".format(cgroup_parent), "r")
+        self.validate_permission("{}/cpuset.mems.effective".format(cgroup_parent), "r")
 
-        self.validate_permission("gpdb/memory.current", "r")
+        self.validate_permission("{}/memory.current".format(cgroup_parent), "r")
 
-        self.validate_permission("gpdb/io.max", "rw")
+        self.validate_permission("{}/io.max".format(cgroup_parent), "rw")
 
     def die(self, msg):
         raise ValidationException("cgroup is not properly configured: {}".format(msg))
@@ -85,7 +86,11 @@ class CgroupValidationVersionTwo(CgroupValidation):
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="gpcheckresgroupv2impl")
+    parser.add_argument("--cgroup_parent")
+    args = parser.parse_args()
+
     try:
-        CgroupValidationVersionTwo().validate_all()
+        CgroupValidationVersionTwo().validate_all(args.cgroup_parent)
     except ValidationException as e:
         exit(e.message)

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -166,7 +166,15 @@ class Guc:
                 if msg is not None:
                     return msg
             elif newval == "'group-v2'":
-                msg = GpResGroup().validate_v2()
+                cgroup_parent_guc = get_gucs_from_database("gp_resource_group_cgroup_parent")
+                if not cgroup_parent_guc or len(cgroup_parent_guc) == 0:
+                    return "cannot get value of guc 'gp_resource_group_cgroup_parent'"
+
+                cgroup_parent = cgroup_parent_guc[0].value
+                if not cgroup_parent:
+                    return "cannot get value of guc 'gp_resource_group_cgroup_parent'"
+
+                msg = GpResGroup().validate_v2(cgroup_parent)
                 if msg is not None:
                     return msg
             elif newval != "'queue'" and newval != "'none'":

--- a/gpMgmt/bin/gppylib/gpresgroup.py
+++ b/gpMgmt/bin/gppylib/gpresgroup.py
@@ -39,14 +39,14 @@ class GpResGroup(object):
         return msg
 
     @staticmethod
-    def validate_v2():
+    def validate_v2(cgroup_parent):
         pool = base.WorkerPool()
         gp_array = GpArray.initFromCatalog(dbconn.DbURL(), utility=True)
         host_list = list(set(gp_array.get_hostlist(True)))
         msg = None
 
         for h in host_list:
-            cmd = Command(h, "gpcheckresgroupv2impl", REMOTE, h)
+            cmd = Command(h, "gpcheckresgroupv2impl --cgroup_parent={}".format(cgroup_parent), REMOTE, h)
             pool.addCommand(cmd)
         pool.join()
 

--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -297,16 +297,16 @@ Complete the following tasks on each node in your Greenplum Database cluster to 
     ```
     reboot now
     ```
-1. Create the directory `/sys/fs/cgroup/gpdb`, add all the necessary controllers, and ensure `gpadmin` user has read and write permission on it.
+1. Create the directory `/sys/fs/cgroup/gpdb.service`, add all the necessary controllers, and ensure `gpadmin` user has read and write permission on it.
     ```
-    mkdir -p /sys/fs/cgroup/gpdb
+    mkdir -p /sys/fs/cgroup/gpdb.service
     echo "+cpuset +io +cpu +memory" | tee -a /sys/fs/cgroup/cgroup.subtree_control
-    chown -R gpadmin:gpadmin /sys/fs/cgroup/gpdb
+    chown -R gpadmin:gpadmin /sys/fs/cgroup/gpdb.service
     ```
 
 You may encounter the error `Invalid argument` after running the above commands. This is because cgroups v2 do not support control of real-time processes, and the `cpu` controller can only be enabled when all the real-time processes are in the root cgroup. In this situation, find all real-time processes and move them to the root cgroup before you re-enable the controllers. 
 
-1. Ensure that `gpadmin` has write permission on `/sys/fs/cgroup/cgroup.procs`. This is required to move the Greenplum processes from the user slices to `/sys/fs/cgroup/gpdb/` after the cluster is started in order to manage the postmaster services and all its auxiliary processes.
+1. Ensure that `gpadmin` has write permission on `/sys/fs/cgroup/cgroup.procs`. This is required to move the Greenplum processes from the user slices to `/sys/fs/cgroup/gpdb.service/` after the cluster is started in order to manage the postmaster services and all its auxiliary processes.
     ```
     chmod a+w /sys/fs/cgroup/cgroup.procs
     ```


### PR DESCRIPTION
WHPG currently uses the `gp_resource_group_cgroup_parent` GUC to
define the root cgroup, but the gpconfig utility was not previously updated
to respect this value.

This commit updates the behavior of gpconfig. Now, when checking 
`gp_resource_manager`, gpconfig will dynamically retrieve the 
`gp_resource_group_cgroup_parent` value from the database to 
properly verify cgroup directory structures and permissions.