### PR TITLE
strip RelabelType when pulling up distribution key through binary-compatible cast in partitioned table scans

### DIFF
--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -119,6 +119,7 @@ pullUpExpr_mutator(Node *node, void *context)
 		{
 			ListCell   *cell;
 			Expr	   *tlistexpr = NULL;
+			Expr	   *naked_tlistexpr = NULL;
 			AttrNumber	targetattno = 1;
 
 			foreach(cell, ctx->targetlist)
@@ -128,10 +129,20 @@ pullUpExpr_mutator(Node *node, void *context)
 				/*
 				 * We don't use equal(), because we want to ignore typmod.
 				 * A projection sometimes loses typmod, and that's OK.
+				 *
+				 * Also strip RelabelType nodes, consistent with
+				 * cdbpullup_findEclassInTargetList(), to handle
+				 * binary-compatible casts (e.g. varchar->text) that appear
+				 * in reltarget->exprs after apply_scanjoin_target_to_paths()
+				 * pushes projections down to partition child rels.
 				 */
-				if (IsA(tlistexpr, Var))
+				naked_tlistexpr = tlistexpr;
+				while (IsA(naked_tlistexpr, RelabelType))
+					naked_tlistexpr = (Expr *) ((RelabelType *) naked_tlistexpr)->arg;
+
+				if (IsA(naked_tlistexpr, Var))
 				{
-					Var		   *tlistvar = (Var *) tlistexpr;
+					Var		   *tlistvar = (Var *) naked_tlistexpr;
 
 					if (var->varno == tlistvar->varno &&
 						var->varattno == tlistvar->varattno &&
@@ -143,16 +154,31 @@ pullUpExpr_mutator(Node *node, void *context)
 			if (!cell)
 				goto fail;
 
-			/* Substitute the corresponding entry from newvarlist, if given. */
+			/*
+			 * Substitute the corresponding entry from newvarlist, if given.
+			 *
+			 * Strip RelabelType from the newvarlist entry for the same
+			 * reason as above: we are substituting the inner Var node only.
+			 * expression_tree_mutator re-wraps the result in RelabelType at
+			 * the outer level, so returning the full cast expression here
+			 * would produce a double-cast and fail the type Assert below.
+			 */
 			if (ctx->newvarlist)
-				newnode = (Node *) copyObject(list_nth(ctx->newvarlist,
-													   targetattno - 1));
+			{
+				Expr	   *newvar_entry = (Expr *) list_nth(ctx->newvarlist,
+															  targetattno - 1);
+
+				while (IsA(newvar_entry, RelabelType))
+					newvar_entry = (Expr *) ((RelabelType *) newvar_entry)->arg;
+				newnode = (Node *) copyObject(newvar_entry);
+			}
 
 			/* Substitute a Var node referencing the targetlist entry. */
 			else
 				newnode = (Node *) cdbpullup_make_expr(ctx->newvarno,
 													   targetattno,
-													   tlistexpr, true);
+													   naked_tlistexpr,
+													   true);
 		}
 
 		/* Make sure we haven't inadvertently changed the data type. */

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -101,10 +101,22 @@ pullUpExpr_mutator(Node *node, void *context)
 			if (!tle)
 				goto fail;
 
-			/* Substitute the corresponding entry from newvarlist, if given. */
+			/*
+			 * Substitute the corresponding entry from newvarlist, if given.
+			 *
+			 * Strip RelabelType for the same reason as the RelOptInfo branch
+			 * below: we substitute the inner Var only and rely on
+			 * expression_tree_mutator to re-wrap RelabelType at the outer
+			 * level, avoiding a double-cast that would fail the type Assert.
+			 */
 			if (ctx->newvarlist)
-				newnode = (Node *) copyObject(list_nth(ctx->newvarlist,
-													   tle->resno - 1));
+			{
+				Expr	*newvar_entry = (Expr *) list_nth(ctx->newvarlist,
+																tle->resno - 1);
+				while (IsA(newvar_entry, RelabelType))
+					newvar_entry = (Expr *) ((RelabelType *) newvar_entry)->arg;
+				newnode = (Node *) copyObject(newvar_entry);
+			}
 
 			/* Substitute a Var node referencing the targetlist entry. */
 			else
@@ -142,7 +154,7 @@ pullUpExpr_mutator(Node *node, void *context)
 
 				if (IsA(naked_tlistexpr, Var))
 				{
-					Var		   *tlistvar = (Var *) naked_tlistexpr;
+					Var	*tlistvar = (Var *) naked_tlistexpr;
 
 					if (var->varno == tlistvar->varno &&
 						var->varattno == tlistvar->varattno &&
@@ -165,9 +177,8 @@ pullUpExpr_mutator(Node *node, void *context)
 			 */
 			if (ctx->newvarlist)
 			{
-				Expr	   *newvar_entry = (Expr *) list_nth(ctx->newvarlist,
+				Expr	*newvar_entry = (Expr *) list_nth(ctx->newvarlist,
 															  targetattno - 1);
-
 				while (IsA(newvar_entry, RelabelType))
 					newvar_entry = (Expr *) ((RelabelType *) newvar_entry)->arg;
 				newnode = (Node *) copyObject(newvar_entry);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6648,3 +6648,34 @@ PARTITION BY RANGE (year)
 ( START (2010) END (2012) EVERY (1),
   DEFAULT PARTITION outlying_years );
 drop table p3_sales;
+-- Test TargetList Relabel when pulling equivalence up
+CREATE TABLE test_pullup_ec (id varchar(10), val int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (val) (START (1) END (11) EVERY (5));
+INSERT INTO test_pullup_ec VALUES ('a', 1), ('a', 6), ('b', 2), ('b', 7), ('c', 3);
+-- Trigger: Casting the distribution key to text in the SELECT clause (a binary-compatible cast).
+-- After `apply_scanjoin_target_to_paths` pushes down `id::text`,
+-- the child partition's `reltarget` becomes `RelabelType(Var(id, varchar))`.
+-- Old logic: `IsA(tlistexpr, Var)` checks the `RelabelType` -> fails -> marks as Strewn.
+-- New logic: Strips the `RelabelType` -> finds the underlying `Var` -> Pull-Up succeeds -> retains Hashed(id).
+EXPLAIN (COSTS OFF) SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: ((test_pullup_ec_1_prt_1.id)::text)
+         ->  Append
+               ->  Seq Scan on test_pullup_ec_1_prt_1
+               ->  Seq Scan on test_pullup_ec_1_prt_2
+ Optimizer: Postgres-based planner
+(7 rows)
+
+SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text ORDER BY 1;
+ id | count 
+----+-------
+ a  |     2
+ b  |     2
+ c  |     1
+(3 rows)
+
+DROP TABLE test_pullup_ec;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6619,3 +6619,37 @@ PARTITION BY RANGE (year)
 ( START (2010) END (2012) EVERY (1),
   DEFAULT PARTITION outlying_years );
 drop table p3_sales;
+-- Test TargetList Relabel when pulling equivalence up
+CREATE TABLE test_pullup_ec (id varchar(10), val int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (val) (START (1) END (11) EVERY (5));
+INSERT INTO test_pullup_ec VALUES ('a', 1), ('a', 6), ('b', 2), ('b', 7), ('c', 3);
+-- Trigger: Casting the distribution key to text in the SELECT clause (a binary-compatible cast).
+-- After `apply_scanjoin_target_to_paths` pushes down `id::text`,
+-- the child partition's `reltarget` becomes `RelabelType(Var(id, varchar))`.
+-- Old logic: `IsA(tlistexpr, Var)` checks the `RelabelType` -> fails -> marks as Strewn.
+-- New logic: Strips the `RelabelType` -> finds the underlying `Var` -> Pull-Up succeeds -> retains Hashed(id).
+EXPLAIN (COSTS OFF) SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: ((id)::text)
+         ->  Sort
+               Sort Key: ((id)::text)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ((id)::text)
+                     ->  Dynamic Seq Scan on test_pullup_ec
+                           Number of partitions to scan: 2 (out of 2)
+ Optimizer: GPORCA
+(10 rows)
+
+SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text ORDER BY 1;
+ id | count 
+----+-------
+ a  |     2
+ b  |     2
+ c  |     1
+(3 rows)
+
+DROP TABLE test_pullup_ec;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4252,3 +4252,21 @@ PARTITION BY RANGE (year)
   DEFAULT PARTITION outlying_years );
 
 drop table p3_sales;
+
+-- Test TargetList Relabel when pulling equivalence up
+CREATE TABLE test_pullup_ec (id varchar(10), val int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (val) (START (1) END (11) EVERY (5));
+
+INSERT INTO test_pullup_ec VALUES ('a', 1), ('a', 6), ('b', 2), ('b', 7), ('c', 3);
+
+-- Trigger: Casting the distribution key to text in the SELECT clause (a binary-compatible cast).
+-- After `apply_scanjoin_target_to_paths` pushes down `id::text`,
+-- the child partition's `reltarget` becomes `RelabelType(Var(id, varchar))`.
+-- Old logic: `IsA(tlistexpr, Var)` checks the `RelabelType` -> fails -> marks as Strewn.
+-- New logic: Strips the `RelabelType` -> finds the underlying `Var` -> Pull-Up succeeds -> retains Hashed(id).
+EXPLAIN (COSTS OFF) SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text;
+
+SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text ORDER BY 1;
+
+DROP TABLE test_pullup_ec;


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
When a query casts a partitioned table's distribution key to a                                                                                                                                                                            
binary-compatible type (e.g. `varchar::text`), the planner incorrectly                                                                                                                                                                    
process the re-label Var in `pullUpExpr_mutator()`.

## Reproduction

```sql
CREATE TABLE test_pullup_ec (id varchar(10), val int)
DISTRIBUTED BY (id)
PARTITION BY RANGE (val) (START (1) END (11) EVERY (5));

EXPLAIN (COSTS OFF) SELECT id::text, count(*) FROM test_pullup_ec GROUP BY id::text;
ERROR:  could not pull up equivalence class using projected target list (pathkeys.c:1539)
```

## RCA

`apply_scanjoin_target_to_paths()` pushes the outer query's projection                                                                                                                                                                    
down to partition child rels. For a binary-compatible cast like `id::text`,
this produces a `RelabelType(Var(id, varchar))` node in each partition                                                                                                                                                                    
child's `reltarget->exprs`.                                                                                                                                                                                                               
                                                                                                                                                                                                                                            
When `create_append_path()` later calls `cdbpathlocus_pull_above_projection()`                                                                                                                                                            
to derive the `AppendPath`'s locus, it invokes `cdbpullup_expr()` to rewrite                                                                                                                                                              
the distribution key expression in terms of the partition child's target. 
Inside `pullUpExpr_mutator()`, the code that handles `List of Expr`                                                                                                                                                                       
targetlists (i.e., planner-side `reltarget->exprs`, not plan-node                                                                                                                                                                         
`TargetEntry` lists) compared the distribution key Var directly against                                                                                                                                                                   
each targetlist entry:                                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
```cpp                                                                                                                                                                                                                            
if (IsA(tlistexpr, Var))  /* fails when tlistexpr is RelabelType(Var) */
```                                                                                                                                                              
                                                                                                                                                                                                                                            
Because tlistexpr is a RelabelType node rather than a plain Var,                                                                                                                                                                          
the check fails, the Var is not found, and Pull-Up returns NULL.                                                                                                                                                                          
`cdbpathlocus_pull_above_projection()` then falls back to a Strewn locus,                                                                                                                                                                   
losing the Hashed(id) distribution information for the `AppendPath`.  

## Fix

Strip RelabelType nodes before matching, mirroring the approach already
used in `cdbpullup_findEclassInTargetList()`:

```cpp
naked_tlistexpr = tlistexpr;                                                                                                                                                                                                            
while (IsA(naked_tlistexpr, RelabelType))
    naked_tlistexpr = (Expr *) ((RelabelType *) naked_tlistexpr)->arg;                                                                                                                                                                    
   
if (IsA(naked_tlistexpr, Var))  /* now correctly matches */ 
```

When substituting from newvarlist, also strip `RelabelType` from the                                                                                                                                                                        
substituted entry before returning it. This is required because                                                                                                                                                                         
`expression_tree_mutator` re-wraps the substituted inner `Var` in the outer                                                                                                                                                                   
`RelabelType` at the call site; without stripping, the `newvarlist` entry                                                                                                                                                                     
would be returned in full and then re-wrapped.