### PR TITLE
Enable mirrors and JIT

### DIFF
--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -167,7 +167,7 @@ jobs:
           CC='ccache gcc -m64' \
           CFLAGS='-O2 -g3' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
           ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
-                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
+                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --with-llvm \
                       --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
                       --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
@@ -205,7 +205,7 @@ jobs:
         id: cluster
         run: |
           source concourse/scripts/common.bash
-          export WITH_MIRRORS=false
+          export WITH_MIRRORS=true
           make_cluster
 
       - name: Run installcheck tests

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -44,6 +44,15 @@ select gp_inject_fault_infinite('postmaster_server_loop_no_sigkill', 'skip', dbi
 (1 row)
 1&:create table fts_reset_t(a int);  <waiting ...>
 
+-- Wait for the PANIC to take effect and seg0 to enter RESET mode before
+-- session 2 attempts its CREATE TABLE. Without this, on fast CI runners
+-- session 2 can dispatch before the segment is actually down.
+select pg_sleep(2);
+ pg_sleep 
+----------
+          
+(1 row)
+
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);  <waiting ...>
 

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -32,6 +32,11 @@ from gp_segment_configuration where role = 'p' and content = 0;
 from gp_segment_configuration where role = 'p' AND content = 0;
 1&:create table fts_reset_t(a int);
 
+-- Wait for the PANIC to take effect and seg0 to enter RESET mode before
+-- session 2 attempts its CREATE TABLE. Without this, on fast CI runners
+-- session 2 can dispatch before the segment is actually down.
+select pg_sleep(2);
+
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);
 


### PR DESCRIPTION
The installcheck suite was running against a mirrorless cluster (WITH_MIRRORS=false) and without JIT (--with-llvm missing from configure). This caused 11 test failures on every run — not flakes. 

Also fixed - `fts_segment_reset isolation2 test` :
Added pg_sleep(2) between the PANIC-triggering session and the session that expects to block on the resetting segment. Without this, on fast runners session 2 can dispatch before the PANIC takes effect, causing
the CREATE TABLE to succeed instead of blocking.

<img width="998" height="489" alt="image" src="https://github.com/user-attachments/assets/d8b2867b-be34-462e-b468-fb15a84ecafa" />
