### PR TITLE
ORCA(fix):  Preserve EUnused across PcrCopy

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
@@ -88,7 +88,7 @@ public:
 
 	// create a column reference given its type, attno, nullability and name
 	CColRef *PcrCreate(const IMDType *pmdtype, INT type_modifier,
-					   BOOL mark_as_used, IMDId *mdid_table, INT attno,
+					   CColRef::EUsedStatus usage, IMDId *mdid_table, INT attno,
 					   BOOL is_nullable, ULONG id, const CName &name,
 					   ULONG ulOpSource, BOOL isDistCol,
 					   ULONG ulWidth = gpos::ulong_max);

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -207,9 +207,10 @@ CColumnFactory::PcrCreate(const CColumnDescriptor *pcoldesc, ULONG id,
 //---------------------------------------------------------------------------
 CColRef *
 CColumnFactory::PcrCreate(const IMDType *pmdtype, INT type_modifier,
-						  BOOL mark_as_used, IMDId *mdid_table, INT attno,
-						  BOOL is_nullable, ULONG id, const CName &name,
-						  ULONG ulOpSource, BOOL isDistCol, ULONG ulWidth)
+						  CColRef::EUsedStatus usage, IMDId *mdid_table,
+						  INT attno, BOOL is_nullable, ULONG id,
+						  const CName &name, ULONG ulOpSource, BOOL isDistCol,
+						  ULONG ulWidth)
 {
 	CName *pnameCopy = GPOS_NEW(m_mp) CName(m_mp, name);
 	CAutoP<CName> a_pnameCopy(pnameCopy);
@@ -223,9 +224,20 @@ CColumnFactory::PcrCreate(const IMDType *pmdtype, INT type_modifier,
 	// ensure uniqueness
 	GPOS_ASSERT(nullptr == LookupColRef(id));
 	m_sht.Insert(colref);
-	if (mark_as_used)
+
+	// Preserve the source's tristate usage.
+	switch (usage)
 	{
-		colref->MarkAsUsed();
+		case CColRef::EUsed:
+			colref->MarkAsUsed();
+			break;
+		case CColRef::EUnused:
+			colref->MarkAsUnused();
+			break;
+		case CColRef::EUnknown:
+		default:
+			// constructor default
+			break;
 	}
 	colref->SetMdidTable(mdid_table);
 
@@ -273,10 +285,10 @@ CColumnFactory::PcrCopy(const CColRef *colref)
 		CColRefTable::PcrConvert(const_cast<CColRef *>(colref));
 
 	return PcrCreate(colref->RetrieveType(), colref->TypeModifier(),
-					 colref->GetUsage(true, true) == CColRef::EUsed,
-					 colref->GetMdidTable(), pcrTable->AttrNum(),
-					 pcrTable->IsNullable(), id, name, pcrTable->UlSourceOpId(),
-					 colref->IsDistCol(), pcrTable->Width());
+					 colref->GetUsage(true, true), colref->GetMdidTable(),
+					 pcrTable->AttrNum(), pcrTable->IsNullable(), id, name,
+					 pcrTable->UlSourceOpId(), colref->IsDistCol(),
+					 pcrTable->Width());
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/server/include/unittest/gpopt/base/CColumnFactoryTest.h
+++ b/src/backend/gporca/server/include/unittest/gpopt/base/CColumnFactoryTest.h
@@ -31,6 +31,7 @@ public:
 	// actual unittests
 	static GPOS_RESULT EresUnittest();
 	static GPOS_RESULT EresUnittest_Basic();
+	static GPOS_RESULT EresUnittest_PcrCopyPreservesUsage();
 };
 }  // namespace gpopt
 

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -237,7 +237,7 @@ CJoinCardinalityTest::EresUnittest_Join()
 			(void) col_factory->PcrCreate(
 				pmdtypeint4, default_type_modifier, CColRef::EUsed,
 				nullptr, ul /* attno */, false /*IsNullable*/, id, CName(&str),
-				false /*IsDistCol*/, false);
+				0 /*ulOpSource*/, false /*isDistCol*/);
 		}
 	}
 	cols->Release();

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -235,7 +235,7 @@ CJoinCardinalityTest::EresUnittest_Join()
 			CWStringConst str(GPOS_WSZ_LIT("col"));
 			// create column references for grouping columns
 			(void) col_factory->PcrCreate(
-				pmdtypeint4, default_type_modifier, true /*mark_as_used*/,
+				pmdtypeint4, default_type_modifier, CColRef::EUsed,
 				nullptr, ul /* attno */, false /*IsNullable*/, id, CName(&str),
 				false /*IsDistCol*/, false);
 		}

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -400,7 +400,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	{
 		// create column references for grouping columns
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			pmdtypeint4, default_type_modifier, CColRef::EUsed, nullptr,
 			0 /* attno */, false /*IsNullable*/, 1 /* id */, CName(&strColA),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);
@@ -409,7 +409,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	if (nullptr == col_factory->LookupColRef(2 /*id*/))
 	{
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			pmdtypeint4, default_type_modifier, CColRef::EUsed, nullptr,
 			1 /* attno */, false /*IsNullable*/, 2 /* id */, CName(&strColB),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);
@@ -418,7 +418,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	if (nullptr == col_factory->LookupColRef(10 /*id*/))
 	{
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			pmdtypeint4, default_type_modifier, CColRef::EUsed, nullptr,
 			2 /* attno */, false /*IsNullable*/, 10 /* id */, CName(&strColC),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);

--- a/src/backend/gporca/server/src/unittest/gpopt/base/CColumnFactoryTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/base/CColumnFactoryTest.cpp
@@ -40,7 +40,8 @@ GPOS_RESULT
 CColumnFactoryTest::EresUnittest()
 {
 	CUnittest rgut[] = {
-		GPOS_UNITTEST_FUNC(CColumnFactoryTest::EresUnittest_Basic)};
+		GPOS_UNITTEST_FUNC(CColumnFactoryTest::EresUnittest_Basic),
+		GPOS_UNITTEST_FUNC(CColumnFactoryTest::EresUnittest_PcrCopyPreservesUsage)};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
 }
@@ -87,6 +88,76 @@ CColumnFactoryTest::EresUnittest_Basic()
 	cf.Destroy(pcrThree);
 
 	cf.Destroy(pcrTwo);
+
+	return GPOS_OK;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CColumnFactoryTest::EresUnittest_PcrCopyPreservesUsage
+//
+//	@doc:
+//		Verify that PcrCopy preserves the source colref's EUsedStatus
+//		tristate (EUsed / EUnused / EUnknown). Regression guard against
+//		re-introduction of the BOOL collapse: previously, an EUnused
+//		source colref was copied as EUnknown because PcrCopy passed a
+//		BOOL through PcrCreate.
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CColumnFactoryTest::EresUnittest_PcrCopyPreservesUsage()
+{
+	CAutoMemoryPool amp;
+	CMemoryPool *mp = amp.Pmp();
+
+	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
+	pmdp->AddRef();
+	CMDAccessor mda(mp, CMDCache::Pcache());
+	mda.RegisterProvider(CTestUtils::m_sysidDefault, pmdp);
+
+	const IMDTypeInt4 *pmdtypeint4 = mda.PtMDType<IMDTypeInt4>();
+
+	CColumnFactory cf;
+
+	// Exercise all three EUsedStatus values through the PcrCopy round-trip.
+	const CColRef::EUsedStatus rgUsage[] = {
+		CColRef::EUsed,
+		CColRef::EUnused,
+		CColRef::EUnknown};
+
+	for (ULONG ul = 0; ul < GPOS_ARRAY_SIZE(rgUsage); ul++)
+	{
+		CWStringConst str(GPOS_WSZ_LIT("col"));
+
+		// Create a CColRefTable with the desired EUsedStatus. PcrCopy
+		// short-circuits computed colrefs, so we need the table variant
+		// to exercise the lossy code path that was fixed.
+		// Use large explicit ids to avoid colliding with PcrCopy's
+		// internal m_aul counter on the second/third iterations.
+		const ULONG ulId = 1000 + ul;
+		CColRef *pcrOriginal = cf.PcrCreate(
+			pmdtypeint4, default_type_modifier, rgUsage[ul],
+			nullptr /*mdid_table*/, ul /*attno*/, false /*is_nullable*/,
+			ulId /*id*/, CName(&str), 0 /*ulOpSource*/, false /*isDistCol*/);
+
+		// Sanity: original carries the requested usage.
+		GPOS_UNITTEST_ASSERT(rgUsage[ul] ==
+							 pcrOriginal->GetUsage(false /*system_eq_used*/,
+												   false /*dist_eq_used*/));
+
+		CColRef *pcrCopy = cf.PcrCopy(pcrOriginal);
+
+		// Contract: PcrCopy must preserve EUsedStatus. Previously this
+		// failed for EUnused (copy ends up as EUnknown because the BOOL
+		// collapse loses the distinction).
+		GPOS_UNITTEST_ASSERT(rgUsage[ul] ==
+							 pcrCopy->GetUsage(false /*system_eq_used*/,
+											   false /*dist_eq_used*/));
+
+		cf.Destroy(pcrCopy);
+		cf.Destroy(pcrOriginal);
+	}
 
 	return GPOS_OK;
 }


### PR DESCRIPTION
## Summary

Fixes a lossy tristate→BOOL collapse in `CColumnFactory::PcrCopy` that silently violates the post-translation `EUsedStatus` invariant from commit (`801b7a920b6`). This is one of the upstream root cause of the extra columns in the `CXformGbAggWithMDQA2Join` trasform fixed in [this](https://github.com/warehouse-pg/warehouse-pg/pull/149) PR.

## Background

ORCA tracks column "used-ness" with a tristate `CColRef::EUsedStatus` (`EUsed` / `EUnused` / `EUnknown`). The
translator marks colrefs `EUsed` during DXL→Expr walks; at the end of translation, `MarkUnknownColsAsUnused` flips remaining `EUnknown` to `EUnused`. After that point, the system invariant is **"no `EUnknown` colref exists in the expression tree."**

`PcrCopy` was silently violating that invariant. The 11-arg`PcrCreate` overload it routes through took a `BOOL mark_as_used`, into which `PcrCopy` collapsed the source's tristate as `colref->GetUsage(true,true) == EUsed`. So:

| Source `EUsedStatus` | bool passed | Resulting copy |
|---|---|---|
| `EUsed` | `true` | `EUsed` |
| **`EUnused`** | **`false`** | **`EUnknown` — laundered** |
| `EUnknown` | `false` | `EUnknown` |

The `EUnused → EUnknown` laundering defeats `CLogicalGet::DeriveOutputColumns`'s filter (which keeps
`EUsed || EUnknown`, drops `EUnused`). Unused columns leak into the
optimizer's column accounting, end up in`reqd_prop_plan->PcrsRequired()`, then are dropped at DXL emit by
`CTranslatorExprToDXL.cpp` (`!= EUsed`). 

## Connection to [PR-149](https://github.com/warehouse-pg/warehouse-pg/pull/149)

The partitioned-MDQA SIGSEGV reproducer is a victim of these extra columns. 

**The xform-level clip in `CXformGbAggWithMDQA2Join` was asymptom-level fix** . **This PR fixes the upstream root cause** in `PcrCopy` itself, so every xform that copies a `Get`'s output array post-translation now preserves `EUnused` correctly. 




## References

- `801b7a920b6` (#480) — original `EUsedStatus` framework.
- `c78b4e04d8` (#521) — trip-wire assertion at `CTranslatorExprToDXL.cpp:6903`.
- `7e27a4990a` — introduced the lossy `BOOL` collapse this PR replaces.
- **[PR-149](https://github.com/warehouse-pg/warehouse-pg/pull/149)** — symptom-level fix in `CXformGbAggWithMDQA2Join`

