### PR TITLE
fix(orca): remove stale assert in PcnstrFromChildPartition

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/ListPartTextKeyNoConstEval.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartTextKeyNoConstEval.mdp
@@ -1,0 +1,468 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    What this minidump tests -
+             Captures the ORCA plan for a LIST-partitioned table whose
+             partition key is a non-numeric type (text), with
+             optimizer_enable_constant_expression_evaluation = off.
+
+        Query & Plan:
+        --------------------
+        CREATE TABLE lp_text (a int, b text)
+            DISTRIBUTED BY (a) PARTITION BY LIST (b);
+        CREATE TABLE lp_text_1   PARTITION OF lp_text FOR VALUES IN ('a');
+        CREATE TABLE lp_text_2   PARTITION OF lp_text FOR VALUES IN ('b');
+        CREATE TABLE lp_text_def PARTITION OF lp_text DEFAULT;
+        INSERT INTO lp_text VALUES (1,'a'), (2,'b'), (3,'c');
+
+        SET optimizer_enable_constant_expression_evaluation = off;
+        EXPLAIN (COSTS OFF) SELECT * FROM lp_text WHERE b = 'a';
+                                  QUERY PLAN
+        -------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)
+           ->  Dynamic Seq Scan on lp_text
+                 Number of partitions to scan: 3 (out of 3)
+                 Filter: (b = 'a'::text)
+         Optimizer: GPORCA
+        (5 rows)
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" ArrayIntervalThreshold="1000" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:PlanHint/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,103048,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationExtendedStatistics Mdid="10.34268.1.0" Name="bar"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="6.34276.1.0" Name="bar_1_prt_p_na" IsTemporary="false" Rows="3.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
+          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVT" LintValue="3366568420"/>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkNB" LintValue="2740167981"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.34286.1.0" Name="bar_1_prt_p_asia" IsTemporary="false" Rows="2.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
+          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkpQ" LintValue="960410733"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.34281.1.0" Name="bar_1_prt_p_eu" IsTemporary="false" Rows="2.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
+          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVL" LintValue="2460074482"/>
+                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkRF" LintValue="1060479085"/>
+              </dxl:Array>
+            </dxl:ArrayComp>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+          <dxl:Opfamily Mdid="0.10022.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.34268.1.0" Name="bar" Rows="10.000000" RelPages="8" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.34268.1.0" Name="bar" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
+          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.34276.1.0"/>
+          <dxl:Partition Mdid="6.34281.1.0"/>
+          <dxl:Partition Mdid="6.34286.1.0"/>
+          <dxl:Partition Mdid="6.34271.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.34268.1.0.1" Name="region" Width="3.000000" NullFreq="0.000000" NdvRemain="7.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.34268.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Relation Mdid="6.34271.1.0" Name="bar_1_prt_lp_default" IsTemporary="false" Rows="3.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
+          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+                <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkNB" LintValue="2740167981"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkRF" LintValue="1060479085"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkpQ" LintValue="960410733"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVL" LintValue="2460074482"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVT" LintValue="3366568420"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+        <dxl:Ident ColId="3" ColName="amount" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:IsNull>
+          <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+        </dxl:IsNull>
+        <dxl:LogicalGet HasSecurityQuals="false">
+          <dxl:TableDescriptor Mdid="6.34268.1.0" TableName="bar" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="region" TypeMdid="0.25.1.0" ColWidth="3"/>
+              <dxl:Column ColId="3" Attno="3" ColName="amount" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000233" Rows="1.000000" Width="11"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="id">
+            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="region">
+            <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="amount">
+            <dxl:Ident ColId="2" ColName="amount" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:DynamicTableScan SelectorIds="">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000192" Rows="1.000000" Width="11"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="id">
+              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="region">
+              <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="amount">
+              <dxl:Ident ColId="2" ColName="amount" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:IsNull>
+              <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
+            </dxl:IsNull>
+          </dxl:Filter>
+          <dxl:Partitions>
+            <dxl:Partition Mdid="6.34276.1.0"/>
+            <dxl:Partition Mdid="6.34281.1.0"/>
+            <dxl:Partition Mdid="6.34286.1.0"/>
+            <dxl:Partition Mdid="6.34271.1.0"/>
+          </dxl:Partitions>
+          <dxl:TableDescriptor Mdid="6.34268.1.0" TableName="bar" LockMode="1" AclMode="2">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="region" TypeMdid="0.25.1.0" ColWidth="3"/>
+              <dxl:Column ColId="2" Attno="3" ColName="amount" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:DynamicTableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ListPartTextKeyNoConstEval.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ListPartTextKeyNoConstEval.mdp
@@ -37,12 +37,11 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" ArrayIntervalThreshold="1000" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
       <dxl:PlanHint/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,103048,104002,104003,104004,104005,106000"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:RelationExtendedStatistics Mdid="10.34268.1.0" Name="bar"/>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -97,6 +96,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.57105.1.0.1" Name="b" Width="2.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.57105.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -165,11 +166,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Relation Mdid="6.34276.1.0" Name="bar_1_prt_p_na" IsTemporary="false" Rows="3.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:Relation Mdid="6.57108.1.0" Name="lp_text_1" IsTemporary="false" Rows="1.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
         <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
-          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="2"/>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
           <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
           <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
@@ -186,53 +186,77 @@
         <dxl:PartConstraint>
           <dxl:And>
             <dxl:IsNotNull>
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-            </dxl:IsNotNull>
-            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-              <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVT" LintValue="3366568420"/>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkNB" LintValue="2740167981"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-          </dxl:And>
-        </dxl:PartConstraint>
-      </dxl:Relation>
-      <dxl:Relation Mdid="6.34286.1.0" Name="bar_1_prt_p_asia" IsTemporary="false" Rows="2.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
-        <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
-          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-        <dxl:PartConstraint>
-          <dxl:And>
-            <dxl:IsNotNull>
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:IsNotNull>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkpQ" LintValue="960410733"/>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="1075015857"/>
             </dxl:Comparison>
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Relation Mdid="6.34281.1.0" Name="bar_1_prt_p_eu" IsTemporary="false" Rows="2.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:RelationStatistics Mdid="2.57105.1.0" Name="lp_text" Rows="3.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.57105.1.0" Name="lp_text" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="l">
         <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
-          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="2"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.57108.1.0"/>
+          <dxl:Partition Mdid="6.57113.1.0"/>
+          <dxl:Partition Mdid="6.57118.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.57118.1.0" Name="lp_text_def" IsTemporary="false" Rows="1.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="2"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:Not>
+            <dxl:And>
+              <dxl:IsNotNull>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+              </dxl:IsNotNull>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+                <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="1075015857"/>
+                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="4226146208"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
+            </dxl:And>
+          </dxl:Not>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.57113.1.0" Name="lp_text_2" IsTemporary="false" Rows="1.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="b" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="2"/>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
           <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
           <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
@@ -249,18 +273,16 @@
         <dxl:PartConstraint>
           <dxl:And>
             <dxl:IsNotNull>
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:IsNotNull>
-            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-              <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-              <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVL" LintValue="2460074482"/>
-                <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkRF" LintValue="1060479085"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWI=" LintValue="4226146208"/>
+            </dxl:Comparison>
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.57105.1.0" Name="lp_text"/>
       <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>
@@ -282,122 +304,30 @@
           <dxl:Opfamily Mdid="0.10022.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:RelationStatistics Mdid="2.34268.1.0" Name="bar" Rows="10.000000" RelPages="8" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.34268.1.0" Name="bar" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,9,3" PartitionColumns="1" PartitionTypes="l">
-        <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
-          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-        <dxl:Partitions>
-          <dxl:Partition Mdid="6.34276.1.0"/>
-          <dxl:Partition Mdid="6.34281.1.0"/>
-          <dxl:Partition Mdid="6.34286.1.0"/>
-          <dxl:Partition Mdid="6.34271.1.0"/>
-        </dxl:Partitions>
-      </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.34268.1.0.1" Name="region" Width="3.000000" NullFreq="0.000000" NdvRemain="7.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.34268.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.16666666666666666" DistinctValues="1.66666666666666674">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:Relation Mdid="6.34271.1.0" Name="bar_1_prt_lp_default" IsTemporary="false" Rows="3.000000" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
-        <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="region" Attno="2" Mdid="0.25.1.0" Nullable="true" ColWidth="3"/>
-          <dxl:Column Name="amount" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-        <dxl:PartConstraint>
-          <dxl:Not>
-            <dxl:And>
-              <dxl:IsNotNull>
-                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-              </dxl:IsNotNull>
-              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
-                <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-                <dxl:Array ArrayType="0.1009.1.0" ElementType="0.25.1.0" MultiDimensional="false">
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkNB" LintValue="2740167981"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkRF" LintValue="1060479085"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABkpQ" LintValue="960410733"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVL" LintValue="2460074482"/>
-                  <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABlVT" LintValue="3366568420"/>
-                </dxl:Array>
-              </dxl:ArrayComp>
-            </dxl:And>
-          </dxl:Not>
-        </dxl:PartConstraint>
-      </dxl:Relation>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
-        <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-        <dxl:Ident ColId="3" ColName="amount" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalSelect>
-        <dxl:IsNull>
-          <dxl:Ident ColId="2" ColName="region" TypeMdid="0.25.1.0"/>
-        </dxl:IsNull>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.25.1.0"/>
+          <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="1075015857"/>
+        </dxl:Comparison>
         <dxl:LogicalGet HasSecurityQuals="false">
-          <dxl:TableDescriptor Mdid="6.34268.1.0" TableName="bar" LockMode="1" AclMode="2">
+          <dxl:TableDescriptor Mdid="6.57105.1.0" TableName="lp_text" LockMode="1" AclMode="2">
             <dxl:Columns>
-              <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="2" Attno="2" ColName="region" TypeMdid="0.25.1.0" ColWidth="3"/>
-              <dxl:Column ColId="3" Attno="3" ColName="amount" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="2"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
@@ -406,59 +336,52 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000233" Rows="1.000000" Width="11"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="6"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="id">
-            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="region">
-            <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="amount">
-            <dxl:Ident ColId="2" ColName="amount" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
         <dxl:DynamicTableScan SelectorIds="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000192" Rows="1.000000" Width="11"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="6"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="id">
-              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="region">
-              <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="amount">
-              <dxl:Ident ColId="2" ColName="amount" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter>
-            <dxl:IsNull>
-              <dxl:Ident ColId="1" ColName="region" TypeMdid="0.25.1.0"/>
-            </dxl:IsNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="1075015857"/>
+            </dxl:Comparison>
           </dxl:Filter>
           <dxl:Partitions>
-            <dxl:Partition Mdid="6.34276.1.0"/>
-            <dxl:Partition Mdid="6.34281.1.0"/>
-            <dxl:Partition Mdid="6.34286.1.0"/>
-            <dxl:Partition Mdid="6.34271.1.0"/>
+            <dxl:Partition Mdid="6.57108.1.0"/>
+            <dxl:Partition Mdid="6.57113.1.0"/>
+            <dxl:Partition Mdid="6.57118.1.0"/>
           </dxl:Partitions>
-          <dxl:TableDescriptor Mdid="6.34268.1.0" TableName="bar" LockMode="1" AclMode="2">
+          <dxl:TableDescriptor Mdid="6.57105.1.0" TableName="lp_text" LockMode="1" AclMode="2">
             <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="1" Attno="2" ColName="region" TypeMdid="0.25.1.0" ColWidth="3"/>
-              <dxl:Column ColId="2" Attno="3" ColName="amount" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="2"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:DynamicTableScan>

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -3003,7 +3003,6 @@ CExpressionPreprocessor::PcnstrFromChildPartition(
 		IMDIndex::EmdindBtree);
 	CRefCount::SafeRelease(part_constraint_expr);
 	CRefCount::SafeRelease(pdrgpcrsChild);
-	GPOS_ASSERT(cnstr);
 	return cnstr;
 }
 

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -252,7 +252,8 @@ PartTbl-SPE-DynamicTableScan-Range-Cost1 PartTbl-SPE-DynamicTableScan-Range-Cost
 PartTbl-SPE-DynamicTableScan-Range-Cost3 PartTbl-SPE-DynamicTableScan-Range-Cost4
 PartTbl-SPE-DynamicTableScan-Range-Cost5 PartTbl-SPE-DynamicTableScan-List-Cost1
 PartTbl-SPE-DynamicTableScan-List-Cost2 PartTbl-SPE-DynamicTableScan-List-Cost3
-PartTbl-SPE-DynamicTableScan-List-Cost4 PartTbl-SPE-DynamicTableScan-List-Cost5;
+PartTbl-SPE-DynamicTableScan-List-Cost4 PartTbl-SPE-DynamicTableScan-List-Cost5
+ListPartTextKeyNoConstEval;
 
 CPartTblSPEBoolTest:
 PartTbl-SPE-Boolean1 PartTbl-SPE-Boolean2;

--- a/src/test/regress/expected/orca_static_pruning.out
+++ b/src/test/regress/expected/orca_static_pruning.out
@@ -301,3 +301,77 @@ SELECT * FROM rp_insert;
  1 | 1
 (4 rows)
 
+-- Static partition pruning on LIST-partitioned tables with a
+-- non-numeric key type (text, varchar) when constant expression
+-- evaluation is disabled. The optimizer should plan and execute the
+-- query correctly.
+SET optimizer_enable_constant_expression_evaluation = off;
+-- text-keyed LIST partition
+CREATE TABLE lp_text (a int, b text) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_text_1 PARTITION OF lp_text FOR VALUES IN ('a');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_text_2 PARTITION OF lp_text FOR VALUES IN ('b');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_text_def PARTITION OF lp_text DEFAULT;
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO lp_text VALUES (1, 'a'), (2, 'b'), (3, 'c');
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: lp_text_1.a, lp_text_1.b
+   ->  Seq Scan on orca_static_pruning.lp_text_1
+         Output: lp_text_1.a, lp_text_1.b
+         Filter: (lp_text_1.b = 'a'::text)
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off', optimizer_enable_constant_expression_evaluation = 'off'
+(7 rows)
+
+SELECT * FROM lp_text WHERE b = 'a';
+ a | b 
+---+---
+ 1 | a
+(1 row)
+
+-- varchar-keyed LIST partition
+CREATE TABLE lp_varchar (a int, b varchar(8)) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_varchar_1 PARTITION OF lp_varchar FOR VALUES IN ('x');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_varchar_2 PARTITION OF lp_varchar FOR VALUES IN ('y');
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO lp_varchar VALUES (1, 'x'), (2, 'y');
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_varchar WHERE b = 'x';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: lp_varchar_1.a, lp_varchar_1.b
+   ->  Seq Scan on orca_static_pruning.lp_varchar_1
+         Output: lp_varchar_1.a, lp_varchar_1.b
+         Filter: ((lp_varchar_1.b)::text = 'x'::text)
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off', optimizer_enable_constant_expression_evaluation = 'off'
+(7 rows)
+
+SELECT * FROM lp_varchar WHERE b = 'x';
+ a | b 
+---+---
+ 1 | x
+(1 row)
+
+-- Negative control: same text-keyed table with the GUC ON.
+SET optimizer_enable_constant_expression_evaluation = on;
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: lp_text_1.a, lp_text_1.b
+   ->  Seq Scan on orca_static_pruning.lp_text_1
+         Output: lp_text_1.a, lp_text_1.b
+         Filter: (lp_text_1.b = 'a'::text)
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(7 rows)
+
+RESET optimizer_enable_constant_expression_evaluation;
+DROP TABLE lp_text;
+DROP TABLE lp_varchar;

--- a/src/test/regress/expected/orca_static_pruning_optimizer.out
+++ b/src/test/regress/expected/orca_static_pruning_optimizer.out
@@ -317,3 +317,79 @@ SELECT * FROM rp_insert;
  1 | 1
 (4 rows)
 
+-- Static partition pruning on LIST-partitioned tables with a
+-- non-numeric key type (text, varchar) when constant expression
+-- evaluation is disabled. The optimizer should plan and execute the
+-- query correctly.
+SET optimizer_enable_constant_expression_evaluation = off;
+-- text-keyed LIST partition
+CREATE TABLE lp_text (a int, b text) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_text_1 PARTITION OF lp_text FOR VALUES IN ('a');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_text_2 PARTITION OF lp_text FOR VALUES IN ('b');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_text_def PARTITION OF lp_text DEFAULT;
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO lp_text VALUES (1, 'a'), (2, 'b'), (3, 'c');
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a, b
+   ->  Dynamic Seq Scan on orca_static_pruning.lp_text
+         Output: a, b
+         Number of partitions to scan: 3 (out of 3)
+         Filter: (lp_text.b = 'a'::text)
+ Optimizer: GPORCA
+ Settings: optimizer_enable_constant_expression_evaluation = 'off'
+(8 rows)
+
+SELECT * FROM lp_text WHERE b = 'a';
+ a | b 
+---+---
+ 1 | a
+(1 row)
+
+-- varchar-keyed LIST partition
+CREATE TABLE lp_varchar (a int, b varchar(8)) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_varchar_1 PARTITION OF lp_varchar FOR VALUES IN ('x');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE lp_varchar_2 PARTITION OF lp_varchar FOR VALUES IN ('y');
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO lp_varchar VALUES (1, 'x'), (2, 'y');
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_varchar WHERE b = 'x';
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a, b
+   ->  Dynamic Seq Scan on orca_static_pruning.lp_varchar
+         Output: a, b
+         Number of partitions to scan: 2 (out of 2)
+         Filter: ((lp_varchar.b)::text = 'x'::text)
+ Optimizer: GPORCA
+ Settings: optimizer_enable_constant_expression_evaluation = 'off'
+(8 rows)
+
+SELECT * FROM lp_varchar WHERE b = 'x';
+ a | b 
+---+---
+ 1 | x
+(1 row)
+
+-- Negative control: same text-keyed table with the GUC ON.
+SET optimizer_enable_constant_expression_evaluation = on;
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a, b
+   ->  Dynamic Seq Scan on orca_static_pruning.lp_text
+         Output: a, b
+         Number of partitions to scan: 1 (out of 3)
+         Filter: (lp_text.b = 'a'::text)
+ Optimizer: GPORCA
+(7 rows)
+
+RESET optimizer_enable_constant_expression_evaluation;
+DROP TABLE lp_text;
+DROP TABLE lp_varchar;

--- a/src/test/regress/sql/orca_static_pruning.sql
+++ b/src/test/regress/sql/orca_static_pruning.sql
@@ -149,3 +149,38 @@ INSERT INTO rp_insert VALUES (1, 1), (3, 3);
 EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert SELECT * FROM rp_insert;
 INSERT INTO rp_insert SELECT * FROM rp_insert;
 SELECT * FROM rp_insert;
+
+-- Static partition pruning on LIST-partitioned tables with a
+-- non-numeric key type (text, varchar) when constant expression
+-- evaluation is disabled. The optimizer should plan and execute the
+-- query correctly.
+
+SET optimizer_enable_constant_expression_evaluation = off;
+
+-- text-keyed LIST partition
+CREATE TABLE lp_text (a int, b text) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_text_1 PARTITION OF lp_text FOR VALUES IN ('a');
+CREATE TABLE lp_text_2 PARTITION OF lp_text FOR VALUES IN ('b');
+CREATE TABLE lp_text_def PARTITION OF lp_text DEFAULT;
+INSERT INTO lp_text VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+SELECT * FROM lp_text WHERE b = 'a';
+
+-- varchar-keyed LIST partition
+CREATE TABLE lp_varchar (a int, b varchar(8)) DISTRIBUTED BY (a) PARTITION BY LIST (b);
+CREATE TABLE lp_varchar_1 PARTITION OF lp_varchar FOR VALUES IN ('x');
+CREATE TABLE lp_varchar_2 PARTITION OF lp_varchar FOR VALUES IN ('y');
+INSERT INTO lp_varchar VALUES (1, 'x'), (2, 'y');
+
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_varchar WHERE b = 'x';
+SELECT * FROM lp_varchar WHERE b = 'x';
+
+-- Negative control: same text-keyed table with the GUC ON.
+SET optimizer_enable_constant_expression_evaluation = on;
+EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM lp_text WHERE b = 'a';
+
+RESET optimizer_enable_constant_expression_evaluation;
+
+DROP TABLE lp_text;
+DROP TABLE lp_varchar;


### PR DESCRIPTION
## Summary

A query failure was observed while running static partition elimination (SPE) on a LIST-partitioned table whose partition key column was of type `text`. Specifically, on a `GPOS_DEBUG` build with `optimizer_enable_constant_expression_evaluation = off`, a simple `EXPLAIN SELECT * FROM lp_text WHERE b = 'a';` aborted the backend onan assertion inside ORCA's preprocessing pass.

On debugging, the abort was traced to a `GPOS_ASSERT(cnstr)` at the end of `CExpressionPreprocessor::PcnstrFromChildPartition()`. 

This PR deletes the one-line assert and adds regression + minidumpcoverage so the combination (LIST partition + non-numeric key + GUC off + debug build) doesn't crash again.

## Observations during debugging

PcnstrFromChildPartition() calls CConstraint::PcnstrFromScalarExpr() and then asserted the result was non-null. The function actually has two legitimate paths that return nullptr:

  1. The early `if (nullptr == dxlnode) return nullptr;` exit when GPDB ships no partition-constraint DXL for the leaf.
  2. PcnstrFromScalarExpr itself returns nullptr when the predicate's column type fails CUtils::FConstrainableType — which excludes non-numeric types (text, varchar, uuid, etc.) when optimizer_enable_constant_expression_evaluation is off.

The sole caller (PrunePartitions) already null-checks rel_cnstr. The assert only ever fired in GPOS_DEBUG builds; release builds compile it out and have always behaved correctly.

## Error Log

1) Debug mode, GUC - ON, Query works 


<img width="700" height="760" alt="image" src="https://github.com/user-attachments/assets/79055b03-6022-4e74-a21f-561a37cdd93a" />



2) Debug mode, GUC - OFF, Query fails 

<img width="772" height="810" alt="image" src="https://github.com/user-attachments/assets/197daf49-8cd4-4521-967f-ad90db32801c" />




