### PR TITLE
PTT-1125: Backport May 2026 PG CVE fixes to WHPG_7_2_STABLE

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -12,3 +12,4 @@ TableAmRoutine
 MainLWLockNames
 choose_setop_type
 gp_resgroup_print_operator_memory_limits
+pqFunctionCall3

--- a/contrib/hstore_plperl/hstore_plperl.c
+++ b/contrib/hstore_plperl/hstore_plperl.c
@@ -2,6 +2,7 @@
 
 #include "fmgr.h"
 #include "hstore/hstore.h"
+#include "storage/shmem.h"		/* for mul_size() */
 #include "plperl.h"
 #include "plperl_helpers.h"
 
@@ -121,7 +122,7 @@ plperl_to_hstore(PG_FUNCTION_ARGS)
 
 	pcount = hv_iterinit(hv);
 
-	pairs = palloc(pcount * sizeof(Pairs));
+	pairs = (Pairs *) palloc(mul_size(pcount, sizeof(Pairs)));
 
 	i = 0;
 	while ((he = hv_iternext(hv)))

--- a/contrib/hstore_plpython/hstore_plpython.c
+++ b/contrib/hstore_plpython/hstore_plpython.c
@@ -4,6 +4,7 @@
 #include "plpython.h"
 #include "plpy_typeio.h"
 #include "hstore/hstore.h"
+#include "storage/shmem.h"		/* for mul_size() */
 
 PG_MODULE_MAGIC;
 
@@ -147,7 +148,7 @@ plpython_to_hstore(PG_FUNCTION_ARGS)
 		Py_ssize_t	i;
 		Pairs	   *pairs;
 
-		pairs = palloc(pcount * sizeof(*pairs));
+		pairs = (Pairs *) palloc(mul_size(pcount, sizeof(*pairs)));
 
 		for (i = 0; i < pcount; i++)
 		{

--- a/contrib/intarray/_int_bool.c
+++ b/contrib/intarray/_int_bool.c
@@ -440,32 +440,51 @@ boolop(PG_FUNCTION_ARGS)
 static void
 findoprnd(ITEM *ptr, int32 *pos)
 {
+	int32		mypos;
+
 	/* since this function recurses, it could be driven to stack overflow. */
 	check_stack_depth();
 
+	/* get the position this call is supposed to update */
+	mypos = *pos;
+	Assert(mypos >= 0);
+
+	/* in all cases, we should decrement *pos to advance over this item */
+	(*pos)--;
+
 #ifdef BS_DEBUG
-	elog(DEBUG3, (ptr[*pos].type == OPR) ?
-		 "%d  %c" : "%d  %d", *pos, ptr[*pos].val);
+	elog(DEBUG3, (ptr[mypos].type == OPR) ?
+		 "%d  %c" : "%d  %d", mypos, ptr[mypos].val);
 #endif
-	if (ptr[*pos].type == VAL)
+
+	if (ptr[mypos].type == VAL)
 	{
-		ptr[*pos].left = 0;
-		(*pos)--;
+		/* base case: a VAL has no operand, so just set its left to zero */
+		ptr[mypos].left = 0;
 	}
-	else if (ptr[*pos].val == (int32) '!')
+	else if (ptr[mypos].val == (int32) '!')
 	{
-		ptr[*pos].left = -1;
-		(*pos)--;
+		/* unary operator, likewise easy: operand is just before it */
+		ptr[mypos].left = -1;
+		/* recurse to scan operand */
 		findoprnd(ptr, pos);
 	}
 	else
 	{
-		ITEM	   *curitem = &ptr[*pos];
-		int32		tmp = *pos;
+		/* binary operator */
+		int32		delta;
 
-		(*pos)--;
+		/* recurse to scan right operand */
 		findoprnd(ptr, pos);
-		curitem->left = *pos - tmp;
+		/* fill left with offset to left operand's top */
+		delta = *pos - mypos;
+		Assert(delta < 0);
+		if (unlikely(delta < PG_INT16_MIN))
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("query_int expression is too complex")));
+		ptr[mypos].left = (int16) delta;
+		/* recurse to scan left operand */
 		findoprnd(ptr, pos);
 	}
 }

--- a/contrib/ltree/ltree_io.c
+++ b/contrib/ltree/ltree_io.c
@@ -7,6 +7,7 @@
 
 #include <ctype.h>
 
+#include "common/int.h"
 #include "ltree.h"
 #include "utils/memutils.h"
 #include "crc32.h"
@@ -268,7 +269,12 @@ lquery_in(PG_FUNCTION_ARGS)
 				lptr++;
 				lptr->start = ptr;
 				state = LQPRS_WAITDELIM;
-				curqlevel->numvar++;
+				if (pg_add_u16_overflow(curqlevel->numvar, 1, &curqlevel->numvar))
+					ereport(ERROR,
+							(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+							 errmsg("lquery level has too many variants"),
+							 errdetail("Number of variants exceeds the maximum allowed (%d).",
+									   PG_UINT16_MAX)));
 			}
 			else
 				UNCHAR;
@@ -512,7 +518,17 @@ lquery_in(PG_FUNCTION_ARGS)
 			lptr = GETVAR(curqlevel);
 			while (lptr - GETVAR(curqlevel) < curqlevel->numvar)
 			{
-				cur->totallen += MAXALIGN(LVAR_HDRSIZE + lptr->len);
+				{
+					int			newlen = cur->totallen + MAXALIGN(LVAR_HDRSIZE + lptr->len);
+
+					if (newlen > PG_UINT16_MAX)
+						ereport(ERROR,
+								(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+								 errmsg("lquery level is too large"),
+								 errdetail("Total size of level exceeds the maximum allowed (%d bytes).",
+										   PG_UINT16_MAX)));
+					cur->totallen = (uint16) newlen;
+				}
 				lrptr->len = lptr->len;
 				lrptr->flag = lptr->flag;
 				lrptr->val = ltree_crc32_sz(lptr->start, lptr->len);

--- a/contrib/ltree/ltxtquery_io.c
+++ b/contrib/ltree/ltxtquery_io.c
@@ -277,28 +277,45 @@ makepol(QPRS_STATE *state)
 static void
 findoprnd(ITEM *ptr, int32 *pos)
 {
+	int32		mypos;
+
 	/* since this function recurses, it could be driven to stack overflow. */
 	check_stack_depth();
 
-	if (ptr[*pos].type == VAL || ptr[*pos].type == VALTRUE)
+	/* get the position this call is supposed to update */
+	mypos = *pos;
+
+	/* in all cases, we should increment *pos to advance over this item */
+	(*pos)++;
+
+	if (ptr[mypos].type == VAL || ptr[mypos].type == VALTRUE)
 	{
-		ptr[*pos].left = 0;
-		(*pos)++;
+		/* base case: a VAL has no operand, so just set its left to zero */
+		ptr[mypos].left = 0;
 	}
-	else if (ptr[*pos].val == (int32) '!')
+	else if (ptr[mypos].val == (int32) '!')
 	{
-		ptr[*pos].left = 1;
-		(*pos)++;
+		/* unary operator, likewise easy: operand is just after it */
+		ptr[mypos].left = 1;
+		/* recurse to scan operand */
 		findoprnd(ptr, pos);
 	}
 	else
 	{
-		ITEM	   *curitem = &ptr[*pos];
-		int32		tmp = *pos;
+		/* binary operator */
+		int32		delta;
 
-		(*pos)++;
+		/* recurse to scan right operand */
 		findoprnd(ptr, pos);
-		curitem->left = *pos - tmp;
+		/* fill left with offset to left operand's top */
+		delta = *pos - mypos;
+		Assert(delta > 0);
+		if (unlikely(delta > PG_INT16_MAX))
+			ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					 errmsg("ltxtquery is too large")));
+		ptr[mypos].left = (int16) delta;
+		/* recurse to scan left operand */
 		findoprnd(ptr, pos);
 	}
 }

--- a/src/backend/libpq/auth-scram.c
+++ b/src/backend/libpq/auth-scram.c
@@ -535,7 +535,7 @@ scram_verify_plain_password(const char *username, const char *password,
 	 * Compare the verifier's Server Key with the one computed from the
 	 * user-supplied password.
 	 */
-	return memcmp(computed_key, server_key, SCRAM_KEY_LEN) == 0;
+	return timingsafe_bcmp(computed_key, server_key, SCRAM_KEY_LEN) == 0;
 }
 
 
@@ -1050,9 +1050,9 @@ verify_final_nonce(scram_state *state)
 
 	if (final_nonce_len != client_nonce_len + server_nonce_len)
 		return false;
-	if (memcmp(state->client_final_nonce, state->client_nonce, client_nonce_len) != 0)
+	if (timingsafe_bcmp(state->client_final_nonce, state->client_nonce, client_nonce_len) != 0)
 		return false;
-	if (memcmp(state->client_final_nonce + client_nonce_len, state->server_nonce, server_nonce_len) != 0)
+	if (timingsafe_bcmp(state->client_final_nonce + client_nonce_len, state->server_nonce, server_nonce_len) != 0)
 		return false;
 
 	return true;
@@ -1093,7 +1093,7 @@ verify_client_proof(scram_state *state)
 	/* Hash it one more time, and compare with StoredKey */
 	scram_H(ClientKey, SCRAM_KEY_LEN, client_StoredKey);
 
-	if (memcmp(client_StoredKey, state->StoredKey, SCRAM_KEY_LEN) != 0)
+	if (timingsafe_bcmp(client_StoredKey, state->StoredKey, SCRAM_KEY_LEN) != 0)
 		return false;
 
 	return true;

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -3722,7 +3722,7 @@ PerformRadiusTransaction(const char *server, const char *secret, const char *por
 		}
 		pfree(cryptvector);
 
-		if (memcmp(receivepacket->vector, encryptedpassword, RADIUS_VECTOR_LENGTH) != 0)
+		if (timingsafe_bcmp(receivepacket->vector, encryptedpassword, RADIUS_VECTOR_LENGTH) != 0)
 		{
 			ereport(LOG,
 					(errmsg("RADIUS response from %s has incorrect MD5 signature",

--- a/src/backend/libpq/crypt.c
+++ b/src/backend/libpq/crypt.c
@@ -199,7 +199,8 @@ md5_crypt_verify(const char *role, const char *shadow_pass,
 		return STATUS_ERROR;
 	}
 
-	if (strcmp(client_pass, crypt_pwd) == 0)
+	if (strlen(client_pass) == strlen(crypt_pwd) &&
+		timingsafe_bcmp(client_pass, crypt_pwd, strlen(crypt_pwd)) == 0)
 		retval = STATUS_OK;
 	else
 	{
@@ -264,7 +265,8 @@ plain_crypt_verify(const char *role, const char *shadow_pass,
 				 */
 				return STATUS_ERROR;
 			}
-			if (strcmp(crypt_client_pass, shadow_pass) == 0)
+			if (strlen(crypt_client_pass) == strlen(shadow_pass) &&
+				timingsafe_bcmp(crypt_client_pass, shadow_pass, strlen(shadow_pass)) == 0)
 				return STATUS_OK;
 			else
 			{

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2257,6 +2257,7 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
     char       *gpqeid = NULL;
 	XLogRecPtr  recptr;
 
+retry:
 	pq_startmsgread();
 
 	/*
@@ -2382,7 +2383,16 @@ retry1:
 		 * another SSL negotiation request, and a GSS request should only
 		 * follow if SSL was rejected (client may negotiate in either order)
 		 */
-		return ProcessStartupPacket(port, true, SSLok == 'S');
+		ssl_done = true;
+		if (SSLok == 'S')
+		{
+			/*
+			 * We are done with SSL and negotiated correctly, so consider the
+			 * same for GSS.
+			 */
+			gss_done = true;
+		}
+		goto retry;
 	}
 	else if (proto == NEGOTIATE_GSS_CODE && !gss_done)
 	{
@@ -2426,7 +2436,16 @@ retry1:
 		 * another GSS negotiation request, and an SSL request should only
 		 * follow if GSS was rejected (client may negotiate in either order)
 		 */
-		return ProcessStartupPacket(port, GSSok == 'G', true);
+		gss_done = true;
+		if (GSSok == 'G')
+		{
+			/*
+			 * We are done with GSS and negotiated correctly, so consider the
+			 * same for SSL.
+			 */
+			ssl_done = true;
+		}
+		goto retry;
 	}
 
 	/* Could add additional special packet types here */

--- a/src/backend/regex/regc_color.c
+++ b/src/backend/regex/regc_color.c
@@ -218,6 +218,7 @@ newcolor(struct colormap *cm)
 		n = cm->ncds * 2;
 		if (n > MAX_COLOR + 1)
 			n = MAX_COLOR + 1;
+		/* the MAX_COLOR+1 limit ensures these alloc sizes can't overflow: */
 		if (cm->cd == cm->cdspace)
 		{
 			newCd = (struct colordesc *) MALLOC(n * sizeof(struct colordesc));
@@ -434,9 +435,8 @@ newhicolorrow(struct colormap *cm,
 			CERR(REG_ESPACE);
 			return 0;
 		}
-		newarray = (color *) REALLOC(cm->hicolormap,
-									 cm->maxarrayrows * 2 *
-									 cm->hiarraycols * sizeof(color));
+		newarray = REALLOC_ARRAY(cm->hicolormap, color,
+								 cm->maxarrayrows * 2 * cm->hiarraycols);
 		if (newarray == NULL)
 		{
 			CERR(REG_ESPACE);
@@ -477,9 +477,8 @@ newhicolorcols(struct colormap *cm)
 		CERR(REG_ESPACE);
 		return;
 	}
-	newarray = (color *) REALLOC(cm->hicolormap,
-								 cm->maxarrayrows *
-								 cm->hiarraycols * 2 * sizeof(color));
+	newarray = REALLOC_ARRAY(cm->hicolormap, color,
+							 cm->maxarrayrows * cm->hiarraycols * 2);
 	if (newarray == NULL)
 	{
 		CERR(REG_ESPACE);
@@ -652,8 +651,7 @@ subcoloronechr(struct vars *v,
 	 * Potentially, we could need two more colormapranges than we have now, if
 	 * the given chr is in the middle of some existing range.
 	 */
-	newranges = (colormaprange *)
-		MALLOC((cm->numcmranges + 2) * sizeof(colormaprange));
+	newranges = MALLOC_ARRAY(colormaprange, cm->numcmranges + 2);
 	if (newranges == NULL)
 	{
 		CERR(REG_ESPACE);
@@ -766,8 +764,7 @@ subcoloronerange(struct vars *v,
 	 * Potentially, if we have N non-adjacent ranges, we could need as many as
 	 * 2N+1 result ranges (consider case where new range spans 'em all).
 	 */
-	newranges = (colormaprange *)
-		MALLOC((cm->numcmranges * 2 + 1) * sizeof(colormaprange));
+	newranges = MALLOC_ARRAY(colormaprange, cm->numcmranges * 2 + 1);
 	if (newranges == NULL)
 	{
 		CERR(REG_ESPACE);

--- a/src/backend/regex/regc_nfa.c
+++ b/src/backend/regex/regc_nfa.c
@@ -2895,6 +2895,13 @@ compact(struct nfa *nfa,
 					break;
 				case LACON:
 					assert(s->no != cnfa->pre);
+					assert(a->co >= 0);
+					/* make sure the modified color number will fit */
+					if (a->co > MAX_COLOR - cnfa->ncolors)
+					{
+						NERR(REG_ECOLORS);
+						return;
+					}
 					ca->co = (color) (cnfa->ncolors + a->co);
 					ca->to = a->to->no;
 					ca++;

--- a/src/backend/regex/regcomp.c
+++ b/src/backend/regex/regcomp.c
@@ -1953,8 +1953,8 @@ newlacon(struct vars *v,
 	else
 	{
 		n = v->nlacons;
-		newlacons = (struct subre *) REALLOC(v->lacons,
-											 (n + 1) * sizeof(struct subre));
+		/* better use REALLOC_ARRAY here, as struct subre is big */
+		newlacons = REALLOC_ARRAY(v->lacons, struct subre, n + 1);
 	}
 	if (newlacons == NULL)
 	{

--- a/src/backend/regex/rege_dfa.c
+++ b/src/backend/regex/rege_dfa.c
@@ -469,20 +469,29 @@ newdfa(struct vars *v,
 	}
 	else
 	{
+		/*
+		 * Restrict the ranges of nstates and ncolors enough that the arrays
+		 * we allocate here have no more than INT_MAX members.  This protects
+		 * not only the allocation calculations just below, but later indexing
+		 * into these arrays.
+		 */
+		if (wordsper >= INT_MAX / (nss + WORK) ||
+			cnfa->ncolors >= INT_MAX / nss)
+		{
+			ERR(REG_ETOOBIG);
+			return NULL;
+		}
 		d = (struct dfa *) MALLOC(sizeof(struct dfa));
 		if (d == NULL)
 		{
 			ERR(REG_ESPACE);
 			return NULL;
 		}
-		d->ssets = (struct sset *) MALLOC(nss * sizeof(struct sset));
-		d->statesarea = (unsigned *) MALLOC((nss + WORK) * wordsper *
-											sizeof(unsigned));
+		d->ssets = MALLOC_ARRAY(struct sset, nss);
+		d->statesarea = MALLOC_ARRAY(unsigned, (nss + WORK) * wordsper);
 		d->work = &d->statesarea[nss * wordsper];
-		d->outsarea = (struct sset **) MALLOC(nss * cnfa->ncolors *
-											  sizeof(struct sset *));
-		d->incarea = (struct arcp *) MALLOC(nss * cnfa->ncolors *
-											sizeof(struct arcp));
+		d->outsarea = MALLOC_ARRAY(struct sset *, nss * cnfa->ncolors);
+		d->incarea = MALLOC_ARRAY(struct arcp, nss * cnfa->ncolors);
 		d->cptsmalloced = 1;
 		d->mallocarea = (char *) d;
 		if (d->ssets == NULL || d->statesarea == NULL ||

--- a/src/backend/regex/regexec.c
+++ b/src/backend/regex/regexec.c
@@ -220,8 +220,7 @@ pg_regexec(regex_t *re,
 		if (v->g->nsub + 1 <= LOCALMAT)
 			v->pmatch = mat;
 		else
-			v->pmatch = (regmatch_t *) MALLOC((v->g->nsub + 1) *
-											  sizeof(regmatch_t));
+			v->pmatch = MALLOC_ARRAY(regmatch_t, v->g->nsub + 1);
 		if (v->pmatch == NULL)
 			return REG_ESPACE;
 		v->nmatch = v->g->nsub + 1;
@@ -1107,7 +1106,7 @@ citerdissect(struct vars *v,
 		max_matches = t->max;
 	if (max_matches < min_matches)
 		max_matches = min_matches;
-	endpts = (chr **) MALLOC((max_matches + 1) * sizeof(chr *));
+	endpts = MALLOC_ARRAY(chr *, max_matches + 1);
 	if (endpts == NULL)
 		return REG_ESPACE;
 	endpts[0] = begin;
@@ -1310,7 +1309,7 @@ creviterdissect(struct vars *v,
 		max_matches = t->max;
 	if (max_matches < min_matches)
 		max_matches = min_matches;
-	endpts = (chr **) MALLOC((max_matches + 1) * sizeof(chr *));
+	endpts = MALLOC_ARRAY(chr *, max_matches + 1);
 	if (endpts == NULL)
 		return REG_ESPACE;
 	endpts[0] = begin;

--- a/src/backend/tsearch/wparser_def.c
+++ b/src/backend/tsearch/wparser_def.c
@@ -2548,6 +2548,9 @@ prsd_headline(PG_FUNCTION_ARGS)
 	bool		highlightall = false;
 	int			max_cover;
 	ListCell   *l;
+	size_t		startsellen;
+	size_t		stopsellen;
+	size_t		fragdelimlen;
 
 	/* Extract configuration option values */
 	prs->startsel = NULL;
@@ -2633,9 +2636,24 @@ prsd_headline(PG_FUNCTION_ARGS)
 		prs->fragdelim = pstrdup(" ... ");
 
 	/* Caller will need these lengths, too */
-	prs->startsellen = strlen(prs->startsel);
-	prs->stopsellen = strlen(prs->stopsel);
-	prs->fragdelimlen = strlen(prs->fragdelim);
+	startsellen = strlen(prs->startsel);
+	stopsellen = strlen(prs->stopsel);
+	fragdelimlen = strlen(prs->fragdelim);
+	if (startsellen > PG_INT16_MAX)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("value for \"%s\" is too long", "StartSel")));
+	if (stopsellen > PG_INT16_MAX)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("value for \"%s\" is too long", "StopSel")));
+	if (fragdelimlen > PG_INT16_MAX)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("value for \"%s\" is too long", "FragmentDelimiter")));
+	prs->startsellen = startsellen;
+	prs->stopsellen = stopsellen;
+	prs->fragdelimlen = fragdelimlen;
 
 	PG_RETURN_POINTER(prs);
 }

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -5378,6 +5378,7 @@ accumArrayResultArr(ArrayBuildStateArr *astate,
 				ndatabytes;
 	char	   *data;
 	int			i;
+	int			newnitems;
 
 	/*
 	 * We disallow accumulating null subarrays.  Another plausible definition
@@ -5406,6 +5407,14 @@ accumArrayResultArr(ArrayBuildStateArr *astate,
 	data = ARR_DATA_PTR(arg);
 	nitems = ArrayGetNItems(ndims, dims);
 	ndatabytes = ARR_SIZE(arg) - ARR_DATA_OFFSET(arg);
+
+	/* Check that the array doesn't grow too large */
+	newnitems = astate->nitems + nitems;
+	if (newnitems > MaxArraySize)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("array size exceeds the maximum allowed (%zu)",
+						MaxArraySize)));
 
 	if (astate->ndims == 0)
 	{
@@ -5474,8 +5483,6 @@ accumArrayResultArr(ArrayBuildStateArr *astate,
 	/* Deal with null bitmap if needed */
 	if (astate->nullbitmap || ARR_HASNULL(arg))
 	{
-		int			newnitems = astate->nitems + nitems;
-
 		if (astate->nullbitmap == NULL)
 		{
 			/*
@@ -5501,7 +5508,7 @@ accumArrayResultArr(ArrayBuildStateArr *astate,
 						  nitems);
 	}
 
-	astate->nitems += nitems;
+	astate->nitems = newnitems;
 	astate->dims[0] += 1;
 
 	MemoryContextSwitchTo(oldcontext);

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -88,6 +88,7 @@
 #include "catalog/pg_collation.h"
 #include "mb/pg_wchar.h"
 #include "parser/scansup.h"
+#include "storage/shmem.h"		/* for mul_size() */
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
@@ -3563,7 +3564,7 @@ datetime_to_char_body(TmToChar *tmtc, text *fmt, bool is_interval, Oid collid)
 	/*
 	 * Allocate workspace for result as C string
 	 */
-	result = palloc((fmt_len * DCH_MAX_ITEM_SIZ) + 1);
+	result = palloc(mul_size(fmt_len, DCH_MAX_ITEM_SIZ) + 1);
 	*result = '\0';
 
 	if (fmt_len > DCH_CACHE_SIZE)
@@ -3574,7 +3575,7 @@ datetime_to_char_body(TmToChar *tmtc, text *fmt, bool is_interval, Oid collid)
 		 */
 		incache = false;
 
-		format = (FormatNode *) palloc((fmt_len + 1) * sizeof(FormatNode));
+		format = (FormatNode *) palloc(mul_size(fmt_len + 1, sizeof(FormatNode)));
 
 		parse_format(format, fmt_str, DCH_keywords,
 					 DCH_suff, DCH_index, DCH_TYPE, NULL);
@@ -3828,7 +3829,7 @@ do_to_timestamp(text *date_txt, text *fmt,
 			 */
 			incache = false;
 
-			format = (FormatNode *) palloc((fmt_len + 1) * sizeof(FormatNode));
+			format = (FormatNode *) palloc(mul_size(fmt_len + 1, sizeof(FormatNode)));
 
 			parse_format(format, fmt_str, DCH_keywords,
 						 DCH_suff, DCH_index, DCH_TYPE, NULL);
@@ -4256,7 +4257,7 @@ NUM_cache(int len, NUMDesc *Num, text *pars_str, bool *shouldFree)
 		 * Allocate new memory if format picture is bigger than static cache
 		 * and do not use cache (call parser always)
 		 */
-		format = (FormatNode *) palloc((len + 1) * sizeof(FormatNode));
+		format = (FormatNode *) palloc(mul_size(len + 1, sizeof(FormatNode)));
 
 		*shouldFree = true;
 

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -1959,15 +1959,19 @@ Datum
 timeofday(PG_FUNCTION_ARGS)
 {
 	struct timeval tp;
-	char		templ[128];
-	char		buf[128];
 	pg_time_t	tt;
+	struct pg_tm *tm;
+	char		part1[128];
+	char		part2[128];
+	char		buf[128 + 128 + 10];
 
 	gettimeofday(&tp, NULL);
 	tt = (pg_time_t) tp.tv_sec;
-	pg_strftime(templ, sizeof(templ), "%a %b %d %H:%M:%S.%%06d %Y %Z",
-				pg_localtime(&tt, session_timezone));
-	snprintf(buf, sizeof(buf), templ, tp.tv_usec);
+	tm = pg_localtime(&tt, session_timezone);
+
+	pg_strftime(part1, sizeof(part1), "%a %b %d %H:%M:%S", tm);
+	pg_strftime(part2, sizeof(part2), "%Y %Z", tm);
+	snprintf(buf, sizeof(buf), "%s.%06d %s", part1, (int) tp.tv_usec, part2);
 
 	PG_RETURN_TEXT_P(cstring_to_text(buf));
 }

--- a/src/bin/pg_rewind/file_ops.c
+++ b/src/bin/pg_rewind/file_ops.c
@@ -43,6 +43,9 @@ open_target_file(const char *path, bool trunc)
 {
 	int			mode;
 
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target file path is unsafe for open: \"%s\"", path);
+
 	if (dry_run)
 		return;
 
@@ -195,6 +198,9 @@ remove_target_file(const char *path, bool missing_ok)
 {
 	char		dstpath[MAXPGPATH];
 
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target file path is unsafe for removal: \"%s\"", path);
+
 	if (dry_run)
 		return;
 
@@ -214,6 +220,9 @@ truncate_target_file(const char *path, off_t newsize)
 {
 	char		dstpath[MAXPGPATH];
 	int			fd;
+
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target file path is unsafe for truncation: \"%s\"", path);
 
 	if (dry_run)
 		return;
@@ -237,6 +246,10 @@ create_target_dir(const char *path)
 {
 	char		dstpath[MAXPGPATH];
 
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target directory path is unsafe for directory creation: \"%s\"",
+				 path);
+
 	if (dry_run)
 		return;
 
@@ -250,6 +263,10 @@ static void
 remove_target_dir(const char *path)
 {
 	char		dstpath[MAXPGPATH];
+
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target directory path is unsafe for directory removal: \"%s\"",
+				 path);
 
 	if (dry_run)
 		return;
@@ -265,6 +282,9 @@ create_target_symlink(const char *path, const char *link)
 {
 	char		dstpath[MAXPGPATH];
 
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target symlink path is unsafe for creation: \"%s\"", path);
+
 	if (dry_run)
 		return;
 
@@ -278,6 +298,9 @@ static void
 remove_target_symlink(const char *path)
 {
 	char		dstpath[MAXPGPATH];
+
+	if (!path_is_safe_for_extraction(path))
+		pg_fatal("target symlink path is unsafe for removal: \"%s\"", path);
 
 	if (dry_run)
 		return;

--- a/src/common/unicode_norm.c
+++ b/src/common/unicode_norm.c
@@ -20,6 +20,11 @@
 
 #include "common/unicode_norm.h"
 #include "common/unicode_norm_table.h"
+#ifndef FRONTEND
+#include "utils/memutils.h"
+#else
+#define MaxAllocSize	((Size) 0x3fffffff)	/* 1GB-1; memutils.h is backend-only */
+#endif
 
 #ifndef FRONTEND
 #define ALLOC(size) palloc(size)
@@ -323,10 +328,28 @@ unicode_normalize_kc(const pg_wchar *input)
 
 	/*
 	 * Calculate how many characters long the decomposed version will be.
+	 *
+	 * Some characters decompose to quite a few code points, so that the
+	 * decomposed version's size could overrun MaxAllocSize, and even 32-bit
+	 * size_t, even though the input string presumably fits in that.  In
+	 * frontend we want to just return NULL in that case, so monitor the sum
+	 * and exit early once we'd need more than MaxAllocSize bytes.
 	 */
 	decomp_size = 0;
 	for (p = input; *p; p++)
+	{
 		decomp_size += get_decomposed_size(*p);
+		if (unlikely(decomp_size > MaxAllocSize / sizeof(pg_wchar)))
+		{
+#ifndef FRONTEND
+			/* Exit loop and let palloc() throw error below */
+			break;
+#else
+			/* Just return NULL with no explicit error */
+			return NULL;
+#endif
+		}
+	}
 
 	decomp_chars = (pg_wchar *) ALLOC((decomp_size + 1) * sizeof(pg_wchar));
 	if (decomp_chars == NULL)

--- a/src/include/common/int.h
+++ b/src/include/common/int.h
@@ -270,4 +270,102 @@ pg_mul_s64_overflow(int64 a, int64 b, int64 *result)
 #endif
 }
 
+
+/*------------------------------------------------------------------------
+ * Overflow routines for unsigned integers and size_t
+ *
+ * Backported from upstream REL_14_STABLE for CVE-2026-6473.
+ *------------------------------------------------------------------------
+ */
+
+static inline bool
+pg_add_u16_overflow(uint16 a, uint16 b, uint16 *result)
+{
+#if defined(HAVE__BUILTIN_OP_OVERFLOW)
+	return __builtin_add_overflow(a, b, result);
+#else
+	uint16		res = a + b;
+
+	if (res < a)
+	{
+		*result = 0x5EED;
+		return true;
+	}
+	*result = res;
+	return false;
+#endif
+}
+
+static inline bool
+pg_add_u32_overflow(uint32 a, uint32 b, uint32 *result)
+{
+#if defined(HAVE__BUILTIN_OP_OVERFLOW)
+	return __builtin_add_overflow(a, b, result);
+#else
+	uint32		res = a + b;
+
+	if (res < a)
+	{
+		*result = 0x5EED;
+		return true;
+	}
+	*result = res;
+	return false;
+#endif
+}
+
+static inline bool
+pg_mul_u32_overflow(uint32 a, uint32 b, uint32 *result)
+{
+#if defined(HAVE__BUILTIN_OP_OVERFLOW)
+	return __builtin_mul_overflow(a, b, result);
+#else
+	uint64		res = (uint64) a * (uint64) b;
+
+	if (res > PG_UINT32_MAX)
+	{
+		*result = 0x5EED;
+		return true;
+	}
+	*result = (uint32) res;
+	return false;
+#endif
+}
+
+static inline bool
+pg_add_size_overflow(size_t a, size_t b, size_t *result)
+{
+#if defined(HAVE__BUILTIN_OP_OVERFLOW)
+	return __builtin_add_overflow(a, b, result);
+#else
+	size_t		res = a + b;
+
+	if (res < a)
+	{
+		*result = 0x5EED;
+		return true;
+	}
+	*result = res;
+	return false;
+#endif
+}
+
+static inline bool
+pg_mul_size_overflow(size_t a, size_t b, size_t *result)
+{
+#if defined(HAVE__BUILTIN_OP_OVERFLOW)
+	return __builtin_mul_overflow(a, b, result);
+#else
+	size_t		res = a * b;
+
+	if (a != 0 && b != res / a)
+	{
+		*result = 0x5EED;
+		return true;
+	}
+	*result = res;
+	return false;
+#endif
+}
+
 #endif							/* COMMON_INT_H */

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -492,6 +492,13 @@ extern int	pqGethostbyname(const char *name,
 							struct hostent **result,
 							int *herrno);
 
+/*
+ * timingsafe_bcmp() compares len bytes from b1 and b2 in constant time.
+ * Returns 0 if equal, non-zero otherwise.  Used for password / token
+ * comparisons that must resist timing attacks.
+ */
+extern int	timingsafe_bcmp(const void *b1, const void *b2, size_t len);
+
 extern void pg_qsort(void *base, size_t nel, size_t elsize,
 					 int (*cmp) (const void *, const void *));
 extern int	pg_qsort_strcmp(const void *a, const void *b);

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -54,6 +54,7 @@ extern void make_native_path(char *path);
 extern void cleanup_path(char *path);
 extern bool path_contains_parent_reference(const char *path);
 extern bool path_is_relative_and_below_cwd(const char *path);
+extern bool path_is_safe_for_extraction(const char *path);
 extern bool path_is_prefix_of_path(const char *path1, const char *path2);
 extern char *make_absolute_path(const char *path);
 extern const char *get_progname(const char *argv0);

--- a/src/include/regex/regcustom.h
+++ b/src/include/regex/regcustom.h
@@ -62,7 +62,38 @@
 #define MALLOC(n)		malloc(n)
 #define FREE(p)			free(VS(p))
 #define REALLOC(p,n)	realloc(VS(p),n)
+/*
+ * MALLOC_ARRAY / REALLOC_ARRAY: like MALLOC / REALLOC but do an explicit
+ * size_t-multiplication overflow check first, returning NULL on overflow.
+ * Backported from upstream commit 39bc8f2caca for CVE-2026-6473.
+ */
+#define MALLOC_ARRAY(type, n) \
+						((type *) pg_regex_malloc_array(sizeof(type), n))
+#define REALLOC_ARRAY(p, type, n) \
+						((type *) pg_regex_realloc_array(p, sizeof(type), n))
 #define assert(x)		Assert(x)
+
+#include "common/int.h"
+
+static inline void *
+pg_regex_malloc_array(size_t s1, size_t s2)
+{
+	size_t		req;
+
+	if (unlikely(pg_mul_size_overflow(s1, s2, &req)))
+		return NULL;
+	return malloc(req);
+}
+
+static inline void *
+pg_regex_realloc_array(void *p, size_t s1, size_t s2)
+{
+	size_t		req;
+
+	if (unlikely(pg_mul_size_overflow(s1, s2, &req)))
+		return NULL;
+	return realloc(p, req);
+}
 
 /* internal character type and related */
 typedef pg_wchar chr;			/* the type itself */

--- a/src/include/regex/regguts.h
+++ b/src/include/regex/regguts.h
@@ -76,6 +76,14 @@
 #ifndef FREE
 #define FREE(p)		free(VS(p))
 #endif
+#ifndef MALLOC_ARRAY
+/* we don't depend on calloc's zeroing behavior, we do need overflow check */
+#define MALLOC_ARRAY(type, n) ((type *) calloc(sizeof(type), n))
+#endif
+#ifndef REALLOC_ARRAY
+/* XXX this definition does not provide the desired overflow check */
+#define REALLOC_ARRAY(p, type, n) ((type *) REALLOC(p, sizeof(type) * (n)))
+#endif
 
 /* want size of a char in bits, and max value in bounded quantifiers */
 #ifndef _POSIX2_RE_DUP_MAX

--- a/src/interfaces/libpq/fe-auth-scram.c
+++ b/src/interfaces/libpq/fe-auth-scram.c
@@ -556,7 +556,7 @@ read_server_first_message(fe_scram_state *state, char *input)
 
 	/* Verify immediately that the server used our part of the nonce */
 	if (strlen(nonce) < strlen(state->client_nonce) ||
-		memcmp(nonce, state->client_nonce, strlen(state->client_nonce)) != 0)
+		timingsafe_bcmp(nonce, state->client_nonce, strlen(state->client_nonce)) != 0)
 	{
 		printfPQExpBuffer(&conn->errorMessage,
 						  libpq_gettext("invalid SCRAM response (nonce mismatch)\n"));
@@ -755,7 +755,8 @@ verify_server_signature(fe_scram_state *state)
 					  strlen(state->client_final_message_without_proof));
 	scram_HMAC_final(expected_ServerSignature, &ctx);
 
-	if (memcmp(expected_ServerSignature, state->ServerSignature, SCRAM_KEY_LEN) != 0)
+	if (timingsafe_bcmp(expected_ServerSignature, state->ServerSignature,
+						SCRAM_KEY_LEN) != 0)
 		return false;
 
 	return true;

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -2691,6 +2691,20 @@ PQfn(PGconn *conn,
 	 const PQArgBlock *args,
 	 int nargs)
 {
+	return PQnfn(conn, fnid, result_buf, -1, result_len,
+				 result_is_int, args, nargs);
+}
+
+/*
+ * PQnfn
+ *		Private version of PQfn() with verification that returned data fits in
+ *		result_buf when result_is_int == 0.  Setting buf_size to -1 disables
+ *		this verification.
+ */
+PGresult *
+PQnfn(PGconn *conn, int fnid, int *result_buf, int buf_size, int *result_len,
+	  int result_is_int, const PQArgBlock *args, int nargs)
+{
 	*result_len = 0;
 
 	if (!conn)
@@ -2709,7 +2723,7 @@ PQfn(PGconn *conn,
 
 	if (PG_PROTOCOL_MAJOR(conn->pversion) >= 3)
 		return pqFunctionCall3(conn, fnid,
-							   result_buf, result_len,
+							   result_buf, buf_size, result_len,
 							   result_is_int,
 							   args, nargs);
 	else

--- a/src/interfaces/libpq/fe-lobj.c
+++ b/src/interfaces/libpq/fe-lobj.c
@@ -288,8 +288,8 @@ lo_read(PGconn *conn, int fd, char *buf, size_t len)
 	argv[1].len = 4;
 	argv[1].u.integer = (int) len;
 
-	res = PQfn(conn, conn->lobjfuncs->fn_lo_read,
-			   (void *) buf, &result_len, 0, argv, 2);
+	res = PQnfn(conn, conn->lobjfuncs->fn_lo_read,
+				(void *) buf, len, &result_len, 0, argv, 2);
 	if (PQresultStatus(res) == PGRES_COMMAND_OK)
 	{
 		PQclear(res);
@@ -439,8 +439,8 @@ lo_lseek64(PGconn *conn, int fd, pg_int64 offset, int whence)
 	argv[2].len = 4;
 	argv[2].u.integer = whence;
 
-	res = PQfn(conn, conn->lobjfuncs->fn_lo_lseek64,
-			   (void *) &retval, &result_len, 0, argv, 3);
+	res = PQnfn(conn, conn->lobjfuncs->fn_lo_lseek64,
+				(void *) &retval, sizeof(retval), &result_len, 0, argv, 3);
 	if (PQresultStatus(res) == PGRES_COMMAND_OK && result_len == 8)
 	{
 		PQclear(res);
@@ -605,8 +605,8 @@ lo_tell64(PGconn *conn, int fd)
 	argv[0].len = 4;
 	argv[0].u.integer = fd;
 
-	res = PQfn(conn, conn->lobjfuncs->fn_lo_tell64,
-			   (void *) &retval, &result_len, 0, argv, 1);
+	res = PQnfn(conn, conn->lobjfuncs->fn_lo_tell64,
+				(void *) &retval, sizeof(retval), &result_len, 0, argv, 1);
 	if (PQresultStatus(res) == PGRES_COMMAND_OK && result_len == 8)
 	{
 		PQclear(res);

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -2080,7 +2080,7 @@ pqEndcopy3(PGconn *conn)
  */
 PGresult *
 pqFunctionCall3(PGconn *conn, Oid fnid,
-				int *result_buf, int *actual_result_len,
+				int *result_buf, int buf_size, int *actual_result_len,
 				int result_is_int,
 				const PQArgBlock *args, int nargs)
 {
@@ -2211,6 +2211,18 @@ pqFunctionCall3(PGconn *conn, Oid fnid,
 					}
 					else
 					{
+						/*
+						 * If the server returned too much data for the
+						 * buffer, something fishy is going on.  Abandon ship.
+						 */
+						if (buf_size != -1 && *actual_result_len > buf_size)
+						{
+							appendPQExpBufferStr(&conn->errorMessage,
+												 libpq_gettext("server returned too much data\n"));
+							handleSyncLoss(conn, id, *actual_result_len);
+							return pqPrepareAsyncResult(conn);
+						}
+
 						if (pqGetnchar((char *) result_buf,
 									   *actual_result_len,
 									   conn))

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -699,9 +699,13 @@ extern int	pqGetline3(PGconn *conn, char *s, int maxlen);
 extern int	pqGetlineAsync3(PGconn *conn, char *buffer, int bufsize);
 extern int	pqEndcopy3(PGconn *conn);
 extern PGresult *pqFunctionCall3(PGconn *conn, Oid fnid,
-								 int *result_buf, int *actual_result_len,
+								 int *result_buf, int buf_size,
+								 int *actual_result_len,
 								 int result_is_int,
 								 const PQArgBlock *args, int nargs);
+extern PGresult *PQnfn(PGconn *conn, int fnid, int *result_buf, int buf_size,
+					   int *result_len, int result_is_int,
+					   const PQArgBlock *args, int nargs);
 
 /* === in fe-misc.c === */
 

--- a/src/port/Makefile
+++ b/src/port/Makefile
@@ -39,7 +39,7 @@ OBJS = $(LIBOBJS) $(PG_CRC32C_OBJS) chklocale.o erand48.o inet_net_ntop.o \
 	noblock.o path.o pg_bitutils.o pgcheckdir.o pgmkdirp.o pgsleep.o \
 	pg_strong_random.o pgstrcasecmp.o pgstrsignal.o pqsignal.o \
 	qsort.o qsort_arg.o quotes.o snprintf.o sprompt.o strerror.o \
-	tar.o thread.o
+	tar.o thread.o timingsafe_bcmp.o
 
 # libpgport.a, libpgport_shlib.a, and libpgport_srv.a contain the same files
 # foo.o, foo_shlib.o, and foo_srv.o are all built from foo.c

--- a/src/port/path.c
+++ b/src/port/path.c
@@ -429,6 +429,23 @@ path_is_relative_and_below_cwd(const char *path)
 }
 
 /*
+ * Detect whether a path is safe for use during archive extraction.
+ *
+ * This applies canonicalize_path(), then it checks that the path does
+ * not contain any parent directory references.
+ */
+bool
+path_is_safe_for_extraction(const char *path)
+{
+	char		buf[MAXPGPATH];
+
+	strlcpy(buf, path, sizeof(buf));
+	canonicalize_path(buf);
+
+	return path_is_relative_and_below_cwd(buf);
+}
+
+/*
  * Detect whether path1 is a prefix of path2 (including equality).
  *
  * This is pretty trivial, but it seems better to export a function than

--- a/src/port/timingsafe_bcmp.c
+++ b/src/port/timingsafe_bcmp.c
@@ -1,0 +1,43 @@
+/*
+ * src/port/timingsafe_bcmp.c
+ *
+ *	$OpenBSD: timingsafe_bcmp.c,v 1.3 2015/08/31 02:53:57 guenther Exp $
+ */
+
+/*
+ * Copyright (c) 2010 Damien Miller.  All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "c.h"
+
+#ifdef USE_SSL
+#include <openssl/crypto.h>
+#endif
+
+int
+timingsafe_bcmp(const void *b1, const void *b2, size_t n)
+{
+#ifdef USE_SSL
+	return CRYPTO_memcmp(b1, b2, n);
+#else
+	const unsigned char *p1 = b1,
+			   *p2 = b2;
+	int			ret = 0;
+
+	for (; n > 0; n--)
+		ret |= *p1++ ^ *p2++;
+	return (ret != 0);
+#endif
+}

--- a/src/timezone/strftime.c
+++ b/src/timezone/strftime.c
@@ -122,6 +122,13 @@ static char *_yconv(int, int, bool, bool, char *, char const *);
  * Convert timestamp t to string s, a caller-allocated buffer of size maxsize,
  * using the given format pattern.
  *
+ * Unlike standard strftime(), we guarantee to provide a null-terminated
+ * result even on failure, so long as maxsize > 0.  If we overrun the buffer,
+ * return an empty string rather than risking mis-encoded multibyte output.
+ * (Since this module only supports C locale, you might think multibyte
+ * characters are impossible --- but the time zone name printed by %Z comes
+ * from outside and could contain such.)
+ *
  * See also timestamptz_to_str.
  */
 size_t
@@ -135,11 +142,15 @@ pg_strftime(char *s, size_t maxsize, const char *format, const struct pg_tm *t)
 	if (!p)
 	{
 		errno = EOVERFLOW;
+		if (maxsize > 0)
+			*s = '\0';
 		return 0;
 	}
 	if (p == s + maxsize)
 	{
 		errno = ERANGE;
+		if (maxsize > 0)
+			*s = '\0';
 		return 0;
 	}
 	*p = '\0';


### PR DESCRIPTION
PTT-1125 — backport the [May 2026 PostgreSQL security release](https://www.postgresql.org/about/news/postgresql-2025-cve-may-2026/) CVE fixes to `WHPG_7_2_STABLE`.

This is a **clean cherry-pick** of the 6 CVE commits from #158 (the `main` PR) — no manual conflict resolution was needed. `WHPG_7_2_STABLE` differs from `main` only in 3 libpq files (due to 2 unrelated upstream commits not yet on `WHPG_7_2_STABLE`), and those differences don't interact semantically with the CVE patches, so the 3-way merge auto-resolved cleanly.

The final patch diff is **byte-identical** to the `main` PR: 33 files changed, +492 / −85.

## CVEs included

| CVE | Subject |
|---|---|
| CVE-2026-6477 | `PQfn()` buffer overrun in frontend LO interface (`libpq`) |
| CVE-2026-6474 | `pg_strftime` `%Z` format-string abuse in `timeofday()` |
| CVE-2026-6478 | Timing-safe comparisons in auth paths (SCRAM, MD5, RADIUS, plain) |
| CVE-2026-6475 | Path traversal in `pg_rewind` |
| CVE-2026-6479 | SSL/GSS recursion stack overflow in `ProcessStartupPacket()` |
| CVE-2026-6473 | Integer overflow hardening (ltree, ts_headline, intarray, regex, unicode_normalize, formatting, array_agg, hstore_pl*) |

Not applicable on this branch (same as `main`):
- CVE-2026-6472 (multirange overflows — PG14-multirange code path absent on this branch)
- CVE-2026-6638 (PG16+ only)

## Verification

- Full build (`./configure --with-perl --with-python …; make -j20`) passes.
- See #158 for the rationale on per-CVE patch contents, what infrastructure was inlined, and what sub-parts of CVE-2026-6473 were skipped.

## Per-CVE commits

```
d9994e7f9e2 Backport CVE-2026-6473: integer overflow hardening (multiple subparts)
f80256e1040 Backport CVE-2026-6479: stack overflow via repeated SSL/GSS negotiation
da24cf48579 Backport CVE-2026-6475: prevent path traversal in pg_rewind
3c3c5b6e8b9 Backport CVE-2026-6478: timing-safe comparisons in auth paths
17e46a0b3ee Backport CVE-2026-6474: pg_strftime %Z format-string abuse in timeofday()
26c869bcc75 Backport CVE-2026-6477: PQfn buffer overrun in frontend LO interface
```
