### PR TITLE
Fix GPHOME_CLIENTS resolution in greenplum_clients_path.sh for WHPG6

### DIFF
--- a/gpAux/client/scripts/greenplum_clients_path.sh
+++ b/gpAux/client/scripts/greenplum_clients_path.sh
@@ -1,4 +1,27 @@
-GPHOME_CLIENTS=`pwd`
+if test -n "${ZSH_VERSION:-}"; then
+    # zsh
+    SCRIPT_PATH="${(%):-%x}"
+elif test -n "${BASH_VERSION:-}"; then
+    # bash
+    SCRIPT_PATH="${BASH_SOURCE[0]}"
+else
+    # Unknown shell, hope below works.
+    # Tested with dash
+    result=$(lsof -p $$ -Fn | tail --lines=1 | xargs --max-args=2 | cut --delimiter=' ' --fields=2)
+    SCRIPT_PATH=${result#n}
+fi
+
+if test -z "$SCRIPT_PATH"; then
+    echo "The shell cannot be identified. \$GPHOME_CLIENTS may not be set correctly." >&2
+fi
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
+
+if [ ! -L "${SCRIPT_DIR}" ]; then
+    GPHOME_CLIENTS=${SCRIPT_DIR}
+else
+    GPHOME_CLIENTS=$(readlink "${SCRIPT_DIR}")
+fi
+
 PATH=${GPHOME_CLIENTS}/bin:${GPHOME_CLIENTS}/ext/python/bin:${PATH}
 PYTHONPATH=${GPHOME_CLIENTS}/bin/ext:${PYTHONPATH}
 


### PR DESCRIPTION
Previously, GPHOME_CLIENTS was set to pwd (the current working directory at the time the script is sourced), which is incorrect when the script is sourced from a directory other than the clients installation root.

  This change resolves the actual directory of the script itself using shell-specific methods:
  - zsh: uses ${(%):-%x}
  - bash: uses ${BASH_SOURCE[0]}
  - other shells (e.g. dash): falls back to lsof to determine the script path

  It then sets GPHOME_CLIENTS to the resolved directory, following symlinks if the directory itself is a symlink (readlink).
  
This patch is ported from greenplum_clients_path.sh of main branch.