### PR TITLE
jit: fix build with LLVM 21

### DIFF
--- a/src/backend/jit/llvm/llvmjit_inline.cpp
+++ b/src/backend/jit/llvm/llvmjit_inline.cpp
@@ -243,7 +243,11 @@ llvm_build_inline_plan(LLVMContextRef lc, llvm::Module *mod)
 
 		llvm_split_symbol_name(symbolName.data(), &cmodname, &cfuncname);
 
+#if LLVM_VERSION_MAJOR >= 21
+		funcGUID = llvm::GlobalValue::getGUIDAssumingExternalLinkage(cfuncname);
+#else
 		funcGUID = llvm::GlobalValue::getGUID(cfuncname);
+#endif
 
 		/* already processed */
 		if (inlineState.processed)

--- a/src/backend/jit/llvm/llvmjit_wrap.cpp
+++ b/src/backend/jit/llvm/llvmjit_wrap.cpp
@@ -110,7 +110,14 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::orc::ObjectLayer, LLVMOrcObjectLayerRef
 LLVMOrcObjectLayerRef
 LLVMOrcCreateRTDyldObjectLinkingLayerWithSafeSectionMemoryManager(LLVMOrcExecutionSessionRef ES)
 {
+#if LLVM_VERSION_MAJOR >= 21
+	return wrap(new llvm::orc::RTDyldObjectLinkingLayer(
+		*unwrap(ES), [](const llvm::MemoryBuffer&) {
+			return std::make_unique<llvm::backport::SectionMemoryManager>(nullptr, true);
+		}));
+#else
 	return wrap(new llvm::orc::RTDyldObjectLinkingLayer(
 		*unwrap(ES), [] { return std::make_unique<llvm::backport::SectionMemoryManager>(nullptr, true); }));
+#endif
 }
 #endif


### PR DESCRIPTION
LLVM 21 made two source-incompatible API changes that broke compilation
of the JIT layer. Add version guards so the same source builds against
both LLVM <21 and LLVM 21.

1. llvm::GlobalValue::getGUID(StringRef) was renamed to
   getGUIDAssumingExternalLinkage(). Used in llvm_build_inline_plan() to
   look up function summaries by GUID.

2. llvm::orc::RTDyldObjectLinkingLayer's GetMemoryManagerFunction type
   changed from
       unique_function<unique_ptr<MemoryManager>()>
   to
       unique_function<unique_ptr<MemoryManager>(const MemoryBuffer&)>
   The lambda passed to its constructor now takes a const MemoryBuffer&.
   This affects LLVMOrcCreateRTDyldObjectLinkingLayerWithSafeSectionMemoryManager(),
   which is compiled unconditionally when USE_LLVM_BACKPORT_SECTION_MEMORY_MANAGER
   is defined.
 
 Cherry-picked two upstream commits to fix them.