### PR TITLE
Switch CI workflows to version-agnostic Docker image name (PTT-1174) [WHPG 6]

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -184,9 +184,9 @@ Tests run in pre-built container images from `ghcr.io/warehouse-pg/`, selected p
 
 | Image | EL |
 |-------|----|
-| `ghcr.io/warehouse-pg/whpg7-rocky8-build` | 8 |
+| `ghcr.io/warehouse-pg/whpg-rocky8-build` | 8 |
 
-> **Note:** The image name retains the `whpg7-` prefix even though this workflow targets WHPG 6 — the same Rocky Linux base image is reused, with WHPG 6-specific packages (xerces-c 3.1, python2-devel) installed at job time.
+> **Note:** The image is version-agnostic and shared with WHPG 7 — the same Rocky Linux base image is reused, with WHPG 6-specific packages (xerces-c 3.1, python2-devel) installed at job time.
 >
 > **EL9:** Not in the matrix. WHPG 6 requires Python 2 (for PyGreSQL 4.0, gpdemo, and the xerces-c 3.1 build script), and Python 2 is not available on EL9, so this workflow cannot build WHPG 6 there. EL9 coverage is provided by the `warehouse-pg-packaging` pipeline instead.
 

--- a/.github/workflows/abi-tests.yml
+++ b/.github/workflows/abi-tests.yml
@@ -71,7 +71,7 @@ jobs:
     needs: abi-dump-setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/warehouse-pg/whpg7-rocky8-build
+      image: ghcr.io/warehouse-pg/whpg-rocky8-build
     strategy:
       matrix:
         name:
@@ -152,7 +152,7 @@ jobs:
       - abi-dump
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/warehouse-pg/whpg7-rocky8-build
+      image: ghcr.io/warehouse-pg/whpg-rocky8-build
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v4

--- a/.github/workflows/whpg-ci.yml
+++ b/.github/workflows/whpg-ci.yml
@@ -80,7 +80,7 @@ jobs:
         # Run the suite under both optimizers: on = GPORCA, off = Postgres planner
         optimizer: ['on', 'off']
     container:
-      image: ghcr.io/warehouse-pg/whpg7-${{ format('rocky{0}', matrix.el_version) }}-build
+      image: ghcr.io/warehouse-pg/whpg-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
       WHPG_MAJORVERSION: '6'
@@ -342,7 +342,7 @@ jobs:
       matrix:
         el_version: ['8']   # CI matrix runs on EL 8
     container:
-      image: ghcr.io/warehouse-pg/whpg7-${{ format('rocky{0}', matrix.el_version) }}-build
+      image: ghcr.io/warehouse-pg/whpg-${{ format('rocky{0}', matrix.el_version) }}-build
       options: --privileged
     env:
       WHPG_MAJORVERSION: '6'


### PR DESCRIPTION
## What

Switches the WHPG 6 CI consumer workflows to the version-agnostic build image `ghcr.io/warehouse-pg/whpg-rocky{el}-build` (was `whpg7-rocky{el}-build`):

- `whpg-ci.yml` — `installcheck` and `orca-unit-tests` containers
- `abi-tests.yml` — `abi-dump` and `abi-compare` containers
- `README.md` — container image table + note (the note that explained the misleading `whpg7-` prefix is now resolved)

## Why

The build image is shared by both WHPG 6 and WHPG 7. On this WHPG 6 branch the `whpg7` prefix was especially misleading. See PTT-1174.

This branch has no `build-docker-image.yml` (the image is built from `main`), and the renamed image (`whpg-rocky8-build`) is already published to GHCR, so this is a single consumer-only PR — no build-workflow change needed here.

## Testing

- `grep -rn "whpg7" .github/` returns nothing.
- CI on this PR exercises the `whpg-ci.yml` change directly — the containers pull the renamed image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
