### PR TITLE
ORCA(fix): Narrow CTE Producer columns in MDQA to Join xform

### DIFF
--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -167,7 +167,7 @@ jobs:
           CC='ccache gcc -m64' \
           CFLAGS='-O2 -g3' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
           ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
-                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
+                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --with-llvm \
                       --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
                       --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
@@ -205,7 +205,7 @@ jobs:
         id: cluster
         run: |
           source concourse/scripts/common.bash
-          export WITH_MIRRORS=false
+          export WITH_MIRRORS=true
           make_cluster
 
       - name: Run installcheck tests

--- a/src/backend/gporca/data/dxl/minidump/MDQA_PartTable_DynScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQA_PartTable_DynScan.mdp
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Background -
+        Tests an orca crash when the optimizer rewrites a query
+        with multiple distinct-qualified aggregates (MDQAs) over a partitioned
+        table. `CXformGbAggWithMDQA2Join` was declaring every column the
+        child could produce on the CTE Producer, rather than just the columns
+        the GbAgg actually needs. On the partitioned-table path the over-declared
+        columns include unreferenced and system columns whose `EUsage` state
+        is `EUnknown`/`EUnused`, violating an invariant in `MakeDXLTableDescr`
+        that requires required columns to be `EUsed`.
+
+        Query & Plan:
+        --------------------
+        CREATE TABLE mdqa_part(
+          a int,    -- group-by key + distribution key
+          b int,    -- DISTINCT arg
+          c int,    -- DISTINCT arg
+          d int     -- unused unless explicitly referenced
+        )
+        DISTRIBUTED BY (a)
+        PARTITION BY RANGE(a) (
+          START (0) END (100) EVERY (50),
+          DEFAULT PARTITION other
+        );
+        INSERT INTO mdqa_part SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+        CREATE INDEX mdqa_part_b_idx ON mdqa_part(b);
+        ANALYZE mdqa_part;
+        SELECT a,
+               count(DISTINCT b) AS cnt_b,
+               count(DISTINCT c) AS cnt_c
+          FROM mdqa_part WHERE b BETWEEN 0 AND 2 GROUP BY a;
+
+        postgres=# explain SELECT a,                                                                                                                                                                count(DISTINCT b) AS cnt_b,                                                                                                                                                          count(DISTINCT c) AS cnt_c                                                                                                                                                      FROM mdqa_part                                                                                                                                                                      WHERE b BETWEEN 0 AND 2                                                                                                                                                              GROUP BY a;
+                                                        QUERY PLAN
+        ----------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=20)
+           ->  Sequence  (cost=0.00..868.00 rows=1 width=20)
+                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..6.00 rows=1 width=1)
+                       ->  Dynamic Index Scan on mdqa_part_b_idx on mdqa_part  (cost=0.00..6.00 rows=1 width=12)
+                             Index Cond: ((b >= 0) AND (b <= 2))
+                             Number of partitions to scan: 3 (out of 3)
+                 ->  Hash Join  (cost=0.00..862.00 rows=1 width=20)
+                       Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+                       ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                             Group Key: share0_ref3.a
+                             ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                   Sort Key: share0_ref3.a
+                                   ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                   Group Key: share0_ref2.a
+                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                         Sort Key: share0_ref2.a
+                                         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
+         Optimizer: GPORCA
+        (20 rows)
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="6.29887.1.0" Name="mdqa_part_1_prt_other" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.29899.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:Or>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                  </dxl:Comparison>
+                </dxl:And>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                    <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+                  </dxl:Comparison>
+                </dxl:And>
+              </dxl:Or>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.29884.1.0" Name="mdqa_part" Rows="0.000000" RelPages="3" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.29884.1.0" Name="mdqa_part" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,10,4" PartitionColumns="0" PartitionTypes="r">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.29896.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.29890.1.0"/>
+          <dxl:Partition Mdid="6.29893.1.0"/>
+          <dxl:Partition Mdid="6.29887.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.29884.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationExtendedStatistics Mdid="10.29884.1.0" Name="mdqa_part"/>
+      <dxl:Relation Mdid="6.29890.1.0" Name="mdqa_part_1_prt_2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.29897.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Index Mdid="7.29896.1.0" Name="mdqa_part_b_idx" IsClustered="false" AmCanOrder="true" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="" ReturnableColumns="1" SortDirection="ASC" NullsDirection="LAST">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="0.29897.1.0"/>
+          <dxl:Partition Mdid="0.29898.1.0"/>
+          <dxl:Partition Mdid="0.29899.1.0"/>
+        </dxl:Partitions>
+      </dxl:Index>
+      <dxl:Relation Mdid="6.29893.1.0" Name="mdqa_part_1_prt_3" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="10,4">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.29898.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="100"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.29884.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29884.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="12" ColName="cnt_b" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="13" ColName="cnt_c" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="1"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="cnt_b">
+            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" AggArgTypes="23">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct">
+                <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="cnt_c">
+            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" AggArgTypes="23">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct">
+                <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalSelect>
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+            </dxl:Comparison>
+          </dxl:And>
+          <dxl:LogicalGet HasSecurityQuals="false">
+            <dxl:TableDescriptor Mdid="6.29884.1.0" TableName="mdqa_part" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="10384">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="868.001037" Rows="1.000000" Width="20"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="11" Alias="cnt_b">
+            <dxl:Ident ColId="11" ColName="cnt_b" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="cnt_c">
+            <dxl:Ident ColId="12" ColName="cnt_c" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Sequence>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="868.000963" Rows="1.000000" Width="20"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="11" Alias="cnt_b">
+              <dxl:Ident ColId="11" ColName="cnt_b" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="12" Alias="cnt_c">
+              <dxl:Ident ColId="12" ColName="cnt_c" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:CTEProducer CTEId="0" Columns="13,14,15">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="6.000130" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="13" Alias="a">
+                <dxl:Ident ColId="13" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="b">
+                <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="c">
+                <dxl:Ident ColId="15" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:DynamicIndexScan IndexScanDirection="Forward" SelectorIds="">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="6.000111" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="13" Alias="a">
+                  <dxl:Ident ColId="13" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="b">
+                  <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="c">
+                  <dxl:Ident ColId="15" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:IndexCondList>
+                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                  <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                  <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:Comparison>
+              </dxl:IndexCondList>
+              <dxl:Partitions>
+                <dxl:Partition Mdid="6.29890.1.0"/>
+                <dxl:Partition Mdid="6.29893.1.0"/>
+                <dxl:Partition Mdid="6.29887.1.0"/>
+              </dxl:Partitions>
+              <dxl:IndexDescriptor Mdid="7.29896.1.0" IndexName="mdqa_part_b_idx"/>
+              <dxl:TableDescriptor Mdid="6.29884.1.0" TableName="mdqa_part" LockMode="1" AclMode="2">
+                <dxl:Columns>
+                  <dxl:Column ColId="13" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicIndexScan>
+          </dxl:CTEProducer>
+          <dxl:HashJoin JoinType="Inner">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000826" Rows="1.000000" Width="20"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="cnt_b">
+                <dxl:Ident ColId="11" ColName="cnt_b" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="cnt_c">
+                <dxl:Ident ColId="12" ColName="cnt_c" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="0"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="cnt_b">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct">
+                      <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+                    </dxl:ValuesList>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="c">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:CTEConsumer CTEId="0" Columns="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="c">
+                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+              </dxl:Sort>
+            </dxl:Aggregate>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="32"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="12" Alias="cnt_c">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" AggArgTypes="23">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct">
+                      <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+                    </dxl:ValuesList>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="32" Alias="a">
+                  <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000110" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="32" Alias="a">
+                    <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="33" Alias="b">
+                    <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="34" Alias="c">
+                    <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:CTEConsumer CTEId="0" Columns="32,33,34">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="32" Alias="a">
+                      <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="33" Alias="b">
+                      <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="34" Alias="c">
+                      <dxl:Ident ColId="34" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                </dxl:CTEConsumer>
+              </dxl:Sort>
+            </dxl:Aggregate>
+          </dxl:HashJoin>
+        </dxl:Sequence>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -458,7 +458,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="9296">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.104458" Rows="10.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.101361" Rows="10.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -473,7 +473,7 @@ SQL:
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.104258" Rows="10.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.101161" Rows="10.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -492,7 +492,7 @@ SQL:
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.103360" Rows="10.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.100263" Rows="10.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -507,7 +507,7 @@ SQL:
             </dxl:ProjList>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.103260" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.100163" Rows="111.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -528,7 +528,7 @@ SQL:
               <dxl:LimitOffset/>
               <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.063695" Rows="111.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -541,9 +541,9 @@ SQL:
                     <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+                <dxl:CTEProducer CTEId="0" Columns="11,12">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.002041" Rows="111.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="11" Alias="a">
@@ -552,31 +552,10 @@ SQL:
                     <dxl:ProjElem ColId="12" Alias="b">
                       <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="13" Alias="ctid">
-                      <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="14" Alias="xmin">
-                      <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="15" Alias="cmin">
-                      <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="xmax">
-                      <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="17" Alias="cmax">
-                      <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="18" Alias="tableoid">
-                      <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                      <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="a">
@@ -584,27 +563,6 @@ SQL:
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="12" Alias="b">
                         <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="13" Alias="ctid">
-                        <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="14" Alias="xmin">
-                        <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="15" Alias="cmin">
-                        <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="16" Alias="xmax">
-                        <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="17" Alias="cmax">
-                        <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="18" Alias="tableoid">
-                        <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                        <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -644,7 +602,7 @@ SQL:
                     <dxl:Not>
                       <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                         <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:IsDistinctFrom>
                     </dxl:Not>
                   </dxl:HashCondList>
@@ -695,27 +653,6 @@ SQL:
                           <dxl:ProjElem ColId="1" Alias="b">
                             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="xmin">
-                            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="4" Alias="cmin">
-                            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="5" Alias="xmax">
-                            <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="cmax">
-                            <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="7" Alias="tableoid">
-                            <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
@@ -723,7 +660,7 @@ SQL:
                         </dxl:SortingColumnList>
                         <dxl:LimitCount/>
                         <dxl:LimitOffset/>
-                        <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                        <dxl:CTEConsumer CTEId="0" Columns="0,1">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                           </dxl:Properties>
@@ -733,27 +670,6 @@ SQL:
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="1" Alias="b">
                               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="ctid">
-                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="3" Alias="xmin">
-                              <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="4" Alias="cmin">
-                              <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="5" Alias="xmax">
-                              <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="6" Alias="cmax">
-                              <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="7" Alias="tableoid">
-                              <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                         </dxl:CTEConsumer>
@@ -765,21 +681,21 @@ SQL:
                       <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="20"/>
+                      <dxl:GroupingColumn ColId="27"/>
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="10" Alias="count">
                         <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
                           <dxl:ValuesList ParamType="aggdistinct"/>
                         </dxl:AggFunc>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="20" Alias="a">
-                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="27" Alias="a">
+                        <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -788,15 +704,15 @@ SQL:
                         <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="20"/>
-                        <dxl:GroupingColumn ColId="21"/>
+                        <dxl:GroupingColumn ColId="27"/>
+                        <dxl:GroupingColumn ColId="28"/>
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="20" Alias="a">
-                          <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="27" Alias="a">
+                          <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="21" Alias="b">
-                          <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="28" Alias="b">
+                          <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
@@ -805,72 +721,30 @@ SQL:
                           <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="20" Alias="a">
-                            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="27" Alias="a">
+                            <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="21" Alias="b">
-                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="22" Alias="ctid">
-                            <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="23" Alias="xmin">
-                            <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="24" Alias="cmin">
-                            <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="25" Alias="xmax">
-                            <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="26" Alias="cmax">
-                            <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="27" Alias="tableoid">
-                            <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="28" Alias="gp_segment_id">
-                            <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="28" Alias="b">
+                            <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          <dxl:SortingColumn ColId="21" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="28" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                         </dxl:SortingColumnList>
                         <dxl:LimitCount/>
                         <dxl:LimitOffset/>
-                        <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                        <dxl:CTEConsumer CTEId="0" Columns="27,28">
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="20" Alias="a">
-                              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="27" Alias="a">
+                              <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="21" Alias="b">
-                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="22" Alias="ctid">
-                              <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="23" Alias="xmin">
-                              <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="24" Alias="cmin">
-                              <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="25" Alias="xmax">
-                              <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="26" Alias="cmax">
-                              <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="27" Alias="tableoid">
-                              <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="28" Alias="gp_segment_id">
-                              <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="28" Alias="b">
+                              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                         </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
@@ -449,7 +449,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="8288">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.076760" Rows="111.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.073663" Rows="111.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -466,7 +466,7 @@ SQL:
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.063695" Rows="111.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -479,9 +479,9 @@ SQL:
               <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+          <dxl:CTEProducer CTEId="0" Columns="11,12">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.002041" Rows="111.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="a">
@@ -490,31 +490,10 @@ SQL:
               <dxl:ProjElem ColId="12" Alias="b">
                 <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="13" Alias="ctid">
-                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="14" Alias="xmin">
-                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="cmin">
-                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="xmax">
-                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="cmax">
-                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="tableoid">
-                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="a">
@@ -522,27 +501,6 @@ SQL:
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="12" Alias="b">
                   <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="13" Alias="ctid">
-                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="14" Alias="xmin">
-                  <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="15" Alias="cmin">
-                  <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="xmax">
-                  <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="cmax">
-                  <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="tableoid">
-                  <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -582,7 +540,7 @@ SQL:
               <dxl:Not>
                 <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:IsDistinctFrom>
               </dxl:Not>
             </dxl:HashCondList>
@@ -633,27 +591,6 @@ SQL:
                     <dxl:ProjElem ColId="1" Alias="b">
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="xmin">
-                      <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="4" Alias="cmin">
-                      <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="xmax">
-                      <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="cmax">
-                      <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="tableoid">
-                      <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList>
@@ -661,7 +598,7 @@ SQL:
                   </dxl:SortingColumnList>
                   <dxl:LimitCount/>
                   <dxl:LimitOffset/>
-                  <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                     </dxl:Properties>
@@ -671,27 +608,6 @@ SQL:
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="1" Alias="b">
                         <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="xmin">
-                        <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="4" Alias="cmin">
-                        <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="5" Alias="xmax">
-                        <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="6" Alias="cmax">
-                        <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="7" Alias="tableoid">
-                        <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                   </dxl:CTEConsumer>
@@ -703,21 +619,21 @@ SQL:
                 <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="20"/>
+                <dxl:GroupingColumn ColId="27"/>
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="count">
                   <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                     <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ValuesList>
                     <dxl:ValuesList ParamType="aggdirectargs"/>
                     <dxl:ValuesList ParamType="aggorder"/>
                     <dxl:ValuesList ParamType="aggdistinct"/>
                   </dxl:AggFunc>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="a">
-                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="27" Alias="a">
+                  <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -726,15 +642,15 @@ SQL:
                   <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="20"/>
-                  <dxl:GroupingColumn ColId="21"/>
+                  <dxl:GroupingColumn ColId="27"/>
+                  <dxl:GroupingColumn ColId="28"/>
                 </dxl:GroupingColumns>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="20" Alias="a">
-                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="27" Alias="a">
+                    <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="21" Alias="b">
-                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="28" Alias="b">
+                    <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
@@ -743,72 +659,30 @@ SQL:
                     <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="a">
-                      <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="27" Alias="a">
+                      <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="21" Alias="b">
-                      <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="22" Alias="ctid">
-                      <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="23" Alias="xmin">
-                      <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="cmin">
-                      <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="xmax">
-                      <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="cmax">
-                      <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="tableoid">
-                      <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="gp_segment_id">
-                      <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="28" Alias="b">
+                      <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    <dxl:SortingColumn ColId="21" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="27" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="28" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                   </dxl:SortingColumnList>
                   <dxl:LimitCount/>
                   <dxl:LimitOffset/>
-                  <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                  <dxl:CTEConsumer CTEId="0" Columns="27,28">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="a">
-                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="27" Alias="a">
+                        <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="21" Alias="b">
-                        <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="22" Alias="ctid">
-                        <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="23" Alias="xmin">
-                        <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="24" Alias="cmin">
-                        <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="25" Alias="xmax">
-                        <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="26" Alias="cmax">
-                        <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="27" Alias="tableoid">
-                        <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="28" Alias="gp_segment_id">
-                        <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="28" Alias="b">
+                        <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                   </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -499,10 +499,10 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="398361600">
+    <dxl:Plan Id="0" SpaceSize="207648000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2586.144639" Rows="134.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.138293" Rows="134.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -519,7 +519,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2586.132606" Rows="134.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.126260" Rows="134.000000" Width="20"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -540,7 +540,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
           <dxl:Filter/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2586.107284" Rows="134.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.100938" Rows="134.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -556,7 +556,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
             <dxl:Filter/>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.063695" Rows="111.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -569,84 +569,42 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:CTEProducer CTEId="1" Columns="42,43,44,45,46,47,48,49,50">
+              <dxl:CTEProducer CTEId="1" Columns="49,50">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.002041" Rows="111.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="42" Alias="a">
-                    <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="49" Alias="a">
+                    <dxl:Ident ColId="49" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="43" Alias="b">
-                    <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="44" Alias="ctid">
-                    <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="45" Alias="xmin">
-                    <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="46" Alias="cmin">
-                    <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="47" Alias="xmax">
-                    <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="48" Alias="cmax">
-                    <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="49" Alias="tableoid">
-                    <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="50" Alias="gp_segment_id">
-                    <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="50" Alias="b">
+                    <dxl:Ident ColId="50" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="42" Alias="a">
-                      <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="49" Alias="a">
+                      <dxl:Ident ColId="49" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="43" Alias="b">
-                      <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="44" Alias="ctid">
-                      <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="45" Alias="xmin">
-                      <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="46" Alias="cmin">
-                      <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="47" Alias="xmax">
-                      <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="48" Alias="cmax">
-                      <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="49" Alias="tableoid">
-                      <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="gp_segment_id">
-                      <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="50" Alias="b">
+                      <dxl:Ident ColId="50" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
                     <dxl:Columns>
-                      <dxl:Column ColId="42" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="43" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="49" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="50" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="51" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="52" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="53" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="54" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="55" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="56" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="57" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
@@ -672,7 +630,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Not>
                     <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:IsDistinctFrom>
                   </dxl:Not>
                 </dxl:HashCondList>
@@ -723,27 +681,6 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                         <dxl:ProjElem ColId="1" Alias="b">
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="xmin">
-                          <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="4" Alias="cmin">
-                          <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="xmax">
-                          <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="cmax">
-                          <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="tableoid">
-                          <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList>
@@ -751,7 +688,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                       </dxl:SortingColumnList>
                       <dxl:LimitCount/>
                       <dxl:LimitOffset/>
-                      <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8">
+                      <dxl:CTEConsumer CTEId="1" Columns="0,1">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                         </dxl:Properties>
@@ -761,27 +698,6 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="1" Alias="b">
                             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="xmin">
-                            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="4" Alias="cmin">
-                            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="5" Alias="xmax">
-                            <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="6" Alias="cmax">
-                            <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="7" Alias="tableoid">
-                            <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                       </dxl:CTEConsumer>
@@ -793,21 +709,21 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                     <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="51"/>
+                    <dxl:GroupingColumn ColId="65"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="10" Alias="count">
                       <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="66" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
                         <dxl:ValuesList ParamType="aggdistinct"/>
                       </dxl:AggFunc>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="a">
-                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="65" Alias="a">
+                      <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -816,15 +732,15 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                       <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="51"/>
-                      <dxl:GroupingColumn ColId="52"/>
+                      <dxl:GroupingColumn ColId="65"/>
+                      <dxl:GroupingColumn ColId="66"/>
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="51" Alias="a">
-                        <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="65" Alias="a">
+                        <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="52" Alias="b">
-                        <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="66" Alias="b">
+                        <dxl:Ident ColId="66" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -833,72 +749,30 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                         <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="51" Alias="a">
-                          <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="65" Alias="a">
+                          <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="52" Alias="b">
-                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="53" Alias="ctid">
-                          <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="54" Alias="xmin">
-                          <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="55" Alias="cmin">
-                          <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="56" Alias="xmax">
-                          <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="57" Alias="cmax">
-                          <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="58" Alias="tableoid">
-                          <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="59" Alias="gp_segment_id">
-                          <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="66" Alias="b">
+                          <dxl:Ident ColId="66" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="51" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="52" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="65" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="66" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                       </dxl:SortingColumnList>
                       <dxl:LimitCount/>
                       <dxl:LimitOffset/>
-                      <dxl:CTEConsumer CTEId="1" Columns="51,52,53,54,55,56,57,58,59">
+                      <dxl:CTEConsumer CTEId="1" Columns="65,66">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="51" Alias="a">
-                            <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="65" Alias="a">
+                            <dxl:Ident ColId="65" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="52" Alias="b">
-                            <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="53" Alias="ctid">
-                            <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="54" Alias="xmin">
-                            <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="55" Alias="cmin">
-                            <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="56" Alias="xmax">
-                            <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="57" Alias="cmax">
-                            <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="58" Alias="tableoid">
-                            <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="59" Alias="gp_segment_id">
-                            <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="66" Alias="b">
+                            <dxl:Ident ColId="66" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                       </dxl:CTEConsumer>
@@ -909,7 +783,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
             </dxl:Sequence>
             <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.039152" Rows="23.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.035903" Rows="23.000000" Width="20"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="b">
@@ -922,9 +796,9 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30">
+              <dxl:CTEProducer CTEId="0" Columns="22,23">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.003431" Rows="111.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="22" Alias="a">
@@ -933,31 +807,10 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:ProjElem ColId="23" Alias="b">
                     <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="24" Alias="ctid">
-                    <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="25" Alias="xmin">
-                    <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="26" Alias="cmin">
-                    <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="27" Alias="xmax">
-                    <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="cmax">
-                    <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="29" Alias="tableoid">
-                    <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="gp_segment_id">
-                    <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:TableScan>
+                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.003376" Rows="111.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="22" Alias="a">
@@ -966,47 +819,46 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                     <dxl:ProjElem ColId="23" Alias="b">
                       <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="24" Alias="ctid">
-                      <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="25" Alias="xmin">
-                      <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="26" Alias="cmin">
-                      <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="27" Alias="xmax">
-                      <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="cmax">
-                      <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="29" Alias="tableoid">
-                      <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="gp_segment_id">
-                      <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr>
+                      <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="22" Alias="a">
+                        <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="23" Alias="b">
+                        <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
               </dxl:CTEProducer>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.033784" Rows="23.000000" Width="20"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.032242" Rows="23.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="b">
@@ -1025,22 +877,22 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                   <dxl:Not>
                     <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:IsDistinctFrom>
                   </dxl:Not>
                 </dxl:HashCondList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.018084" Rows="23.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.016872" Rows="23.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="12"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                          <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
@@ -1052,257 +904,125 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.016611" Rows="23.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="12"/>
+                      <dxl:GroupingColumn ColId="11"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="a">
+                        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="12" Alias="b">
                         <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr>
-                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Result>
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="a">
+                          <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="12" Alias="b">
                           <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:CTEConsumer CTEId="0" Columns="11,12">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="12"/>
-                        </dxl:GroupingColumns>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs">
-                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ValuesList>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
+                          <dxl:ProjElem ColId="11" Alias="a">
+                            <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                           <dxl:ProjElem ColId="12" Alias="b">
                             <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:Sort SortDiscardDuplicates="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="11" Alias="a">
-                              <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="12" Alias="b">
-                              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="13" Alias="ctid">
-                              <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="14" Alias="xmin">
-                              <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="15" Alias="cmin">
-                              <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="16" Alias="xmax">
-                              <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="17" Alias="cmax">
-                              <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="18" Alias="tableoid">
-                              <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                              <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:LimitCount/>
-                          <dxl:LimitOffset/>
-                          <dxl:CTEConsumer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="11" Alias="a">
-                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="12" Alias="b">
-                                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="13" Alias="ctid">
-                                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="14" Alias="xmin">
-                                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="15" Alias="cmin">
-                                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="16" Alias="xmax">
-                                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="17" Alias="cmax">
-                                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="18" Alias="tableoid">
-                                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Sort>
-                      </dxl:Aggregate>
-                    </dxl:Result>
-                  </dxl:RedistributeMotion>
+                      </dxl:CTEConsumer>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
                 </dxl:Aggregate>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.008530" Rows="23.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.008200" Rows="23.000000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="32"/>
+                    <dxl:GroupingColumn ColId="39"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="21" Alias="count">
                       <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
                         <dxl:ValuesList ParamType="aggdistinct"/>
                       </dxl:AggFunc>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="32" Alias="b">
-                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="39" Alias="b">
+                      <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.008406" Rows="23.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008076" Rows="23.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="32"/>
+                      <dxl:GroupingColumn ColId="39"/>
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="32" Alias="b">
-                        <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="39" Alias="b">
+                        <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.008334" Rows="23.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="32" Alias="b">
-                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="38" Alias="a">
+                          <dxl:Ident ColId="38" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="39" Alias="b">
+                          <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="39" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                       </dxl:SortingColumnList>
                       <dxl:LimitCount/>
                       <dxl:LimitOffset/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:CTEConsumer CTEId="0" Columns="38,39">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.007415" Rows="23.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="32" Alias="b">
-                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="38" Alias="a">
+                            <dxl:Ident ColId="38" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="39" Alias="b">
+                            <dxl:Ident ColId="39" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.007271" Rows="23.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="32"/>
-                          </dxl:GroupingColumns>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="32" Alias="b">
-                              <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="31,32,33,34,35,36,37,38,39">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="31" Alias="a">
-                                <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="32" Alias="b">
-                                <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="33" Alias="ctid">
-                                <dxl:Ident ColId="33" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="34" Alias="xmin">
-                                <dxl:Ident ColId="34" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="35" Alias="cmin">
-                                <dxl:Ident ColId="35" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="36" Alias="xmax">
-                                <dxl:Ident ColId="36" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="37" Alias="cmax">
-                                <dxl:Ident ColId="37" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="38" Alias="tableoid">
-                                <dxl:Ident ColId="38" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="39" Alias="gp_segment_id">
-                                <dxl:Ident ColId="39" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                          </dxl:CTEConsumer>
-                        </dxl:Aggregate>
-                      </dxl:RedistributeMotion>
+                      </dxl:CTEConsumer>
                     </dxl:Sort>
                   </dxl:Aggregate>
                 </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
@@ -455,7 +455,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="1010">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.007238" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.004141" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="sum">
@@ -469,7 +469,7 @@ SQL:
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.007166" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.004069" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="sum">
@@ -479,9 +479,9 @@ SQL:
               <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+          <dxl:CTEProducer CTEId="0" Columns="11,12">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.002041" Rows="111.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="a">
@@ -490,31 +490,10 @@ SQL:
               <dxl:ProjElem ColId="12" Alias="b">
                 <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="13" Alias="ctid">
-                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="14" Alias="xmin">
-                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="15" Alias="cmin">
-                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="16" Alias="xmax">
-                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="17" Alias="cmax">
-                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="tableoid">
-                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="a">
@@ -522,27 +501,6 @@ SQL:
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="12" Alias="b">
                   <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="13" Alias="ctid">
-                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="14" Alias="xmin">
-                  <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="15" Alias="cmin">
-                  <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="16" Alias="xmax">
-                  <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="cmax">
-                  <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="tableoid">
-                  <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -600,7 +558,7 @@ SQL:
                   <dxl:ProjElem ColId="9" Alias="sum">
                     <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                        <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -614,8 +572,8 @@ SQL:
                     <dxl:Cost StartupCost="0" TotalCost="431.000596" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="37" Alias="ColRef_0037">
+                      <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -626,7 +584,7 @@ SQL:
                     </dxl:Properties>
                     <dxl:GroupingColumns/>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                      <dxl:ProjElem ColId="37" Alias="ColRef_0037">
                         <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -638,7 +596,7 @@ SQL:
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                    <dxl:CTEConsumer CTEId="0" Columns="0,1">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                       </dxl:Properties>
@@ -648,27 +606,6 @@ SQL:
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="1" Alias="b">
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="xmin">
-                          <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="4" Alias="cmin">
-                          <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="5" Alias="xmax">
-                          <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="6" Alias="cmax">
-                          <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="7" Alias="tableoid">
-                          <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                     </dxl:CTEConsumer>
@@ -694,7 +631,7 @@ SQL:
                     <dxl:ProjElem ColId="10" Alias="avg">
                       <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
                         <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.17.1.0"/>
+                          <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.17.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
@@ -708,8 +645,8 @@ SQL:
                       <dxl:Cost StartupCost="0" TotalCost="431.001291" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                        <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.17.1.0"/>
+                      <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+                        <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.17.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -720,10 +657,10 @@ SQL:
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                        <dxl:ProjElem ColId="36" Alias="ColRef_0036">
                           <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
                             <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>
@@ -737,15 +674,15 @@ SQL:
                           <dxl:Cost StartupCost="0" TotalCost="431.001230" Rows="111.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="21" Alias="b">
-                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="28" Alias="b">
+                            <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
                           <dxl:HashExpr>
-                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
                         <dxl:Result>
@@ -753,43 +690,22 @@ SQL:
                             <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="21" Alias="b">
-                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="28" Alias="b">
+                              <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
-                          <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                          <dxl:CTEConsumer CTEId="0" Columns="27,28">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="20" Alias="a">
-                                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="27" Alias="a">
+                                <dxl:Ident ColId="27" ColName="a" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="21" Alias="b">
-                                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="22" Alias="ctid">
-                                <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="23" Alias="xmin">
-                                <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="24" Alias="cmin">
-                                <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="25" Alias="xmax">
-                                <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="26" Alias="cmax">
-                                <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="27" Alias="tableoid">
-                                <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="28" Alias="gp_segment_id">
-                                <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="28" Alias="b">
+                                <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                           </dxl:CTEConsumer>

--- a/src/backend/gporca/libgpopt/src/xforms/CXformGbAggWithMDQA2Join.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformGbAggWithMDQA2Join.cpp
@@ -98,10 +98,21 @@ CXformGbAggWithMDQA2Join::PexprMDQAs2Join(CMemoryPool *mp, CExpression *pexpr)
 	GPOS_ASSERT((*pexpr)[1]->DeriveHasMultipleDistinctAggs());
 
 	// extract components
+	CLogicalGbAgg *popGbAgg = CLogicalGbAgg::PopConvert(pexpr->Pop());
 	CExpression *pexprChild = (*pexpr)[0];
+	CExpression *pexprAggList = (*pexpr)[1];	// GbAgg's scalar child
 
+	// Compute the columns actually needed by the GbAgg:
+	//		group-by keys + aggregate-argument references
+	// Clip to what the child can provide.
 	CColRefSet *pcrsChildOutput = pexprChild->DeriveOutputColumns();
-	CColRefArray *pdrgpcrChildOutput = pcrsChildOutput->Pdrgpcr(mp);
+	CColRefSet *pcrsAggListRefs = pexprAggList->DeriveUsedColumns();	// cols read by aggregate args
+	CColRefSet *pcrsUsed = GPOS_NEW(mp) CColRefSet(mp);
+	pcrsUsed->Include(popGbAgg->Pdrgpcr());		// group-by keys
+	pcrsUsed->Union(pcrsAggListRefs);			// agg-list refs
+	pcrsUsed->Intersection(pcrsChildOutput);	// clip to producible
+	CColRefArray *pdrgpcrChildOutput = pcrsUsed->Pdrgpcr(mp);
+	pcrsUsed->Release();
 
 	// create a CTE producer based on child expression
 	CCTEInfo *pcteinfo = COptCtxt::PoctxtFromTLS()->Pcteinfo();

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -362,7 +362,7 @@ InsertNonSingleton NonSingleton TaintedReplicatedAgg TaintedReplicatedWindowAgg 
 InsertReplicatedIntoSerialHashDistributedTable TaintedReplicatedTablesCTE ReplicatedTableWithAggNoMotion;
 
 CDqaTest:
-NonSplittableAgg DqaHavingMax DqaMax DqaMin DqaSubqueryMax DqaNoRedistribute DistinctQueryWithMotions;
+NonSplittableAgg DqaHavingMax DqaMax DqaMin DqaSubqueryMax DqaNoRedistribute DistinctQueryWithMotions MDQA_PartTable_DynScan;
 
 CMCVCardinalityTest:
 BpCharMCVCardinalityEquals BpCharMCVCardinalityGreaterThan

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -3605,13 +3605,13 @@ CREATE TABLE sales (
   sale_amt   numeric(18,3)
 ) DISTRIBUTED BY (sale_key);
 INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
-SELECT 
+SELECT
     '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
     'KEY-' || i AS sale_key,
     'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
     ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
 FROM (
-    SELECT 
+    SELECT
         i,
         (i - 1) % 1000 AS c,
         (i - 1) / 1000 AS r
@@ -3619,11 +3619,11 @@ FROM (
 ) sub;
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
-                                                            QUERY PLAN                                                            
+                                                            QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
    Output: count(*)
@@ -3649,11 +3649,11 @@ SELECT count(*) FROM (
 
 -- Without this patch, this SQL will output 78, which is not correct
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count 
+ count
 -------
    236
 (1 row)
@@ -3662,11 +3662,11 @@ SELECT count(*) FROM (
 SET optimizer_enable_multiple_distinct_aggs=on;
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
-                                                            QUERY PLAN                                                            
+                                                            QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
    Output: count(*)
@@ -3695,9 +3695,755 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count 
+ count
 -------
    236
 (1 row)
 
 DROP TABLE sales;
+-----------------------------------------------------------------------------
+-- Tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS schema_mdqa;
+SET search_path = schema_mdqa, public;
+SET optimizer_enable_multiple_distinct_aggs = on;
+-----------------------------------------------------------------------------
+-- Setup: two partitioned tables, one heap table.
+-----------------------------------------------------------------------------
+-- Partitioned, distributed by group-by key.
+CREATE TABLE mdqa_part(
+  a int,    -- group-by key + distribution key
+  b int,    -- DISTINCT arg
+  c int,    -- DISTINCT arg
+  d int     -- unused unless explicitly referenced
+)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_part SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+CREATE INDEX mdqa_part_b_idx ON mdqa_part(b);
+ANALYZE mdqa_part;
+-- Partitioned, distributed by a column NOT used in the query.
+CREATE TABLE mdqa_dist_unused(
+  a int,        -- group-by key
+  b int,
+  c int,
+  dist_col int  -- distribution key, never referenced in any test query
+)
+DISTRIBUTED BY (dist_col)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_dist_unused SELECT i, i%5, i%3, i%11
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_dist_unused;
+-- Non-partitioned control. Same shape, heap table.
+CREATE TABLE mdqa_heap(a int, b int, c int, d int) DISTRIBUTED BY (a);
+INSERT INTO mdqa_heap SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+ANALYZE mdqa_heap;
+-- Based on crashing query
+CREATE TABLE orders(
+  order_date  date,
+  account_id  int,
+  region      text,
+  order_id    int,
+  amount      numeric(15,2)
+)
+DISTRIBUTED BY (account_id)
+PARTITION BY RANGE(order_date) (
+  START ('2026-04-01'::date) END ('2026-04-08'::date) EVERY ('1 day'::interval),
+  DEFAULT PARTITION other
+);
+INSERT INTO orders
+  SELECT ('2026-04-01'::date + ((i % 7) || ' days')::interval)::date,
+         i % 20,
+         CASE WHEN i % 3 = 0 THEN 'NORTH' ELSE 'SOUTH' END,
+         i,
+         (i * 1000)::numeric(15,2)
+  FROM generate_series(1, 200) i;
+ANALYZE orders;
+-----------------------------------------------------------------------------
+-- Test 1 - minimal MDQA on partitioned table.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 2 - with selective predicate + index to encourage a dynamic scan.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE b BETWEEN 0 AND 2
+ GROUP BY a;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                             Filter: ((b >= 0) AND (b <= 2))
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                             Filter: ((b >= 0) AND (b <= 2))
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+                                             Filter: ((b >= 0) AND (b <= 2))
+ Optimizer: Postgres-based planner
+(20 rows)
+
+-----------------------------------------------------------------------------
+-- Test 3 - system column (ctid) as a DISTINCT argument.
+-- Validates the fix correctly INCLUDES referenced system columns in the
+-- CTEproducer
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT ctid) AS distinct_rows,
+       count(DISTINCT b)    AS distinct_b
+  FROM mdqa_part
+ GROUP BY a;
+                                                    QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.ctid, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.ctid, mdqa_part_1_prt_2.b, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.ctid), (mdqa_part_1_prt_2.b)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 4 - group-by key referenced ONLY in GROUP BY clause —
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part
+ GROUP BY a;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 5 - distribution key NOT referenced anywhere in the query.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_dist_unused
+ GROUP BY a;
+                                                             QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_dist_unused_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_dist_unused_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_dist_unused_1_prt_2.b, mdqa_dist_unused_1_prt_2.c, mdqa_dist_unused_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_dist_unused_1_prt_2.a, mdqa_dist_unused_1_prt_2.b, mdqa_dist_unused_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_dist_unused_1_prt_2.b), (mdqa_dist_unused_1_prt_2.c)
+                                 Group Key: mdqa_dist_unused_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_dist_unused_1_prt_2
+                                       ->  Seq Scan on mdqa_dist_unused_1_prt_3
+                                       ->  Seq Scan on mdqa_dist_unused_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 6 - MDQA with NO GROUP BY (single global aggregation).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part;
+                                      QUERY PLAN
+--------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                     ->  TupleSplit
+                           Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                           ->  Append
+                                 ->  Seq Scan on mdqa_part_1_prt_2
+                                 ->  Seq Scan on mdqa_part_1_prt_3
+                                 ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(12 rows)
+
+-----------------------------------------------------------------------------
+-- Test 7 - mix of agg functions
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       sum(DISTINCT c)   AS sum_c,
+       avg(DISTINCT b)   AS avg_b,
+       min(DISTINCT c)   AS min_c,
+       max(DISTINCT d)   AS max_d,
+       sum(d)            AS plain_sum_d
+  FROM mdqa_part
+ GROUP BY a
+ ORDER BY a;
+                                                                QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: mdqa_part_1_prt_2.a
+   ->  Finalize HashAggregate
+         Group Key: mdqa_part_1_prt_2.a
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Partial HashAggregate
+                     Group Key: mdqa_part_1_prt_2.a
+                     ->  Partial HashAggregate
+                           Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.d, mdqa_part_1_prt_2.a
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.d, (AggExprId)
+                                 ->  TupleSplit
+                                       Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c), (mdqa_part_1_prt_2.d)
+                                       Group Key: mdqa_part_1_prt_2.a
+                                       ->  Append
+                                             ->  Seq Scan on mdqa_part_1_prt_2
+                                             ->  Seq Scan on mdqa_part_1_prt_3
+                                             ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 8 - MDQA over an inline view (subquery in FROM).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM (SELECT a, b, c, d
+          FROM mdqa_part
+         WHERE d > 0) sub
+ GROUP BY a
+ ORDER BY a;
+                                                      QUERY PLAN
+----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: mdqa_part_1_prt_2.a
+   ->  Finalize HashAggregate
+         Group Key: mdqa_part_1_prt_2.a
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Partial HashAggregate
+                     Group Key: mdqa_part_1_prt_2.a
+                     ->  HashAggregate
+                           Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                                 ->  TupleSplit
+                                       Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                       Group Key: mdqa_part_1_prt_2.a
+                                       ->  Append
+                                             ->  Seq Scan on mdqa_part_1_prt_2
+                                                   Filter: (d > 0)
+                                             ->  Seq Scan on mdqa_part_1_prt_3
+                                                   Filter: (d > 0)
+                                             ->  Seq Scan on mdqa_part_1_prt_other
+                                                   Filter: (d > 0)
+ Optimizer: Postgres-based planner
+(22 rows)
+
+-----------------------------------------------------------------------------
+-- Test 9 - NON-partitioned control for Test 1
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_heap
+ GROUP BY a;
+                               QUERY PLAN
+------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: a
+               ->  HashAggregate
+                     Group Key: (AggExprId), b, c, a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: a, b, c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (b), (c)
+                                 Group Key: a
+                                 ->  Seq Scan on mdqa_heap
+ Optimizer: Postgres-based planner
+(14 rows)
+
+-----------------------------------------------------------------------------
+-- Test 10 - no GROUP BY, heap table.
+-- Confirms the fix doesn't effect the empty-keys / heap path either.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_heap;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: b, c, (AggExprId)
+                     ->  TupleSplit
+                           Split by Col: (b), (c)
+                           ->  Seq Scan on mdqa_heap
+ Optimizer: Postgres-based planner
+(9 rows)
+
+-----------------------------------------------------------------------------
+-- Test 11 - shape-equivalent reproducer of the crashing query
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+WITH qualified_accounts AS (
+    SELECT o.account_id AS account_id
+      FROM orders o
+     WHERE o.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+       AND o.region = 'NORTH'
+     GROUP BY o.account_id
+    HAVING (sum(o.amount) >= 100000.0
+            AND count(DISTINCT o.order_date) >= 5.0)
+)
+SELECT o1.account_id,
+       sum(o1.amount)                AS amount_sum,
+       count(DISTINCT o1.order_date) AS date_cnt,
+       count(DISTINCT o1.account_id) AS account_cnt,
+       count(DISTINCT o1.order_id)   AS order_cnt
+  FROM orders o1
+       JOIN qualified_accounts qa ON (o1.account_id = qa.account_id)
+ WHERE o1.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+   AND o1.region = 'NORTH'
+ GROUP BY o1.account_id;
+                                                                                      QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: o1.account_id
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: o1.account_id
+               ->  Partial HashAggregate
+                     Group Key: (AggExprId), o1.order_date, o1.order_id, o1.account_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: o1.account_id, o1.order_date, o1.order_id, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (o1.order_date), (o1.account_id), (o1.order_id)
+                                 Group Key: o1.account_id
+                                 ->  Hash Join
+                                       Hash Cond: (o1.account_id = o.account_id)
+                                       ->  Append
+                                             ->  Seq Scan on orders_1_prt_2 o1
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_3 o1_1
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_4 o1_2
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_5 o1_3
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_6 o1_4
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_7 o1_5
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                             ->  Seq Scan on orders_1_prt_8 o1_6
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                       ->  Hash
+                                             ->  HashAggregate
+                                                   Group Key: o.account_id
+                                                   Filter: ((sum(o.amount) >= 100000.0) AND ((count(o.order_date))::numeric >= 5.0))
+                                                   ->  HashAggregate
+                                                         Group Key: o.account_id, o.order_date
+                                                         ->  Append
+                                                               ->  Seq Scan on orders_1_prt_2 o
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_3 o_1
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_4 o_2
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_5 o_3
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_6 o_4
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_7 o_5
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                                                               ->  Seq Scan on orders_1_prt_8 o_6
+                                                                     Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+ Optimizer: Postgres-based planner
+(51 rows)
+
+-----------------------------------------------------------------------------
+-- Test 12 - multi-column GROUP BY.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, b,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a, b;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 13 - DQAs referenced from HAVING clause, not SELECT list.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, sum(d) AS total
+  FROM mdqa_part
+ GROUP BY a
+HAVING count(DISTINCT b) > 1
+   AND count(DISTINCT c) > 1;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   Filter: ((count(mdqa_part_1_prt_2.b) > 1) AND (count(mdqa_part_1_prt_2.c) > 1))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  Partial HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(18 rows)
+
+-----------------------------------------------------------------------------
+-- Test 14 - LIST-partitioned table (not RANGE).
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_list_part(a int, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY LIST(a) (
+  PARTITION p1 VALUES (1, 2, 3),
+  PARTITION p2 VALUES (4, 5, 6),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_list_part SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 30) i;
+ANALYZE mdqa_list_part;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_list_part
+ GROUP BY a;
+                                                            QUERY PLAN
+----------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_list_part_1_prt_p1.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_list_part_1_prt_p1.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_list_part_1_prt_p1.b, mdqa_list_part_1_prt_p1.c, mdqa_list_part_1_prt_p1.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_list_part_1_prt_p1.a, mdqa_list_part_1_prt_p1.b, mdqa_list_part_1_prt_p1.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_list_part_1_prt_p1.b), (mdqa_list_part_1_prt_p1.c)
+                                 Group Key: mdqa_list_part_1_prt_p1.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_list_part_1_prt_p1
+                                       ->  Seq Scan on mdqa_list_part_1_prt_p2
+                                       ->  Seq Scan on mdqa_list_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 15 - partition-eliminated query .
+-- Confirms the narrowed producer still works when only a
+-- subset of the partitions are reachable.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE a >= 0 AND a < 50    -- prunes the [50,100) and DEFAULT partitions
+ GROUP BY a;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Seq Scan on mdqa_part_1_prt_2
+                                       Filter: ((a >= 0) AND (a < 50))
+ Optimizer: Postgres-based planner
+(15 rows)
+
+-----------------------------------------------------------------------------
+-- Test 16 - NULL handling in DQA arguments on a partitioned table.
+-----------------------------------------------------------------------------
+INSERT INTO mdqa_part VALUES
+  (NULL, NULL, NULL, NULL),
+  (50,   NULL, 1,    NULL),
+  (51,   2,    NULL, 9);
+ANALYZE mdqa_part;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c,
+       sum(DISTINCT b)   AS sum_b
+  FROM mdqa_part
+ GROUP BY a;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_part_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_part_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, mdqa_part_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_part_1_prt_2.a, mdqa_part_1_prt_2.b, mdqa_part_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_part_1_prt_2.b), (mdqa_part_1_prt_2.c)
+                                 Group Key: mdqa_part_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_part_1_prt_2
+                                       ->  Seq Scan on mdqa_part_1_prt_3
+                                       ->  Seq Scan on mdqa_part_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 17 - DISTRIBUTED RANDOMLY + partitioned.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_random_dist(a int, b int, c int, d int)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_random_dist SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_random_dist;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_random_dist
+ GROUP BY a;
+                                                             QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_random_dist_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_random_dist_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_random_dist_1_prt_2.b, mdqa_random_dist_1_prt_2.c, mdqa_random_dist_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_random_dist_1_prt_2.a, mdqa_random_dist_1_prt_2.b, mdqa_random_dist_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_random_dist_1_prt_2.b), (mdqa_random_dist_1_prt_2.c)
+                                 Group Key: mdqa_random_dist_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_random_dist_1_prt_2
+                                       ->  Seq Scan on mdqa_random_dist_1_prt_3
+                                       ->  Seq Scan on mdqa_random_dist_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 18 - PRIMARY KEY on the group-by
+-- column, with an unused non-key column.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_pk_grpkey(a int PRIMARY KEY, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_pk_grpkey SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 99) i;
+ANALYZE mdqa_pk_grpkey;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_pk_grpkey
+ GROUP BY a;
+                                                          QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_pk_grpkey_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_pk_grpkey_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_pk_grpkey_1_prt_2.b, mdqa_pk_grpkey_1_prt_2.c, mdqa_pk_grpkey_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_pk_grpkey_1_prt_2.a, mdqa_pk_grpkey_1_prt_2.b, mdqa_pk_grpkey_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_pk_grpkey_1_prt_2.b), (mdqa_pk_grpkey_1_prt_2.c)
+                                 Group Key: mdqa_pk_grpkey_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_pk_grpkey_1_prt_2
+                                       ->  Seq Scan on mdqa_pk_grpkey_1_prt_3
+                                       ->  Seq Scan on mdqa_pk_grpkey_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Test 19 - unused column is TEXT
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_text_col(a int, b int, c int, d text)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_text_col
+  SELECT i, i%5, i%3, 'row-' || i FROM generate_series(1, 100) i;
+ANALYZE mdqa_text_col;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_text_col
+ GROUP BY a;
+                                                         QUERY PLAN
+----------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Group Key: mdqa_text_col_1_prt_2.a
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial HashAggregate
+               Group Key: mdqa_text_col_1_prt_2.a
+               ->  HashAggregate
+                     Group Key: (AggExprId), mdqa_text_col_1_prt_2.b, mdqa_text_col_1_prt_2.c, mdqa_text_col_1_prt_2.a
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: mdqa_text_col_1_prt_2.a, mdqa_text_col_1_prt_2.b, mdqa_text_col_1_prt_2.c, (AggExprId)
+                           ->  TupleSplit
+                                 Split by Col: (mdqa_text_col_1_prt_2.b), (mdqa_text_col_1_prt_2.c)
+                                 Group Key: mdqa_text_col_1_prt_2.a
+                                 ->  Append
+                                       ->  Seq Scan on mdqa_text_col_1_prt_2
+                                       ->  Seq Scan on mdqa_text_col_1_prt_3
+                                       ->  Seq Scan on mdqa_text_col_1_prt_other
+ Optimizer: Postgres-based planner
+(17 rows)
+
+-----------------------------------------------------------------------------
+-- Cleanup
+-----------------------------------------------------------------------------
+DROP TABLE mdqa_part;
+DROP TABLE mdqa_dist_unused;
+DROP TABLE mdqa_heap;
+DROP TABLE mdqa_list_part;
+DROP TABLE mdqa_random_dist;
+DROP TABLE mdqa_pk_grpkey;
+DROP TABLE mdqa_text_col;
+DROP TABLE orders;
+DROP SCHEMA schema_mdqa;
+RESET search_path;
+RESET optimizer_enable_multiple_distinct_aggs;
+-----------------------------------------------------------------------------
+-- End of tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -4121,10 +4121,10 @@ SELECT o1.account_id,
                                              ->  Seq Scan on orders_1_prt_8 o1_6
                                                    Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
                                        ->  Hash
-                                             ->  HashAggregate
+                                             ->  Finalize HashAggregate
                                                    Group Key: o.account_id
                                                    Filter: ((sum(o.amount) >= 100000.0) AND ((count(o.order_date))::numeric >= 5.0))
-                                                   ->  HashAggregate
+                                                   ->  Partial HashAggregate
                                                          Group Key: o.account_id, o.order_date
                                                          ->  Append
                                                                ->  Seq Scan on orders_1_prt_2 o

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3257,9 +3257,12 @@ explain (verbose on, costs off) select count(distinct a), count(distinct b) from
    ->  Sequence
          Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
          ->  Shared Scan (share slice:id 1:0)
-               Output: share0_ref1.a, share0_ref1.b, share0_ref1.c, share0_ref1.ctid, share0_ref1.xmin, share0_ref1.cmin, share0_ref1.xmax, share0_ref1.cmax, share0_ref1.tableoid, share0_ref1.gp_segment_id
-               ->  Seq Scan on public.dqa_f4
-                     Output: dqa_f4.a, dqa_f4.b, dqa_f4.c, dqa_f4.ctid, dqa_f4.xmin, dqa_f4.cmin, dqa_f4.xmax, dqa_f4.cmax, dqa_f4.tableoid, dqa_f4.gp_segment_id
+               Output: share0_ref1.a, share0_ref1.b, share0_ref1.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: dqa_f4.a, dqa_f4.b, dqa_f4.c
+                     Hash Key: dqa_f4.c
+                     ->  Seq Scan on public.dqa_f4
+                           Output: dqa_f4.a, dqa_f4.b, dqa_f4.c
          ->  Hash Join
                Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
                Hash Cond: (NOT (share0_ref3.c IS DISTINCT FROM share0_ref2.c))
@@ -3267,33 +3270,23 @@ explain (verbose on, costs off) select count(distinct a), count(distinct b) from
                      Output: count(DISTINCT share0_ref3.a), share0_ref3.c
                      Group Key: share0_ref3.c
                      ->  Sort
-                           Output: share0_ref3.a, share0_ref3.c
+                           Output: share0_ref3.a, share0_ref3.b, share0_ref3.c
                            Sort Key: share0_ref3.c
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Output: share0_ref3.a, share0_ref3.c
-                                 Hash Key: share0_ref3.c
-                                 ->  Result
-                                       Output: share0_ref3.a, share0_ref3.c
-                                       ->  Shared Scan (share slice:id 2:0)
-                                             Output: share0_ref3.a, share0_ref3.b, share0_ref3.c, share0_ref3.ctid, share0_ref3.xmin, share0_ref3.cmin, share0_ref3.xmax, share0_ref3.cmax, share0_ref3.tableoid, share0_ref3.gp_segment_id
+                           ->  Shared Scan (share slice:id 1:0)
+                                 Output: share0_ref3.a, share0_ref3.b, share0_ref3.c
                ->  Hash
                      Output: (count(DISTINCT share0_ref2.b)), share0_ref2.c
                      ->  GroupAggregate
                            Output: count(DISTINCT share0_ref2.b), share0_ref2.c
                            Group Key: share0_ref2.c
                            ->  Sort
-                                 Output: share0_ref2.b, share0_ref2.c
+                                 Output: share0_ref2.a, share0_ref2.b, share0_ref2.c
                                  Sort Key: share0_ref2.c
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Output: share0_ref2.b, share0_ref2.c
-                                       Hash Key: share0_ref2.c
-                                       ->  Result
-                                             Output: share0_ref2.b, share0_ref2.c
-                                             ->  Shared Scan (share slice:id 3:0)
-                                                   Output: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.ctid, share0_ref2.xmin, share0_ref2.cmin, share0_ref2.xmax, share0_ref2.cmax, share0_ref2.tableoid, share0_ref2.gp_segment_id
- Optimizer: Pivotal Optimizer (GPORCA)
+                                 ->  Shared Scan (share slice:id 1:0)
+                                       Output: share0_ref2.a, share0_ref2.b, share0_ref2.c
+ Optimizer: GPORCA
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_enable_multiple_distinct_aggs = 'on'
-(41 rows)
+(34 rows)
 
 select count(distinct a), count(distinct b) from dqa_f4 group by c;
  count | count 

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3999,7 +3999,7 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count
+ count 
 -------
    236
 (1 row)

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3913,13 +3913,13 @@ CREATE TABLE sales (
   sale_amt   numeric(18,3)
 ) DISTRIBUTED BY (sale_key);
 INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
-SELECT 
+SELECT
     '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
     'KEY-' || i AS sale_key,
     'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
     ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
 FROM (
-    SELECT 
+    SELECT
         i,
         (i - 1) % 1000 AS c,
         (i - 1) / 1000 AS r
@@ -3927,11 +3927,11 @@ FROM (
 ) sub;
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
-                                                    QUERY PLAN                                                     
+                                                    QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------
  Aggregate
    Output: count()
@@ -3955,11 +3955,11 @@ SELECT count(*) FROM (
 
 -- Without this patch, this SQL will output 78, which is not correct
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count 
+ count
 -------
    236
 (1 row)
@@ -3968,11 +3968,11 @@ SELECT count(*) FROM (
 SET optimizer_enable_multiple_distinct_aggs=on;
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
-                                                                          QUERY PLAN                                                                           
+                                                                          QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    Output: count()
@@ -3999,9 +3999,828 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count 
+ count
 -------
    236
 (1 row)
 
 DROP TABLE sales;
+-----------------------------------------------------------------------------
+-- Tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS schema_mdqa;
+SET search_path = schema_mdqa, public;
+SET optimizer_enable_multiple_distinct_aggs = on;
+-----------------------------------------------------------------------------
+-- Setup: two partitioned tables, one heap table.
+-----------------------------------------------------------------------------
+-- Partitioned, distributed by group-by key.
+CREATE TABLE mdqa_part(
+  a int,    -- group-by key + distribution key
+  b int,    -- DISTINCT arg
+  c int,    -- DISTINCT arg
+  d int     -- unused unless explicitly referenced
+)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_part SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+CREATE INDEX mdqa_part_b_idx ON mdqa_part(b);
+ANALYZE mdqa_part;
+-- Partitioned, distributed by a column NOT used in the query.
+CREATE TABLE mdqa_dist_unused(
+  a int,        -- group-by key
+  b int,
+  c int,
+  dist_col int  -- distribution key, never referenced in any test query
+)
+DISTRIBUTED BY (dist_col)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_dist_unused SELECT i, i%5, i%3, i%11
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_dist_unused;
+-- Non-partitioned control. Same shape, heap table.
+CREATE TABLE mdqa_heap(a int, b int, c int, d int) DISTRIBUTED BY (a);
+INSERT INTO mdqa_heap SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+ANALYZE mdqa_heap;
+-- Based on crashing query
+CREATE TABLE orders(
+  order_date  date,
+  account_id  int,
+  region      text,
+  order_id    int,
+  amount      numeric(15,2)
+)
+DISTRIBUTED BY (account_id)
+PARTITION BY RANGE(order_date) (
+  START ('2026-04-01'::date) END ('2026-04-08'::date) EVERY ('1 day'::interval),
+  DEFAULT PARTITION other
+);
+INSERT INTO orders
+  SELECT ('2026-04-01'::date + ((i % 7) || ' days')::interval)::date,
+         i % 20,
+         CASE WHEN i % 3 = 0 THEN 'NORTH' ELSE 'SOUTH' END,
+         i,
+         (i * 1000)::numeric(15,2)
+  FROM generate_series(1, 200) i;
+ANALYZE orders;
+-----------------------------------------------------------------------------
+-- Test 1 - minimal MDQA on partitioned table.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 2 - with selective predicate + index to encourage a dynamic scan.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE b BETWEEN 0 AND 2
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Index Scan on mdqa_part_b_idx on mdqa_part
+                     Index Cond: ((b >= 0) AND (b <= 2))
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(20 rows)
+
+-----------------------------------------------------------------------------
+-- Test 3 - system column (ctid) as a DISTINCT argument.
+-- Validates the fix correctly INCLUDES referenced system columns in the
+-- CTEproducer
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT ctid) AS distinct_rows,
+       count(DISTINCT b)    AS distinct_b
+  FROM mdqa_part
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 4 - group-by key referenced ONLY in GROUP BY clause —
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 5 - distribution key NOT referenced anywhere in the query.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_dist_unused
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: mdqa_dist_unused.a
+                     ->  Dynamic Seq Scan on mdqa_dist_unused
+                           Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(21 rows)
+
+-----------------------------------------------------------------------------
+-- Test 6 - MDQA with NO GROUP BY (single global aggregation).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part;
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Redistribute Motion 1:3  (slice2)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Finalize Aggregate
+                           ->  Gather Motion 3:1  (slice5; segments: 3)
+                                 ->  Partial Aggregate
+                                       ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                             Hash Key: share0_ref3.b
+                                             ->  Result
+                                                   ->  Shared Scan (share slice:id 6:0)
+                     ->  Materialize
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Hash Key: share0_ref2.c
+                                                   ->  Result
+                                                         ->  Shared Scan (share slice:id 4:0)
+ Optimizer: GPORCA
+(24 rows)
+
+-----------------------------------------------------------------------------
+-- Test 7 - mix of agg functions
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       sum(DISTINCT c)   AS sum_c,
+       avg(DISTINCT b)   AS avg_b,
+       min(DISTINCT c)   AS min_c,
+       max(DISTINCT d)   AS max_d,
+       sum(d)            AS plain_sum_d
+  FROM mdqa_part
+ GROUP BY a
+ ORDER BY a;
+                                        QUERY PLAN
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: share0_ref4.a
+   ->  Sort
+         Sort Key: share0_ref4.a
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Dynamic Seq Scan on mdqa_part
+                           Number of partitions to scan: 3 (out of 3)
+               ->  Hash Join
+                     Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+                     ->  Hash Join
+                           Hash Cond: (NOT (share0_ref4.a IS DISTINCT FROM share0_ref3.a))
+                           ->  GroupAggregate
+                                 Group Key: share0_ref4.a
+                                 ->  Sort
+                                       Sort Key: share0_ref4.a
+                                       ->  Shared Scan (share slice:id 1:0)
+                           ->  Hash
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref3.a
+                                       ->  Sort
+                                             Sort Key: share0_ref3.a
+                                             ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  HashAggregate
+                                 Group Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(28 rows)
+
+-----------------------------------------------------------------------------
+-- Test 8 - MDQA over an inline view (subquery in FROM).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM (SELECT a, b, c, d
+          FROM mdqa_part
+         WHERE d > 0) sub
+ GROUP BY a
+ ORDER BY a;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: share0_ref3.a
+   ->  Sort
+         Sort Key: share0_ref3.a
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Dynamic Seq Scan on mdqa_part
+                           Number of partitions to scan: 3 (out of 3)
+                           Filter: (d > 0)
+               ->  Hash Join
+                     Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+                     ->  GroupAggregate
+                           Group Key: share0_ref3.a
+                           ->  Sort
+                                 Sort Key: share0_ref3.a
+                                 ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share0_ref2.a
+                                 ->  Sort
+                                       Sort Key: share0_ref2.a
+                                       ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(23 rows)
+
+-----------------------------------------------------------------------------
+-- Test 9 - NON-partitioned control for Test 1
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_heap
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on mdqa_heap
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(18 rows)
+
+-----------------------------------------------------------------------------
+-- Test 10 - no GROUP BY, heap table.
+-- Confirms the fix doesn't effect the empty-keys / heap path either.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_heap;
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Seq Scan on mdqa_heap
+         ->  Redistribute Motion 1:3  (slice2)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Finalize Aggregate
+                           ->  Gather Motion 3:1  (slice5; segments: 3)
+                                 ->  Partial Aggregate
+                                       ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                             Hash Key: share0_ref3.b
+                                             ->  Result
+                                                   ->  Shared Scan (share slice:id 6:0)
+                     ->  Materialize
+                           ->  Finalize Aggregate
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       ->  Partial Aggregate
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Hash Key: share0_ref2.c
+                                                   ->  Result
+                                                         ->  Shared Scan (share slice:id 4:0)
+ Optimizer: GPORCA
+(23 rows)
+
+-----------------------------------------------------------------------------
+-- Test 11 - shape-equivalent reproducer of the crashing query
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+WITH qualified_accounts AS (
+    SELECT o.account_id AS account_id
+      FROM orders o
+     WHERE o.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+       AND o.region = 'NORTH'
+     GROUP BY o.account_id
+    HAVING (sum(o.amount) >= 100000.0
+            AND count(DISTINCT o.order_date) >= 5.0)
+)
+SELECT o1.account_id,
+       sum(o1.amount)                AS amount_sum,
+       count(DISTINCT o1.order_date) AS date_cnt,
+       count(DISTINCT o1.account_id) AS account_cnt,
+       count(DISTINCT o1.order_id)   AS order_cnt
+  FROM orders o1
+       JOIN qualified_accounts qa ON (o1.account_id = qa.account_id)
+ WHERE o1.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+   AND o1.region = 'NORTH'
+ GROUP BY o1.account_id;
+                                                                             QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:1)
+               ->  Hash Join
+                     Hash Cond: (o1.account_id = o.account_id)
+                     ->  Dynamic Seq Scan on orders o1
+                           Number of partitions to scan: 7 (out of 8)
+                           Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+                     ->  Hash
+                           ->  Result
+                                 Filter: (((sum(o.amount)) >= 100000.0) AND (((count(DISTINCT o.order_date)))::numeric >= 5.0))
+                                 ->  GroupAggregate
+                                       Group Key: o.account_id
+                                       ->  Sort
+                                             Sort Key: o.account_id
+                                             ->  Dynamic Seq Scan on orders o
+                                                   Number of partitions to scan: 7 (out of 8)
+                                                   Filter: ((order_date >= '04-01-2026'::date) AND (order_date <= '04-07-2026'::date) AND (region = 'NORTH'::text))
+         ->  Hash Join
+               Hash Cond: (NOT (share1_ref3.account_id IS DISTINCT FROM share1_ref2.account_id))
+               ->  Hash Join
+                     Hash Cond: (NOT (share1_ref4.account_id IS DISTINCT FROM share1_ref3.account_id))
+                     ->  Hash Join
+                           Hash Cond: (NOT (share1_ref5.account_id IS DISTINCT FROM share1_ref4.account_id))
+                           ->  HashAggregate
+                                 Group Key: share1_ref5.account_id
+                                 ->  Shared Scan (share slice:id 1:1)
+                           ->  Hash
+                                 ->  GroupAggregate
+                                       Group Key: share1_ref4.account_id
+                                       ->  Sort
+                                             Sort Key: share1_ref4.account_id
+                                             ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share1_ref3.account_id
+                                 ->  Sort
+                                       Sort Key: share1_ref3.account_id
+                                       ->  Shared Scan (share slice:id 1:1)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share1_ref2.account_id
+                           ->  Sort
+                                 Sort Key: share1_ref2.account_id
+                                 ->  Shared Scan (share slice:id 1:1)
+ Optimizer: GPORCA
+(46 rows)
+
+-----------------------------------------------------------------------------
+-- Test 12 - multi-column GROUP BY.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, b,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a, b;
+                                                                QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: ((NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a)) AND (NOT (share0_ref3.b IS DISTINCT FROM share0_ref2.b)))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a, share0_ref3.b
+                     ->  Sort
+                           Sort Key: share0_ref3.a, share0_ref3.b
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a, share0_ref2.b
+                           ->  Sort
+                                 Sort Key: share0_ref2.a, share0_ref2.b
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 13 - DQAs referenced from HAVING clause, not SELECT list.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, sum(d) AS total
+  FROM mdqa_part
+ GROUP BY a
+HAVING count(DISTINCT b) > 1
+   AND count(DISTINCT c) > 1;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         Filter: (((count(DISTINCT share0_ref3.b)) > 1) AND ((count(DISTINCT share0_ref2.c)) > 1))
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Dynamic Seq Scan on mdqa_part
+                           Number of partitions to scan: 3 (out of 3)
+               ->  Hash Join
+                     Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+                     ->  Hash Join
+                           Hash Cond: (NOT (share0_ref4.a IS DISTINCT FROM share0_ref3.a))
+                           ->  HashAggregate
+                                 Group Key: share0_ref4.a
+                                 ->  Shared Scan (share slice:id 1:0)
+                           ->  Hash
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref3.a
+                                       ->  Sort
+                                             Sort Key: share0_ref3.a
+                                             ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share0_ref2.a
+                                 ->  Sort
+                                       Sort Key: share0_ref2.a
+                                       ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(27 rows)
+
+-----------------------------------------------------------------------------
+-- Test 14 - LIST-partitioned table (not RANGE).
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_list_part(a int, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY LIST(a) (
+  PARTITION p1 VALUES (1, 2, 3),
+  PARTITION p2 VALUES (4, 5, 6),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_list_part SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 30) i;
+ANALYZE mdqa_list_part;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_list_part
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_list_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 15 - partition-eliminated query .
+-- Confirms the narrowed producer still works when only a
+-- subset of the partitions are reachable.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE a >= 0 AND a < 50    -- prunes the [50,100) and DEFAULT partitions
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 1 (out of 3)
+                     Filter: ((a >= 0) AND (a < 50))
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(20 rows)
+
+-----------------------------------------------------------------------------
+-- Test 16 - NULL handling in DQA arguments on a partitioned table.
+-----------------------------------------------------------------------------
+INSERT INTO mdqa_part VALUES
+  (NULL, NULL, NULL, NULL),
+  (50,   NULL, 1,    NULL),
+  (51,   2,    NULL, 9);
+ANALYZE mdqa_part;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c,
+       sum(DISTINCT b)   AS sum_b
+  FROM mdqa_part
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_part
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 17 - DISTRIBUTED RANDOMLY + partitioned.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_random_dist(a int, b int, c int, d int)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_random_dist SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_random_dist;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_random_dist
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: mdqa_random_dist.a
+                     ->  Dynamic Seq Scan on mdqa_random_dist
+                           Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(21 rows)
+
+-----------------------------------------------------------------------------
+-- Test 18 - PRIMARY KEY on the group-by
+-- column, with an unused non-key column.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_pk_grpkey(a int PRIMARY KEY, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_pk_grpkey SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 99) i;
+ANALYZE mdqa_pk_grpkey;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_pk_grpkey
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_pk_grpkey
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Test 19 - unused column is TEXT
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_text_col(a int, b int, c int, d text)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_text_col
+  SELECT i, i%5, i%3, 'row-' || i FROM generate_series(1, 100) i;
+ANALYZE mdqa_text_col;
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_text_col
+ GROUP BY a;
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Dynamic Seq Scan on mdqa_text_col
+                     Number of partitions to scan: 3 (out of 3)
+         ->  Hash Join
+               Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
+               ->  GroupAggregate
+                     Group Key: share0_ref3.a
+                     ->  Sort
+                           Sort Key: share0_ref3.a
+                           ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share0_ref2.a
+                           ->  Sort
+                                 Sort Key: share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-----------------------------------------------------------------------------
+-- Cleanup
+-----------------------------------------------------------------------------
+DROP TABLE mdqa_part;
+DROP TABLE mdqa_dist_unused;
+DROP TABLE mdqa_heap;
+DROP TABLE mdqa_list_part;
+DROP TABLE mdqa_random_dist;
+DROP TABLE mdqa_pk_grpkey;
+DROP TABLE mdqa_text_col;
+DROP TABLE orders;
+DROP SCHEMA schema_mdqa;
+RESET search_path;
+RESET optimizer_enable_multiple_distinct_aggs;
+-----------------------------------------------------------------------------
+-- End of tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3959,7 +3959,7 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count
+ count 
 -------
    236
 (1 row)

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -695,13 +695,13 @@ CREATE TABLE sales (
 ) DISTRIBUTED BY (sale_key);
 
 INSERT INTO sales (sale_date, sale_key, cust_no, sale_amt)
-SELECT 
+SELECT
     '2026-04-01'::date + ((c + r) % (c % 7 + 1)) AS sale_date,
     'KEY-' || i AS sale_key,
     'C' || lpad((c + 1)::text, 4, '0') AS cust_no,
     ((c % 20 + 1) * 1000)::numeric(18,3) AS sale_amt
 FROM (
-    SELECT 
+    SELECT
         i,
         (i - 1) % 1000 AS c,
         (i - 1) / 1000 AS r
@@ -710,15 +710,15 @@ FROM (
 
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
 
 -- Without this patch, this SQL will output 78, which is not correct
 SELECT count(*) FROM (
-  SELECT cust_no, sum(sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
 
@@ -727,8 +727,8 @@ SET optimizer_enable_multiple_distinct_aggs=on;
 
 EXPLAIN (COSTS OFF, VERBOSE)
 SELECT count(*) FROM (
-  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date) 
-  FROM sales GROUP BY cust_no 
+  SELECT cust_no, sum(distinct sale_amt), count(distinct sale_date)
+  FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
 
@@ -739,3 +739,360 @@ SELECT count(*) FROM (
 )as sub;
 
 DROP TABLE sales;
+
+-----------------------------------------------------------------------------
+-- Tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS schema_mdqa;
+SET search_path = schema_mdqa, public;
+
+SET optimizer_enable_multiple_distinct_aggs = on;
+
+-----------------------------------------------------------------------------
+-- Setup: two partitioned tables, one heap table.
+-----------------------------------------------------------------------------
+
+-- Partitioned, distributed by group-by key.
+CREATE TABLE mdqa_part(
+  a int,    -- group-by key + distribution key
+  b int,    -- DISTINCT arg
+  c int,    -- DISTINCT arg
+  d int     -- unused unless explicitly referenced
+)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_part SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+CREATE INDEX mdqa_part_b_idx ON mdqa_part(b);
+ANALYZE mdqa_part;
+
+
+-- Partitioned, distributed by a column NOT used in the query.
+CREATE TABLE mdqa_dist_unused(
+  a int,        -- group-by key
+  b int,
+  c int,
+  dist_col int  -- distribution key, never referenced in any test query
+)
+DISTRIBUTED BY (dist_col)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_dist_unused SELECT i, i%5, i%3, i%11
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_dist_unused;
+
+
+-- Non-partitioned control. Same shape, heap table.
+CREATE TABLE mdqa_heap(a int, b int, c int, d int) DISTRIBUTED BY (a);
+INSERT INTO mdqa_heap SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
+ANALYZE mdqa_heap;
+
+
+-- Based on crashing query
+CREATE TABLE orders(
+  order_date  date,
+  account_id  int,
+  region      text,
+  order_id    int,
+  amount      numeric(15,2)
+)
+DISTRIBUTED BY (account_id)
+PARTITION BY RANGE(order_date) (
+  START ('2026-04-01'::date) END ('2026-04-08'::date) EVERY ('1 day'::interval),
+  DEFAULT PARTITION other
+);
+INSERT INTO orders
+  SELECT ('2026-04-01'::date + ((i % 7) || ' days')::interval)::date,
+         i % 20,
+         CASE WHEN i % 3 = 0 THEN 'NORTH' ELSE 'SOUTH' END,
+         i,
+         (i * 1000)::numeric(15,2)
+  FROM generate_series(1, 200) i;
+ANALYZE orders;
+
+
+-----------------------------------------------------------------------------
+-- Test 1 - minimal MDQA on partitioned table.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 2 - with selective predicate + index to encourage a dynamic scan.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE b BETWEEN 0 AND 2
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 3 - system column (ctid) as a DISTINCT argument.
+-- Validates the fix correctly INCLUDES referenced system columns in the
+-- CTEproducer
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT ctid) AS distinct_rows,
+       count(DISTINCT b)    AS distinct_b
+  FROM mdqa_part
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 4 - group-by key referenced ONLY in GROUP BY clause —
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 5 - distribution key NOT referenced anywhere in the query.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_dist_unused
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 6 - MDQA with NO GROUP BY (single global aggregation).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_part;
+
+-----------------------------------------------------------------------------
+-- Test 7 - mix of agg functions
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       sum(DISTINCT c)   AS sum_c,
+       avg(DISTINCT b)   AS avg_b,
+       min(DISTINCT c)   AS min_c,
+       max(DISTINCT d)   AS max_d,
+       sum(d)            AS plain_sum_d
+  FROM mdqa_part
+ GROUP BY a
+ ORDER BY a;
+
+-----------------------------------------------------------------------------
+-- Test 8 - MDQA over an inline view (subquery in FROM).
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM (SELECT a, b, c, d
+          FROM mdqa_part
+         WHERE d > 0) sub
+ GROUP BY a
+ ORDER BY a;
+
+-----------------------------------------------------------------------------
+-- Test 9 - NON-partitioned control for Test 1
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_heap
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 10 - no GROUP BY, heap table.
+-- Confirms the fix doesn't effect the empty-keys / heap path either.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT count(DISTINCT b),
+       count(DISTINCT c)
+  FROM mdqa_heap;
+
+-----------------------------------------------------------------------------
+-- Test 11 - shape-equivalent reproducer of the crashing query
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+WITH qualified_accounts AS (
+    SELECT o.account_id AS account_id
+      FROM orders o
+     WHERE o.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+       AND o.region = 'NORTH'
+     GROUP BY o.account_id
+    HAVING (sum(o.amount) >= 100000.0
+            AND count(DISTINCT o.order_date) >= 5.0)
+)
+SELECT o1.account_id,
+       sum(o1.amount)                AS amount_sum,
+       count(DISTINCT o1.order_date) AS date_cnt,
+       count(DISTINCT o1.account_id) AS account_cnt,
+       count(DISTINCT o1.order_id)   AS order_cnt
+  FROM orders o1
+       JOIN qualified_accounts qa ON (o1.account_id = qa.account_id)
+ WHERE o1.order_date BETWEEN '2026-04-01'::date AND '2026-04-07'::date
+   AND o1.region = 'NORTH'
+ GROUP BY o1.account_id;
+
+-----------------------------------------------------------------------------
+-- Test 12 - multi-column GROUP BY.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, b,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ GROUP BY a, b;
+
+-----------------------------------------------------------------------------
+-- Test 13 - DQAs referenced from HAVING clause, not SELECT list.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a, sum(d) AS total
+  FROM mdqa_part
+ GROUP BY a
+HAVING count(DISTINCT b) > 1
+   AND count(DISTINCT c) > 1;
+
+-----------------------------------------------------------------------------
+-- Test 14 - LIST-partitioned table (not RANGE).
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_list_part(a int, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY LIST(a) (
+  PARTITION p1 VALUES (1, 2, 3),
+  PARTITION p2 VALUES (4, 5, 6),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_list_part SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 30) i;
+ANALYZE mdqa_list_part;
+
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_list_part
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 15 - partition-eliminated query .
+-- Confirms the narrowed producer still works when only a
+-- subset of the partitions are reachable.
+-----------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_part
+ WHERE a >= 0 AND a < 50    -- prunes the [50,100) and DEFAULT partitions
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 16 - NULL handling in DQA arguments on a partitioned table.
+-----------------------------------------------------------------------------
+INSERT INTO mdqa_part VALUES
+  (NULL, NULL, NULL, NULL),
+  (50,   NULL, 1,    NULL),
+  (51,   2,    NULL, 9);
+ANALYZE mdqa_part;
+
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c,
+       sum(DISTINCT b)   AS sum_b
+  FROM mdqa_part
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 17 - DISTRIBUTED RANDOMLY + partitioned.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_random_dist(a int, b int, c int, d int)
+DISTRIBUTED RANDOMLY
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_random_dist SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 100) i;
+ANALYZE mdqa_random_dist;
+
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_random_dist
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 18 - PRIMARY KEY on the group-by
+-- column, with an unused non-key column.
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_pk_grpkey(a int PRIMARY KEY, b int, c int, d int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_pk_grpkey SELECT i, i%5, i%3, i%7
+  FROM generate_series(1, 99) i;
+ANALYZE mdqa_pk_grpkey;
+
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_pk_grpkey
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Test 19 - unused column is TEXT
+-----------------------------------------------------------------------------
+CREATE TABLE mdqa_text_col(a int, b int, c int, d text)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE(a) (
+  START (0) END (100) EVERY (50),
+  DEFAULT PARTITION other
+);
+INSERT INTO mdqa_text_col
+  SELECT i, i%5, i%3, 'row-' || i FROM generate_series(1, 100) i;
+ANALYZE mdqa_text_col;
+
+EXPLAIN (COSTS OFF)
+SELECT a,
+       count(DISTINCT b) AS cnt_b,
+       count(DISTINCT c) AS cnt_c
+  FROM mdqa_text_col
+ GROUP BY a;
+
+-----------------------------------------------------------------------------
+-- Cleanup
+-----------------------------------------------------------------------------
+DROP TABLE mdqa_part;
+DROP TABLE mdqa_dist_unused;
+DROP TABLE mdqa_heap;
+DROP TABLE mdqa_list_part;
+DROP TABLE mdqa_random_dist;
+DROP TABLE mdqa_pk_grpkey;
+DROP TABLE mdqa_text_col;
+DROP TABLE orders;
+DROP SCHEMA schema_mdqa;
+RESET search_path;
+RESET optimizer_enable_multiple_distinct_aggs;
+
+-----------------------------------------------------------------------------
+-- End of tests for multiple distinct-qualified aggregates
+-----------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
Fixes a SIGSEGV encountered (debug-build assertion at `CTranslatorExprToDXL.cpp`) when the optimizer rewrites a query
with multiple distinct-qualified aggregates (MDQAs) over a **partitioned table**. 

```
CREATE TABLE mdqa_part(
  a int,    -- group-by key + distribution key
  b int,    -- DISTINCT arg
  c int,    -- DISTINCT arg
  d int     -- unused unless explicitly referenced
)
DISTRIBUTED BY (a)
PARTITION BY RANGE(a) (
  START (0) END (100) EVERY (50),
  DEFAULT PARTITION other
);
INSERT INTO mdqa_part SELECT i, i%5, i%3, i%7 FROM generate_series(1, 100) i;
CREATE INDEX mdqa_part_b_idx ON mdqa_part(b);
ANALYZE mdqa_part;

EXPLAIN SELECT a, count(DISTINCT b) AS cnt_b, count(DISTINCT c) AS cnt_c FROM mdqa_part WHERE b BETWEEN 0 AND 2 GROUP BY a;
```

<img width="1134" height="678" alt="image" src="https://github.com/user-attachments/assets/edc2ab77-367e-4067-95ed-0b5841e47b0f" />


`CXformGbAggWithMDQA2Join` was declaring every column, the child could produce on the CTE Producer, rather than just the columns the GbAgg actually needs. The CTE producer only needs *(group keys ∪ aggregate-argument refs)* clipped to what the child can produce. 

On the partitioned-table path the over-declared columns include unreferenced and system columns whose `EUsage` state is `EUnknown`/`EUnused`, violating an invariant in `MakeDXLTableDescr` that requires required columns to be `EUsed`.

The narrowing preserves correctness on every shape (including system columns when referenced, group-only keys, no-GROUP-BY queries, and inline views) because DeriveUsedColumns already walks the agg list correctly and Include(Pdrgpcr()) always picks up the group keys regardless of whether they appear in the projection.


After the fix plan - 


                                                       QUERY PLAN
```
        ----------------------------------------------------------------------------------------------------------
         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..868.00 rows=1 width=20)
           ->  Sequence  (cost=0.00..868.00 rows=1 width=20)
                 ->  Shared Scan (share slice:id 1:0)  (cost=0.00..6.00 rows=1 width=1)
                       ->  Dynamic Index Scan on mdqa_part_b_idx on mdqa_part  (cost=0.00..6.00 rows=1 width=12)
                             Index Cond: ((b >= 0) AND (b <= 2))
                             Number of partitions to scan: 3 (out of 3)
                 ->  Hash Join  (cost=0.00..862.00 rows=1 width=20)
                       Hash Cond: (NOT (share0_ref3.a IS DISTINCT FROM share0_ref2.a))
                       ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                             Group Key: share0_ref3.a
                             ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                                   Sort Key: share0_ref3.a
                                   ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
                       ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                                   Group Key: share0_ref2.a
                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                                         Sort Key: share0_ref2.a
                                         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=8)
         Optimizer: GPORCA
        (20 rows)
```

