### PR TITLE
fix incorrect DQA type classification under HAVING clause

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -2876,11 +2876,7 @@ fetch_multi_dqas_info(PlannerInfo *root,
 					}
 
 					if (!found)
-					{
 						add_column_to_pathtarget(proj_target, (Expr *) var, 0);
-						proj_target->sortgrouprefs = (Index *) repalloc(proj_target->sortgrouprefs,
-																	list_length(proj_target->exprs) * sizeof(Index));
-					}
 				}
 			}
 		}

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -2878,11 +2878,8 @@ fetch_multi_dqas_info(PlannerInfo *root,
 					if (!found)
 					{
 						add_column_to_pathtarget(proj_target, (Expr *) var, 0);
-						if (proj_target->sortgrouprefs == NULL)
-							proj_target->sortgrouprefs = (Index *) palloc0(list_length(proj_target->exprs) * sizeof(Index));
-						else
-							proj_target->sortgrouprefs = (Index *) repalloc(proj_target->sortgrouprefs,
-																			list_length(proj_target->exprs) * sizeof(Index));
+						proj_target->sortgrouprefs = (Index *) repalloc(proj_target->sortgrouprefs,
+																	list_length(proj_target->exprs) * sizeof(Index));
 					}
 				}
 			}

--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -2381,6 +2381,18 @@ recognize_dqa_type(cdb_agg_planning_context *ctx)
 									   PVC_INCLUDE_AGGREGATES |
 									   PVC_INCLUDE_WINDOWFUNCS |
 									   PVC_INCLUDE_PLACEHOLDERS);
+		/*
+		 * Also check havingQual for non-DISTINCT aggregates.
+		 * Normal aggregates in HAVING clause also need special handling.
+		 */
+		if (ctx->havingQual)
+		{
+			List *having_aggs = pull_var_clause((Node *) ctx->havingQual,
+											   PVC_INCLUDE_AGGREGATES |
+											   PVC_INCLUDE_WINDOWFUNCS |
+											   PVC_INCLUDE_PLACEHOLDERS);
+			varnos = list_concat(varnos, having_aggs);
+		}
 		foreach (lc, varnos)
 		{
 			Node	   *node = lfirst(lc);
@@ -2831,16 +2843,63 @@ fetch_multi_dqas_info(PlannerInfo *root,
 	}
 
 	/*
+	 * For MULTI_DQAS_WITHAGG, ensure Vars from normal aggregates are in proj_target
+	 * before calling find_dqa_expr_by_normal_agg. This is important when normal
+	 * aggregates appear only in HAVING clause and not in SELECT list.
+	 */
+	if (ctx->type == MULTI_DQAS_WITHAGG)
+	{
+		foreach(lc, ctx->partial_grouping_target->exprs)
+		{
+			Node *expr = (Node *) lfirst(lc);
+
+			if (is_normal_agg(expr))
+			{
+				List *vars = pull_var_clause(expr,
+											 PVC_RECURSE_AGGREGATES |
+											 PVC_RECURSE_WINDOWFUNCS |
+											 PVC_RECURSE_PLACEHOLDERS);
+				ListCell *vlc;
+				foreach(vlc, vars)
+				{
+					Var *var = (Var *) lfirst(vlc);
+					bool found = false;
+					ListCell *tlc;
+
+					foreach(tlc, proj_target->exprs)
+					{
+						if (equal(var, lfirst(tlc)))
+						{
+							found = true;
+							break;
+						}
+					}
+
+					if (!found)
+					{
+						add_column_to_pathtarget(proj_target, (Expr *) var, 0);
+						if (proj_target->sortgrouprefs == NULL)
+							proj_target->sortgrouprefs = (Index *) palloc0(list_length(proj_target->exprs) * sizeof(Index));
+						else
+							proj_target->sortgrouprefs = (Index *) repalloc(proj_target->sortgrouprefs,
+																			list_length(proj_target->exprs) * sizeof(Index));
+					}
+				}
+			}
+		}
+	}
+
+	/*
 	 * Find DQAExpr for vars in normal agg, if not found
 	 * then use the first DQAExpr for these vars.
 	 *
 	 * select count(distinct a), count(distinct b), sum(b+e), sum(c+d) from t1;
 	 * 				|					|
 	 * 			DQAExpr_1			DQAExpr_2
-	 * 
+	 *
 	 * for sum(b+e), `b` is the distinct var in DQAExpr_2, so `b` and `e` will
 	 * be assinged to DQAExpr_2, also include sum(b+e)
-	 * 
+	 *
 	 * for sum(c+d), we could not find a DQAExpr for `c` and `d`, we just assign
 	 * these unrelated vars to DQAExpr_1
 	 */
@@ -2999,6 +3058,54 @@ fetch_single_dqa_info(PlannerInfo *root,
 												   dqa_group_exprs,
 												   num_total_input_rows,
 												   NULL);
+
+	/*
+	 * For SINGLE_DQA_WITHAGG, we need to ensure that Vars used by normal
+	 * aggregates (non-DISTINCT) are included in the input projection target.
+	 * Otherwise, partial aggregation in intermediate stages won't have access
+	 * to these columns. This is particularly important when normal aggregates
+	 * appear only in HAVING clause and not in SELECT list.
+	 */
+	if (ctx->type == SINGLE_DQA_WITHAGG && ctx->partial_grouping_target)
+	{
+		ListCell *lc;
+		foreach(lc, ctx->partial_grouping_target->exprs)
+		{
+			Node *expr = (Node *) lfirst(lc);
+
+			if (is_normal_agg(expr))
+			{
+				/* Extract Vars from the normal aggregate's arguments */
+				List *vars = pull_var_clause(expr,
+											 PVC_RECURSE_AGGREGATES |
+											 PVC_RECURSE_WINDOWFUNCS |
+											 PVC_RECURSE_PLACEHOLDERS);
+				ListCell *vlc;
+				foreach(vlc, vars)
+				{
+					Var *var = (Var *) lfirst(vlc);
+					bool found = false;
+					int idx = 0;
+					ListCell *tlc;
+
+					/* Check if this Var is already in input_proj_target */
+					foreach(tlc, info->input_proj_target->exprs)
+					{
+						if (equal(var, lfirst(tlc)))
+						{
+							found = true;
+							break;
+						}
+						idx++;
+					}
+
+					/* Add if not found */
+					if (!found)
+						add_column_to_pathtarget(info->input_proj_target, (Expr *) var, 0);
+				}
+			}
+		}
+	}
 }
 
 /*

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -3597,3 +3597,65 @@ GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC;
 DROP TABLE part_f;
 DROP TABLE partsupp_f;
 RESET enable_groupagg;
+-- Test DQA with having clauses
+CREATE TABLE sales (
+  sale_key   varchar(50),
+  cust_no    varchar(11),
+  sale_date  date,
+  sale_amt   numeric(18,3)
+) DISTRIBUTED BY (sale_key);
+INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
+SELECT 
+    '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
+    'KEY-' || i AS sale_key,
+    'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
+    ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
+FROM (
+    SELECT 
+        i,
+        (i - 1) % 1000 AS c,
+        (i - 1) / 1000 AS r
+    FROM generate_series(1, 10000) s(i)
+) sub;
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(*))
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Finalize HashAggregate
+                     Output: sales.cust_no, NULL::numeric, NULL::bigint
+                     Group Key: sales.cust_no
+                     Filter: ((sum(sales.sale_amt) >= '100000'::numeric) AND (count(sales.sale_date) >= 5))
+                     ->  Partial HashAggregate
+                           Output: sales.cust_no, sales.sale_amt, sales.sale_date, PARTIAL sum(sales.sale_amt)
+                           Group Key: sales.cust_no, sales.sale_date
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: sales.cust_no, sales.sale_amt, sales.sale_date
+                                 Hash Key: sales.cust_no
+                                 ->  Seq Scan on public.sales
+                                       Output: sales.cust_no, sales.sale_amt, sales.sale_date
+ Optimizer: Postgres-based planner
+ Settings: gp_eager_two_phase_agg = 'on', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1'
+(20 rows)
+
+-- Without this patch, this SQL will output 78, which is not correct
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+ count 
+-------
+   236
+(1 row)
+
+DROP TABLE sales;

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -3658,4 +3658,46 @@ SELECT count(*) FROM (
    236
 (1 row)
 
+-- Test Multi-DQA with having clause
+SET optimizer_enable_multiple_distinct_aggs=on;
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(*))
+         ->  Partial Aggregate
+               Output: PARTIAL count(*)
+               ->  Finalize HashAggregate
+                     Output: sales.cust_no, NULL::numeric, NULL::bigint
+                     Group Key: sales.cust_no
+                     Filter: ((sum(sales.sale_amt) >= '100000'::numeric) AND (count(sales.sale_date) >= 5))
+                     ->  Partial HashAggregate
+                           Output: sales.cust_no, sales.sale_amt, sales.sale_date, PARTIAL sum(sales.sale_amt)
+                           Group Key: sales.cust_no, sales.sale_date
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: sales.cust_no, sales.sale_amt, sales.sale_date
+                                 Hash Key: sales.cust_no
+                                 ->  Seq Scan on public.sales
+                                       Output: sales.cust_no, sales.sale_amt, sales.sale_date
+ Optimizer: Postgres-based planner
+ Settings: gp_eager_two_phase_agg = 'on', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1', optimizer = 'off'
+(20 rows)
+
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+ count 
+-------
+   236
+(1 row)
+
 DROP TABLE sales;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3971,4 +3971,44 @@ SELECT count(*) FROM (
    236
 (1 row)
 
+-- Test Multi-DQA with having clause
+SET optimizer_enable_multiple_distinct_aggs=on;
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Result
+               Filter: (((sum(sales.sale_amt)) >= '100000'::numeric) AND ((count(DISTINCT sales.sale_date)) >= 5))
+               ->  GroupAggregate
+                     Output: sum(sale_amt), count(DISTINCT sale_date), cust_no
+                     Group Key: sales.cust_no
+                     ->  Sort
+                           Output: cust_no, sale_date, sale_amt
+                           Sort Key: sales.cust_no
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: cust_no, sale_date, sale_amt
+                                 Hash Key: cust_no
+                                 ->  Seq Scan on public.sales
+                                       Output: cust_no, sale_date, sale_amt
+ Optimizer: GPORCA
+ Settings: gp_eager_two_phase_agg = 'on', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1', optimizer_enable_multiple_distinct_aggs = 'on'
+(18 rows)
+
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+ count 
+-------
+   236
+(1 row)
+
 DROP TABLE sales;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3912,3 +3912,63 @@ GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC;
 DROP TABLE part_f;
 DROP TABLE partsupp_f;
 RESET enable_groupagg;
+-- Test DQA with having clauses
+CREATE TABLE sales (
+  sale_key   varchar(50),
+  cust_no    varchar(11),
+  sale_date  date,
+  sale_amt   numeric(18,3)
+) DISTRIBUTED BY (sale_key);
+INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
+SELECT 
+    '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
+    'KEY-' || i AS sale_key,
+    'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
+    ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
+FROM (
+    SELECT 
+        i,
+        (i - 1) % 1000 AS c,
+        (i - 1) / 1000 AS r
+    FROM generate_series(1, 10000) s(i)
+) sub;
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count()
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Result
+               Filter: (((sum(sales.sale_amt)) >= '100000'::numeric) AND ((count(DISTINCT sales.sale_date)) >= 5))
+               ->  GroupAggregate
+                     Output: sum(sale_amt), count(DISTINCT sale_date), cust_no
+                     Group Key: sales.cust_no
+                     ->  Sort
+                           Output: cust_no, sale_date, sale_amt
+                           Sort Key: sales.cust_no
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: cust_no, sale_date, sale_amt
+                                 Hash Key: cust_no
+                                 ->  Seq Scan on public.sales
+                                       Output: cust_no, sale_date, sale_amt
+ Optimizer: GPORCA
+ Settings: gp_eager_two_phase_agg = 'on', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1'
+(18 rows)
+
+-- Without this patch, this SQL will output 78, which is not correct
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+ count 
+-------
+   236
+(1 row)
+
+DROP TABLE sales;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -685,3 +685,41 @@ DROP TABLE part_f;
 DROP TABLE partsupp_f;
 
 RESET enable_groupagg;
+
+-- Test DQA with having clauses
+CREATE TABLE sales (
+  sale_key   varchar(50),
+  cust_no    varchar(11),
+  sale_date  date,
+  sale_amt   numeric(18,3)
+) DISTRIBUTED BY (sale_key);
+
+INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
+SELECT 
+    '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
+    'KEY-' || i AS sale_key,
+    'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
+    ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
+FROM (
+    SELECT 
+        i,
+        (i - 1) % 1000 AS c,
+        (i - 1) / 1000 AS r
+    FROM generate_series(1, 10000) s(i)
+) sub;
+
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+
+-- Without this patch, this SQL will output 78, which is not correct
+SELECT count(*) FROM (
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+
+DROP TABLE sales;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -722,4 +722,20 @@ SELECT count(*) FROM (
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
 
+-- Test Multi-DQA with having clause
+SET optimizer_enable_multiple_distinct_aggs=on;
+
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
+  FROM sales GROUP BY cust_no 
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+
+SELECT count(*) FROM (
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
+  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
+)as sub;
+
 DROP TABLE sales;


### PR DESCRIPTION
### Context

When a HAVING clause is present with DQA (Distinct Qualified Aggregates), 
the planner inadvertently drops the HAVING clause, leading to incorrect query 
results. 

This issue manifests as inconsistent results across multiple executions of the 
same query. The root cause of this inconsistency is that the arrival order of the 
first tuple during network transmission is non-deterministic, which ultimately 
leads to unpredictable outputs.

```sql
CREATE TABLE sales (
  sale_date  date,  
  sale_key   varchar(50),
  cust_no    varchar(11),
  cust_type  varchar(1),
  order_no   varchar(20),          
  sale_amt   numeric(18,3)
) DISTRIBUTED BY (sale_key);

INSERT INTO sales (
    sale_date, 
    sale_key, 
    cust_no, 
    sale_amt, 
    order_no
)
SELECT
    generated_date, 
    'KEY-' || i::text,
    'C' || lpad((mod(i, 1000) + 1)::text, 8, '1'),
    (random() * 50000)::numeric(19,2),
    'ORD-' || i::text
FROM (
    SELECT 
        i, 
        '2026-04-01'::date + (random() * 6)::integer AS generated_date
    FROM generate_series(1, 100000) s(i)
) sub;

SELECT count(*) FROM (
  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
  FROM sales GROUP BY cust_no 
  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
)as sub;
 count 
-------
   879

SELECT count(*) FROM (
  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
  FROM sales GROUP BY cust_no 
  HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
)as sub;
 count 
-------
   882
```

### RCA

The root cause lies in the absence of the aggregate columns, the plan difference makes the bug visible:                                                                                                                                                                                                
   
```sql
  -- Before fix (SINGLE_DQA: sum evaluated over deduplicated rows only)                                                                                                                                                                     
  HashAggregate  Group Key: cust_no                                                                                                                                                                                                         
    Filter: sum(sale_amt) >= 100000
    -> HashAggregate  Output: cust_no, sale_amt, sale_date   ← AGGSPLIT_SIMPLE, no partial agg                                                                                                                                              
                                                                                                                                                                                                                                            
  -- After fix (SINGLE_DQA_WITHAGG: partial sum accumulated during deduplication)                                                                                                                                                           
  Finalize HashAggregate  Group Key: cust_no                                                                                                                                                                                                
    Filter: sum(sale_amt) >= 100000                                                                                                                                                                                                         
    -> Partial HashAggregate  Output: cust_no, sale_amt, sale_date, PARTIAL sum(sale_amt)
```

### changes

  1. `recognize_dqa_type()`: After `scanning ctx->target->exprs`, also scan `ctx->havingQual`. 
 The HAVING qual retains the original aggregate expressions and correctly exposes plain aggregates, 
allowing the query to be promoted to `SINGLE_DQA_WITHAGG` or `MULTI_DQAS_WITHAGG`.
  3. `fetch_single_dqa_info()`: For `SINGLE_DQA_WITHAGG`, pull Vars referenced by plain aggregates 
 in `partial_grouping_target` and add any missing ones to `input_proj_target`, ensuring HAVING-required 
columns survive intermediate projection.  
  5. `fetch_multi_dqas_info()`: Apply the same Var back-fill for `MULTI_DQAS_WITHAGG`.