### PR TITLE
Fix bugs around addr2line in backtrace generation to get proper debug info on errors and faults

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3495,6 +3495,155 @@ append_string_to_pipe_chunk(PipeProtoChunk *buffer, const char* input)
 }
 
 /*
+ * nm-based symbol lookup for resolving function names at file offsets.
+ *
+ * addr2line -f sometimes returns "??" for function names even when file:line
+ * is available (depends on DWARF completeness). nm reads the ELF symbol table
+ * directly and always works for unstripped binaries, so we use it as a
+ * fallback.
+ *
+ * The symbol table is loaded on first use and cached per binary path.
+ */
+#if !defined(WIN32) && !defined(_AIX)
+
+#define NM_NAME_SIZE    256
+#define NM_CACHE_SLOTS  8
+
+typedef struct
+{
+	unsigned long	offset;
+	char			name[NM_NAME_SIZE];
+} NmSymEntry;
+
+typedef struct
+{
+	char			path[1024];
+	NmSymEntry	   *syms;
+	int				count;
+} NmBinaryCache;
+
+static NmBinaryCache nm_cache[NM_CACHE_SLOTS];
+static int nm_cache_count = 0;
+
+static NmSymEntry *
+nm_load_symbols(const char *binary_path, int *out_count)
+{
+	char		cmd[CMD_BUFFER_SIZE];
+	FILE	   *fp;
+	NmSymEntry *syms = NULL;
+	int			count = 0;
+	int			capacity = 0;
+	char		line_buf[SYMBOL_SIZE];
+
+	/*
+	 * nm flags:
+	 * -C, --demangle[=STYLE] Decode mangled/processed symbol names
+	 * -n, --numeric-sort     Sort symbols numerically by address
+	 */
+	snprintf(cmd, sizeof(cmd), "nm -nC %s", binary_path);
+	fp = popen(cmd, "r");
+	if (!fp)
+		return NULL;
+
+	while (fgets(line_buf, sizeof(line_buf), fp))
+	{
+		unsigned long	sym_offset;
+		char			sym_type;
+		char			sym_name[NM_NAME_SIZE];
+
+		if (sscanf(line_buf, "%lx %c %255s", &sym_offset, &sym_type, sym_name) != 3)
+			continue;
+		if (sym_type != 'T' && sym_type != 't' &&
+			sym_type != 'W' && sym_type != 'w')
+			continue;
+
+		if (count >= capacity)
+		{
+			int		new_cap = capacity ? capacity * 2 : 4096;
+			NmSymEntry *new_syms = realloc(syms, new_cap * sizeof(NmSymEntry));
+
+			if (!new_syms)
+			{
+				free(syms);
+				pclose(fp);
+				*out_count = 0;
+				return NULL;
+			}
+			syms = new_syms;
+			capacity = new_cap;
+		}
+
+		syms[count].offset = sym_offset;
+		strncpy(syms[count].name, sym_name, NM_NAME_SIZE - 1);
+		syms[count].name[NM_NAME_SIZE - 1] = '\0';
+		count++;
+	}
+
+	pclose(fp);
+	*out_count = count;
+	return syms;
+}
+
+static const char *
+nm_lookup(NmSymEntry *syms, int count, unsigned long file_offset)
+{
+	int		lo = 0;
+	int		hi = count - 1;
+	int		best = -1;
+
+	while (lo <= hi)
+	{
+		int		mid = lo + (hi - lo) / 2;
+
+		if (syms[mid].offset <= file_offset)
+		{
+			best = mid;
+			lo = mid + 1;
+		}
+		else
+			hi = mid - 1;
+	}
+
+	/* Accept if within 1MB of the symbol start (generous for large functions) */
+	if (best >= 0 && (file_offset - syms[best].offset) < 0x100000)
+		return syms[best].name;
+
+	return NULL;
+}
+
+static const char *
+nm_resolve_function(const char *binary_path, unsigned long file_offset)
+{
+	int		i;
+	NmBinaryCache *entry = NULL;
+
+	for (i = 0; i < nm_cache_count; i++)
+	{
+		if (strcmp(nm_cache[i].path, binary_path) == 0)
+		{
+			entry = &nm_cache[i];
+			break;
+		}
+	}
+
+	if (!entry && nm_cache_count < NM_CACHE_SLOTS)
+	{
+		entry = &nm_cache[nm_cache_count++];
+		strncpy(entry->path, binary_path, sizeof(entry->path) - 1);
+		entry->path[sizeof(entry->path) - 1] = '\0';
+		entry->syms = nm_load_symbols(binary_path, &entry->count);
+	}
+
+	if (entry && entry->syms)
+		return nm_lookup(entry->syms, entry->count, file_offset);
+
+	return NULL;
+}
+
+#endif /* !WIN32 && !_AIX */
+
+
+/*
  * Append the backtrace to the given PipeProtoChunk or the syslogger file or stderr.
  *
  * We can not use the default backtrace_symbols since it calls malloc, which
@@ -3517,7 +3666,8 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 
 	FILE * fd;
 	char cmd[CMD_BUFFER_SIZE];
-	char cmdresult[STACK_DEPTH_MAX][SYMBOL_SIZE];
+	char cmdresult[STACK_DEPTH_MAX][SYMBOL_SIZE];	/* file:line from addr2line */
+	char cmdfunc[STACK_DEPTH_MAX][SYMBOL_SIZE];		/* function name from addr2line -f */
 	char addrtxt[ADDRESS_SIZE];
 
 	/* Pre-resolved dladdr info for all frames */
@@ -3536,7 +3686,7 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
  * -f --functions         Show function names
  * -C --demangle[=style]  Demangle function names
  */
-	const char * prog = "addr2line -C -e";
+	const char * prog = "addr2line -fC -e";
 #endif
 
 	static bool in_translate_stacktrace = false;
@@ -3552,6 +3702,7 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 	{
 		dli_ok_all[stack_no] = (dladdr(stackarray[stack_no], &dli_all[stack_no]) != 0);
 		cmdresult[stack_no][0] = '\0';
+		cmdfunc[stack_no][0] = '\0';
 	}
 
 	if (!in_translate_stacktrace && addr2line_ok)
@@ -3652,6 +3803,18 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 					int idx = frame_indices[i];
 					int len;
 
+					/*
+					 * With -f, addr2line outputs two lines per address:
+					 *   line 1: function name (or "??")
+					 *   line 2: file:line     (or "??:0")
+					 */
+					if (fgets(cmdfunc[idx], SYMBOL_SIZE, fd) == NULL)
+						break;
+					cmdfunc[idx][SYMBOL_SIZE - 1] = '\0';
+					len = strlen(cmdfunc[idx]);
+					if (len > 0 && cmdfunc[idx][len - 1] == '\n')
+						cmdfunc[idx][len - 1] = '\0';
+
 					if (fgets(cmdresult[idx], SYMBOL_SIZE, fd) == NULL)
 						break;
 					cmdresult[idx][SYMBOL_SIZE - 1] = '\0';
@@ -3706,7 +3869,42 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			const char *function = dli.dli_sname;
 			if (function == NULL || function[0] == '\0')
 			{
-				function = "<symbol not found>";
+				/*
+				 * dladdr only sees the dynamic symbol table (.dynsym).
+				 * Try addr2line -f first (uses DWARF, resolves all functions
+				 * including static/inline). Fall back to nm which reads the
+				 * full ELF symbol table (.symtab).
+				 */
+				if (stack_no < actual_stacksize &&
+					cmdfunc[stack_no][0] != '\0' &&
+					strcmp(cmdfunc[stack_no], "??") != 0)
+				{
+					function = cmdfunc[stack_no];
+				}
+				else if (stack_no < actual_stacksize &&
+						 dli_ok_all[stack_no] &&
+						 dli_all[stack_no].dli_fbase != NULL)
+				{
+					const char *bin_path = dli_all[stack_no].dli_fname;
+					unsigned long file_offset;
+
+					if (bin_path != NULL && bin_path[0] != '\0')
+					{
+						if (strncmp(bin_path, "postgres:", strlen("postgres:")) == 0)
+							bin_path = my_exec_path;
+
+						file_offset = (unsigned long)((char *)stackarray[stack_no] -
+													  (char *)dli_all[stack_no].dli_fbase);
+						function = nm_resolve_function(bin_path, file_offset);
+					}
+
+					if (function == NULL)
+						function = "<symbol not found>";
+				}
+				else
+				{
+					function = "<symbol not found>";
+				}
 			}
 
 			// check if lineInfo was retrieved

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3515,17 +3515,28 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 	Dl_info dli;
 	int symbol_len;
 
-
 	FILE * fd;
-	bool fd_ok = false;
 	char cmd[CMD_BUFFER_SIZE];
 	char cmdresult[STACK_DEPTH_MAX][SYMBOL_SIZE];
 	char addrtxt[ADDRESS_SIZE];
 
+	/* Pre-resolved dladdr info for all frames */
+	Dl_info dli_all[STACK_DEPTH_MAX];
+	bool dli_ok_all[STACK_DEPTH_MAX];
+	int actual_stacksize;
+
 #if defined(__darwin__)
 	const char * prog = "atos -o";
 #else
-	const char * prog = "addr2line -s -e";
+/*
+ * addr2line flags:
+ * -f
+ * -e --exe=<executable>  Set the input file name (default is a.out)
+ * -s --basenames         Strip directory names
+ * -f --functions         Show function names
+ * -C --demangle[=style]  Demangle function names
+ */
+	const char * prog = "addr2line -C -e";
 #endif
 
 	static bool in_translate_stacktrace = false;
@@ -3534,6 +3545,14 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 	if (stacksize == 0)
 		return;
 
+	actual_stacksize = (stacksize < STACK_DEPTH_MAX) ? stacksize : STACK_DEPTH_MAX;
+
+	/* Pre-resolve dladdr for all frames before running addr2line */
+	for (stack_no = 0; stack_no < actual_stacksize; stack_no++)
+	{
+		dli_ok_all[stack_no] = (dladdr(stackarray[stack_no], &dli_all[stack_no]) != 0);
+		cmdresult[stack_no][0] = '\0';
+	}
 
 	if (!in_translate_stacktrace && addr2line_ok)
 	{
@@ -3542,48 +3561,107 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 		 * try to do it again when we recurse back here,
 		 */
 		in_translate_stacktrace = true;
+		const char *unique_bins[STACK_DEPTH_MAX];
+		int num_unique_bins = 0;
+		int bin_idx;
 
-		snprintf(cmd,sizeof(cmd),"%s %s ",prog,my_exec_path);
-
-		for (stack_no = 0; stack_no < stacksize && stack_no < 100; stack_no++)
+		/*
+		 * Collect unique binary paths from dladdr results.  Each frame belongs
+		 * to either the main postgres binary or an extension shared library.
+		 * We run a separate addr2line invocation per binary.
+		 */
+		for (stack_no = 0; stack_no < actual_stacksize; stack_no++)
 		{
-			cmdresult[stack_no][0] = '\0';   /* clear this array for later */
-			snprintf(addrtxt, sizeof(addrtxt),"%p ",stackarray[stack_no]);
-			
-			Assert(sizeof(cmd) > strlen(cmd));
-			strncat(cmd, addrtxt, sizeof(cmd) - strlen(cmd) - 1);
+			const char *bin_path;
+			bool found = false;
+			int i;
+
+			if (!dli_ok_all[stack_no] || dli_all[stack_no].dli_fbase == NULL)
+				continue;
+
+			bin_path = dli_all[stack_no].dli_fname;
+			if (bin_path == NULL || bin_path[0] == '\0')
+				continue;
+
+			/* Use my_exec_path for the main postgres binary */
+			if (strncmp(bin_path, "postgres:", strlen("postgres:")) == 0)
+				bin_path = my_exec_path;
+
+			for (i = 0; i < num_unique_bins; i++)
+			{
+				if (strcmp(unique_bins[i], bin_path) == 0)
+				{
+					found = true;
+					break;
+				}
+			}
+			if (!found && num_unique_bins < STACK_DEPTH_MAX)
+				unique_bins[num_unique_bins++] = bin_path;
 		}
 
-		cmdresult[0][0] = '\0';
-		fd = popen(cmd,"r");
-		if (fd != NULL)
-			fd_ok = true;
-
-		if (fd_ok)
+		/* Run addr2line once per unique binary with correct file offsets */
+		for (bin_idx = 0; bin_idx < num_unique_bins; bin_idx++)
 		{
-			for (stack_no = 0; stack_no < stacksize && stack_no < STACK_DEPTH_MAX; stack_no++)
+			const char *binary = unique_bins[bin_idx];
+			int frame_indices[STACK_DEPTH_MAX];
+			int num_frames = 0;
+
+			snprintf(cmd, sizeof(cmd), "%s %s ", prog, binary);
+
+			for (stack_no = 0; stack_no < actual_stacksize; stack_no++)
 			{
-				/* initialize the string */
-				cmdresult[stack_no][0] = '\0';
-				// Get one line of the result from addr2line (or atos)
-				if (fgets(cmdresult[stack_no],SYMBOL_SIZE,fd) == NULL)
-					break;
-				// Force it to be a valid string (in case it was too long)
-				cmdresult[stack_no][SYMBOL_SIZE-1] = '\0';
-				// Get rid of the newline at the end.
-				if (strlen(cmdresult[stack_no]) > 0 &&
-					cmdresult[stack_no][strlen(cmdresult[stack_no])-1] == '\n')
-					cmdresult[stack_no][strlen(cmdresult[stack_no])-1] = '\0';
+				const char *bin_path;
+				unsigned long file_offset;
+
+				if (!dli_ok_all[stack_no] || dli_all[stack_no].dli_fbase == NULL)
+					continue;
+
+				bin_path = dli_all[stack_no].dli_fname;
+				if (bin_path == NULL || bin_path[0] == '\0')
+					continue;
+				if (strncmp(bin_path, "postgres:", strlen("postgres:")) == 0)
+					bin_path = my_exec_path;
+				if (strcmp(bin_path, binary) != 0)
+					continue;
+
+				frame_indices[num_frames++] = stack_no;
+
+				/*
+				 * Compute file offset by subtracting the load base address.
+				 * This is essential for PIE binaries and shared libraries where
+				 * the runtime virtual address differs from the file offset.
+				 */
+				file_offset = (unsigned long)((char *)stackarray[stack_no] -
+											  (char *)dli_all[stack_no].dli_fbase);
+				snprintf(addrtxt, sizeof(addrtxt), "0x%lx ", file_offset);
+
+				Assert(sizeof(cmd) > strlen(cmd));
+				strncat(cmd, addrtxt, sizeof(cmd) - strlen(cmd) - 1);
+			}
+
+			if (num_frames == 0)
+				continue;
+
+			fd = popen(cmd, "r");
+			if (fd != NULL)
+			{
+				int i;
+
+				for (i = 0; i < num_frames; i++)
+				{
+					int idx = frame_indices[i];
+					int len;
+
+					if (fgets(cmdresult[idx], SYMBOL_SIZE, fd) == NULL)
+						break;
+					cmdresult[idx][SYMBOL_SIZE - 1] = '\0';
+					len = strlen(cmdresult[idx]);
+					if (len > 0 && cmdresult[idx][len - 1] == '\n')
+						cmdresult[idx][len - 1] = '\0';
+				}
+				pclose(fd);
 			}
 		}
-
-		if (!fd_ok || strlen(cmdresult[0]) <= 1)
-		{
-			addr2line_ok = false;
-		}
-
-		if (fd != NULL)
-			pclose(fd);
 
 		in_translate_stacktrace = false;
 	}
@@ -3597,7 +3675,14 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 			lineInfo = cmdresult[stack_no];
 		}
 
-		if (dladdr(stackarray[stack_no], &dli) != 0)
+		/* Use pre-resolved dladdr results when available, fall back to live call */
+		if (stack_no < actual_stacksize)
+		{
+			dli = dli_all[stack_no];
+		}
+
+		if (stack_no < actual_stacksize ? dli_ok_all[stack_no]
+										: dladdr(stackarray[stack_no], &dli) != 0)
 		{
 			const char *file = dli.dli_fname;
 			if (file != NULL &&	file[0] != '\0')


### PR DESCRIPTION
Currently, with PIE builds, when an error, panic, segfault, corruption, bug etc happens in code, backtrace produced by whpg looks cryptic.

For example, if I run `SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);` without configuring an underlying engine, I get an error which produces a backtrace.
Currenlty, that backtrace looks like this:

```
2026-04-28 22:33:26.161083 UTC,"postgres","postgres",p71117,th-1531604960,"[local]",,2026-04-28 22:33:22 UTC,0,con27,cmd1,seg-1,,,,sx1,"LOG","00000","statement: SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",,,,,,,0,,"postgres.c",1732,
2026-04-28 22:33:26.182125 UTC,"postgres","postgres",p71117,th-1531604960,"[local]",,2026-04-28 22:33:22 UTC,0,con27,cmd1,seg-1,,,,sx1,"LOG","00000","2026-04-28 22:33:26:181306 UTC,THD000,NOTICE,""Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions"",
",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"COptTasks.cpp",267,
2026-04-28 22:33:26.238852 UTC,"postgres","postgres",p71117,th-1531604960,"[local]",,2026-04-28 22:33:22 UTC,0,con27,cmd3,seg-1,,,,sx1,"ERROR","XX000","pgaa.spark_connect_url is not set and SPARK_REMOTE env var is not available (spark.rs:671)",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"spark.rs",671,"Stack trace:
1    0xaaaacb50faa8 postgres errstart + 0xa44
2    0xffff9b9e1294 pgaa.so <symbol not found> + 0x9b9e1294
3    0xffff8fde4998 pgaa.so <symbol not found> + 0x8fde4998
4    0xffff8fbd51d4 pgaa.so spark_sql_wrapper + 0x1c
5    0xaaaacabb5bcc postgres <symbol not found> + 0xcabb5bcc
6    0xaaaacabb936c postgres ExecInterpExprStillValid + 0x84
7    0xaaaacac60b20 postgres <symbol not found> + 0xcac60b20
8    0xaaaacac60bf8 postgres <symbol not found> + 0xcac60bf8
9    0xaaaacac6122c postgres <symbol not found> + 0xcac6122c
10   0xaaaacabe4a6c postgres <symbol not found> + 0xcabe4a6c
11   0xaaaacabe46c4 postgres <symbol not found> + 0xcabe46c4
12   0xaaaacabc99f4 postgres <symbol not found> + 0xcabc99f4
13   0xaaaacabd1fb4 postgres <symbol not found> + 0xcabd1fb4
14   0xaaaacabcc2f4 postgres standard_ExecutorRun + 0x7e8
15   0xaaaacabcba64 postgres ExecutorRun + 0x154
16   0xaaaacb17d01c postgres <symbol not found> + 0xcb17d01c
17   0xaaaacb17c890 postgres PortalRun + 0x410
18   0xaaaacb167e8c postgres <symbol not found> + 0xcb167e8c
19   0xaaaacb175ff8 postgres PostgresMain + 0x262c
20   0xaaaacafcc53c postgres <symbol not found> + 0xcafcc53c
21   0xaaaacafcb1c0 postgres <symbol not found> + 0xcafcb1c0
22   0xaaaacafbfa14 postgres <symbol not found> + 0xcafbfa14
23   0xaaaacafbe4bc postgres PostmasterMain + 0x3618
24   0xaaaacad25658 postgres <symbol not found> + 0xcad25658
25   0xffffa41d225c libc.so.6 <symbol not found> + 0xa41d225c
26   0xffffa41d233c libc.so.6 __libc_start_main + 0x9c
27   0xaaaaca558170 postgres _start + 0x30
```


After applying the first commit, which mainly fixes `addr2line` bugs and corner cases in existing code,
the backtrace becomes this:
```
2026-04-28 22:03:20.413280 UTC,"postgres","postgres",p28828,th-2122682336,"[local]",,2026-04-28 22:02:35 UTC,0,con8,cmd4,seg-1,,,,sx1,"LOG","00000","statement: SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",,,,,,,0,,"postgres.c",1732,
2026-04-28 22:03:20.415919 UTC,"postgres","postgres",p28828,th-2122682336,"[local]",,2026-04-28 22:02:35 UTC,0,con8,cmd4,seg-1,,,,sx1,"LOG","00000","2026-04-28 22:03:20:415709 UTC,THD000,NOTICE,""Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions"",
",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"COptTasks.cpp",267,
2026-04-28 22:03:28.711103 UTC,"postgres","postgres",p28828,th-2122682336,"[local]",,2026-04-28 22:02:35 UTC,0,con8,cmd6,seg-1,,,,sx1,"ERROR","XX000","pgaa.spark_connect_url is not set and SPARK_REMOTE env var is not available (spark.rs:671)",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"spark.rs",671,"Stack trace:
1    0xaaaac70ffaa8 postgres errstart (/app/warehouse-pg/src/backend/utils/error/elog.c:484)
2    0xffff78631294 pgaa.so <symbol not found> (/home/postgres/.cargo/git/checkouts/pgrx-f84fa5b2d83bd064/dbd8ac7/pgrx-pg-sys/src/submodules/panic.rs:585)
3    0xffff6ca34998 pgaa.so <symbol not found> (/home/postgres/.cargo/git/checkouts/pgrx-f84fa5b2d83bd064/dbd8ac7/pgrx-pg-sys/src/submodules/panic.rs:436)
4    0xffff6c8251d4 pgaa.so spark_sql_wrapper (/app/beacon-analytics/pgaa/src/pg_functions.rs:120)
5    0xaaaac67a5bcc postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/execExprInterp.c:639)
6    0xaaaac67a936c postgres ExecInterpExprStillValid (/app/warehouse-pg/src/backend/executor/execExprInterp.c:1864)
7    0xaaaac6850b20 postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:362)
8    0xaaaac6850bf8 postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:402)
9    0xaaaac685122c postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/nodeResult.c:157)
10   0xaaaac67d4a6c postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/execProcnode.c:645)
11   0xaaaac67d46c4 postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/execProcnode.c:600)
12   0xaaaac67b99f4 postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:271)
13   0xaaaac67c1fb4 postgres <symbol not found> (/app/warehouse-pg/src/backend/executor/execMain.c:2672)
14   0xaaaac67bc2f4 postgres standard_ExecutorRun (/app/warehouse-pg/src/backend/executor/execMain.c:978)
15   0xaaaac67bba64 postgres ExecutorRun (/app/warehouse-pg/src/backend/executor/execMain.c:794)
16   0xaaaac6d6d01c postgres <symbol not found> (/app/warehouse-pg/src/backend/tcop/pquery.c:1151)
17   0xaaaac6d6c890 postgres PortalRun (/app/warehouse-pg/src/backend/tcop/pquery.c:989)
18   0xaaaac6d57e8c postgres <symbol not found> (/app/warehouse-pg/src/backend/tcop/postgres.c:1927)
19   0xaaaac6d65ff8 postgres PostgresMain (/app/warehouse-pg/src/backend/tcop/postgres.c:5460)
20   0xaaaac6bbc53c postgres <symbol not found> (/app/warehouse-pg/src/backend/postmaster/postmaster.c:5591)
21   0xaaaac6bbb1c0 postgres <symbol not found> (/app/warehouse-pg/src/backend/postmaster/postmaster.c:4666)
22   0xaaaac6bafa14 postgres <symbol not found> (/app/warehouse-pg/src/backend/postmaster/postmaster.c:2016)
23   0xaaaac6bae4bc postgres PostmasterMain (/app/warehouse-pg/src/backend/postmaster/postmaster.c:1631)
24   0xaaaac6915658 postgres <symbol not found> (/app/warehouse-pg/src/backend/main/main.c:259)
25   0xffff80e2225c libc.so.6 <symbol not found> (./csu/../sysdeps/nptl/libc_start_call_main.h:74)
26   0xffff80e2233c libc.so.6 __libc_start_main (./csu/../csu/libc-start.c:128)
27   0xaaaac6148170 postgres _start + 0x30
```


The second commit adds further symbol resolution using `nm` for non-dynamic symbols and after that the backtrace looks like this:
```
2026-04-28 20:39:02.639885 UTC,"postgres","postgres",p80727,th-1096708064,"[local]",,2026-04-28 20:39:01 UTC,0,con9,cmd1,seg-1,,,,sx1,"LOG","00000","statement: SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",,,,,,,0,,"postgres.c",1732,
2026-04-28 20:39:02.662737 UTC,"postgres","postgres",p80727,th-1096708064,"[local]",,2026-04-28 20:39:01 UTC,0,con9,cmd1,seg-1,,,,sx1,"LOG","00000","2026-04-28 20:39:02:662343 UTC,THD000,NOTICE,""Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions"",
",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"COptTasks.cpp",267,
2026-04-28 20:39:11.816491 UTC,"postgres","postgres",p80727,th-1096708064,"[local]",,2026-04-28 20:39:01 UTC,0,con9,cmd3,seg-1,,,,sx1,"ERROR","XX000","pgaa.spark_connect_url is not set and SPARK_REMOTE env var is not available (spark.rs:671)",,,,,,"SELECT pgaa.spark_sql('SELECT 1', ARRAY['x']);",0,,"spark.rs",671,"Stack trace:
1    0xaaaac385fc28 postgres errstart (/app/warehouse-pg/src/backend/utils/error/elog.c:484)
2    0xffffb58a1294 pgaa.so pgrx_pg_sys::submodules::panic::do_ereport::do_ereport_impl (/home/postgres/.cargo/git/checkouts/pgrx-f84fa5b2d83bd064/dbd8ac7/pgrx-pg-sys/src/submodules/panic.rs:585)
3    0xffffa9ca4998 pgaa.so pgrx_pg_sys::submodules::panic::pgrx_extern_c_guard (/home/postgres/.cargo/git/checkouts/pgrx-f84fa5b2d83bd064/dbd8ac7/pgrx-pg-sys/src/submodules/panic.rs:436)
4    0xffffa9a951d4 pgaa.so spark_sql_wrapper (/app/beacon-analytics/pgaa/src/pg_functions.rs:120)
5    0xaaaac2f05d4c postgres ExecInterpExpr (/app/warehouse-pg/src/backend/executor/execExprInterp.c:639)
6    0xaaaac2f094ec postgres ExecInterpExprStillValid (/app/warehouse-pg/src/backend/executor/execExprInterp.c:1864)
7    0xaaaac2fb0ca0 postgres ExecEvalExprSwitchContext (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:362)
8    0xaaaac2fb0d78 postgres ExecProject (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:402)
9    0xaaaac2fb13ac postgres ExecResult (/app/warehouse-pg/src/backend/executor/nodeResult.c:157)
10   0xaaaac2f34bec postgres ExecProcNodeGPDB (/app/warehouse-pg/src/backend/executor/execProcnode.c:645)
11   0xaaaac2f34844 postgres ExecProcNodeFirst (/app/warehouse-pg/src/backend/executor/execProcnode.c:600)
12   0xaaaac2f19b74 postgres ExecProcNode (/app/warehouse-pg/src/backend/executor/../../../src/include/executor/executor.h:271)
13   0xaaaac2f22134 postgres ExecutePlan (/app/warehouse-pg/src/backend/executor/execMain.c:2672)
14   0xaaaac2f1c474 postgres standard_ExecutorRun (/app/warehouse-pg/src/backend/executor/execMain.c:978)
15   0xaaaac2f1bbe4 postgres ExecutorRun (/app/warehouse-pg/src/backend/executor/execMain.c:794)
16   0xaaaac34cd19c postgres PortalRunSelect (/app/warehouse-pg/src/backend/tcop/pquery.c:1151)
17   0xaaaac34cca10 postgres PortalRun (/app/warehouse-pg/src/backend/tcop/pquery.c:989)
18   0xaaaac34b800c postgres exec_simple_query (/app/warehouse-pg/src/backend/tcop/postgres.c:1927)
19   0xaaaac34c6178 postgres PostgresMain (/app/warehouse-pg/src/backend/tcop/postgres.c:5460)
20   0xaaaac331c6bc postgres ExitPostmaster (/app/warehouse-pg/src/backend/postmaster/postmaster.c:5591)
21   0xaaaac331b340 postgres BackendStartup (/app/warehouse-pg/src/backend/postmaster/postmaster.c:4666)
22   0xaaaac330fb94 postgres ServerLoop (/app/warehouse-pg/src/backend/postmaster/postmaster.c:2016)
23   0xaaaac330e63c postgres PostmasterMain (/app/warehouse-pg/src/backend/postmaster/postmaster.c:1631)
24   0xaaaac30757d8 postgres startup_hacks (/app/warehouse-pg/src/backend/main/main.c:259)
25   0xffffbe09225c libc.so.6 __libc_start_call_main (./csu/../sysdeps/nptl/libc_start_call_main.h:74)
26   0xffffbe09233c libc.so.6 __libc_start_main (./csu/../csu/libc-start.c:128)
27   0xaaaac28a82f0 postgres _start + 0x30
```

Below is more info about what each commit 

 Add nm-based fallback and addr2line -f for better function name resolution (c49303e144a3f930713a5e8885a87b25b7fb34ce)

  dladdr() only reads the dynamic symbol table (.dynsym), which is sparse —
  static functions, file-scoped helpers, and inlined functions are absent,
  causing many stack frames to show "<symbol not found>".

  Add a three-tier resolution strategy when dladdr fails to provide a
  function name:

  1. addr2line -f (new): add the -f flag so addr2line emits function names
     from DWARF debug info alongside file:line.  This resolves static and
     inline functions that dladdr misses.  Parse the two-line-per-address
     output (function name, then file:line) into a new cmdfunc[] array.

  2. nm (new): when addr2line -f also returns "??", fall back to reading the
     full ELF symbol table (.symtab) via nm.  nm is invoked once per binary,
     parsed into a sorted array, and cached (up to 8 binaries).  Lookup is
     O(log n) binary search on symbol offsets.

  3. "<symbol not found>" as the final fallback, same as before.

  This means unstripped binaries now resolve virtually all function names in
  stack traces, even for static functions that are invisible to dladdr.



Fix addr2line to use file offsets and per-binary invocation (81532595ae3956f62f06e61b2140eed1d356a097)

- fix addr2line invocation
 The existing stacktrace code passed raw virtual addresses (%p) to a single
  addr2line invocation against the main postgres binary.  This produced
  incorrect or "??" results in two cases:

  1. PIE (position-independent executable) builds, where runtime virtual
     addresses differ from the file offsets that addr2line expects.

  2. Stack frames originating in extension shared libraries, which are not
     present in the main postgres binary at all.

  Fix both by using dladdr() to determine which binary each frame belongs to,
  computing file offsets as (VA - load_base), and running a separate addr2line
  invocation per unique binary.

  Also:
  - Replace -s (basename stripping) with -C (C++ symbol demangling) in
    addr2line flags; basename stripping is already handled at display time.
  - Fix inconsistent stack depth limit (was "< 100" in one loop,
    "< STACK_DEPTH_MAX" in another); now uniformly capped via actual_stacksize.
  - Pre-resolve dladdr() for all frames upfront instead of calling it per-frame,
    avoiding redundant lookups in the display loop.
