### PR TITLE
Switch CI workflows to version-agnostic Docker image name (PTT-1174)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -162,12 +162,12 @@ Tests run in pre-built container images from `ghcr.io/warehouse-pg/`:
 
 | Image Pattern | Example |
 |---------------|---------|
-| `whpg{major}-rocky{el}-build` | `whpg7-rocky8-build` |
+| `whpg-rocky{el}-build` | `whpg-rocky8-build` |
 
 The image is selected per matrix EL version; the WHPG major version is fixed at `7`.
 
 ## WHPG Version
 
 This branch builds WHPG **7**. The major version is hardcoded in the workflow
-(`WHPG_MAJORVERSION: '7'` and the `whpg7-rocky{el}-build` image); it is no
+(`WHPG_MAJORVERSION: '7'` and the `whpg-rocky{el}-build` image); it is no
 longer derived from git tags at runtime.

--- a/.github/workflows/abi-tests.yml
+++ b/.github/workflows/abi-tests.yml
@@ -69,7 +69,7 @@ jobs:
     needs: abi-dump-setup
     runs-on: ubuntu-latest 
     container:
-      image: ghcr.io/warehouse-pg/whpg7-rocky8-build
+      image: ghcr.io/warehouse-pg/whpg-rocky8-build
     strategy:
       matrix:
         name:
@@ -138,7 +138,7 @@ jobs:
       - abi-dump
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/warehouse-pg/whpg7-rocky8-build
+      image: ghcr.io/warehouse-pg/whpg-rocky8-build
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v4

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -85,7 +85,7 @@ jobs:
         # Run the suite under both optimizers: on = GPORCA, off = Postgres planner
         optimizer: ['on', 'off']
     container:
-      image: ghcr.io/warehouse-pg/whpg7-${{ format('rocky{0}', matrix.el_version) }}-build
+      image: ghcr.io/warehouse-pg/whpg-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
       WHPG_MAJORVERSION: '7'
@@ -278,7 +278,7 @@ jobs:
         # push to main/stable -> EL 8+9; PRs and ci/** -> EL 8; dispatch -> chosen version
         el_version: ${{ fromJson((github.event_name == 'workflow_dispatch' && (inputs.el_version == 'all' && '["8","9"]' || format('["{0}"]', inputs.el_version))) || ((github.ref_name == 'main' || startsWith(github.ref_name, 'WHPG_')) && '["8","9"]' || '["8"]')) }}
     container:
-      image: ghcr.io/warehouse-pg/whpg7-${{ format('rocky{0}', matrix.el_version) }}-build
+      image: ghcr.io/warehouse-pg/whpg-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
       WHPG_MAJORVERSION: '7'


### PR DESCRIPTION
## What

Switches the CI consumer workflows to the version-agnostic build image `ghcr.io/warehouse-pg/whpg-rocky{el}-build` (was `whpg7-rocky{el}-build`):

- `whpg-ci.yml` — `installcheck` and `orca-unit-tests` containers
- `abi-tests.yml` — `abi-dump` and `abi-compare` containers
- `README.md` — container image docs

## Why

The build image is shared by both WHPG 6 and WHPG 7, so the `whpg7` prefix was misleading.

## Rollout (two PRs)

This is **PR 2 of 2**. PR 1 (#163) renamed `IMAGE_NAME` in `build-docker-image.yml`, and the renamed image has already been published to GHCR (`whpg-rocky8-build`, `whpg-rocky9-build`), so these workflows can pull it.

After this merges, the old `whpg7-*` packages in GHCR can be deleted.

## Testing

- `grep -rn "whpg7-rocky" .github/` returns nothing.
- CI on this PR exercises the `whpg-ci.yml` change directly — the containers pull the renamed image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)