### PR TITLE
Fix CVE-2026-6637 (refint SQL injection / buffer overrun) [PTT-1190]

### DIFF
--- a/contrib/spi/refint.c
+++ b/contrib/spi/refint.c
@@ -12,6 +12,7 @@
 #include "commands/trigger.h"
 #include "executor/spi.h"
 #include "utils/builtins.h"
+#include "utils/memutils.h"
 #include "utils/rel.h"
 
 PG_MODULE_MAGIC;
@@ -186,12 +187,13 @@ check_primary_key(PG_FUNCTION_ARGS)
 
 		/*
 		 * Remember that SPI_prepare places plan in current memory context -
-		 * so, we have to save plan in Top memory context for later use.
+		 * so, we have to save plan in TopMemoryContext for later use.
 		 */
 		if (SPI_keepplan(pplan))
 			/* internal error */
 			elog(ERROR, "check_primary_key: SPI_keepplan failed");
-		plan->splan = (SPIPlanPtr *) malloc(sizeof(SPIPlanPtr));
+		plan->splan = (SPIPlanPtr *) MemoryContextAlloc(TopMemoryContext,
+														sizeof(SPIPlanPtr));
 		*(plan->splan) = pplan;
 		plan->nplans = 1;
 	}
@@ -417,7 +419,8 @@ check_foreign_key(PG_FUNCTION_ARGS)
 		char		sql[8192];
 		char	  **args2 = args;
 
-		plan->splan = (SPIPlanPtr *) malloc(nrefs * sizeof(SPIPlanPtr));
+		plan->splan = (SPIPlanPtr *) MemoryContextAlloc(TopMemoryContext,
+														nrefs * sizeof(SPIPlanPtr));
 
 		for (r = 0; r < nrefs; r++)
 		{
@@ -611,6 +614,13 @@ find_plan(char *ident, EPlan **eplan, int *nplans)
 {
 	EPlan	   *newp;
 	int			i;
+	MemoryContext oldcontext;
+
+	/*
+	 * All allocations done for the plans need to happen in a session-safe
+	 * context.
+	 */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 
 	if (*nplans > 0)
 	{
@@ -620,20 +630,24 @@ find_plan(char *ident, EPlan **eplan, int *nplans)
 				break;
 		}
 		if (i != *nplans)
+		{
+			MemoryContextSwitchTo(oldcontext);
 			return (*eplan + i);
-		*eplan = (EPlan *) realloc(*eplan, (i + 1) * sizeof(EPlan));
+		}
+		*eplan = (EPlan *) repalloc(*eplan, (i + 1) * sizeof(EPlan));
 		newp = *eplan + i;
 	}
 	else
 	{
-		newp = *eplan = (EPlan *) malloc(sizeof(EPlan));
+		newp = *eplan = (EPlan *) palloc(sizeof(EPlan));
 		(*nplans) = i = 0;
 	}
 
-	newp->ident = strdup(ident);
+	newp->ident = pstrdup(ident);
 	newp->nplans = 0;
 	newp->splan = NULL;
 	(*nplans)++;
 
+	MemoryContextSwitchTo(oldcontext);
 	return (newp);
 }

--- a/contrib/spi/refint.c
+++ b/contrib/spi/refint.c
@@ -166,21 +166,24 @@ check_primary_key(PG_FUNCTION_ARGS)
 	if (plan->nplans <= 0)
 	{
 		SPIPlanPtr	pplan;
-		char		sql[8192];
+		StringInfoData sql;
+
+		initStringInfo(&sql);
 
 		/*
 		 * Construct query: SELECT 1 FROM _referenced_relation_ WHERE Pkey1 =
 		 * $1 [AND Pkey2 = $2 [...]]
 		 */
-		snprintf(sql, sizeof(sql), "select 1 from %s where ", relname);
-		for (i = 0; i < nkeys; i++)
+		appendStringInfo(&sql, "select 1 from %s where ", relname);
+		for (i = 1; i <= nkeys; i++)
 		{
-			snprintf(sql + strlen(sql), sizeof(sql) - strlen(sql), "%s = $%d %s",
-				  args[i + nkeys + 1], i + 1, (i < nkeys - 1) ? "and " : "");
+			appendStringInfo(&sql, "%s = $%d ", args[i + nkeys], i);
+			if (i < nkeys)
+				appendStringInfoString(&sql, "and ");
 		}
 
 		/* Prepare plan for query */
-		pplan = SPI_prepare(sql, nkeys, argtypes);
+		pplan = SPI_prepare(sql.data, nkeys, argtypes);
 		if (pplan == NULL)
 			/* internal error */
 			elog(ERROR, "check_primary_key: SPI_prepare returned %d", SPI_result);
@@ -196,6 +199,8 @@ check_primary_key(PG_FUNCTION_ARGS)
 														sizeof(SPIPlanPtr));
 		*(plan->splan) = pplan;
 		plan->nplans = 1;
+
+		pfree(sql.data);
 	}
 
 	/*
@@ -416,7 +421,6 @@ check_foreign_key(PG_FUNCTION_ARGS)
 	if (plan->nplans <= 0)
 	{
 		SPIPlanPtr	pplan;
-		char		sql[8192];
 		char	  **args2 = args;
 
 		plan->splan = (SPIPlanPtr *) MemoryContextAlloc(TopMemoryContext,
@@ -424,6 +428,10 @@ check_foreign_key(PG_FUNCTION_ARGS)
 
 		for (r = 0; r < nrefs; r++)
 		{
+			StringInfoData sql;
+
+			initStringInfo(&sql);
+
 			relname = args2[0];
 
 			/*---------
@@ -437,8 +445,7 @@ check_foreign_key(PG_FUNCTION_ARGS)
 			 *---------
 			 */
 			if (action == 'r')
-
-				snprintf(sql, sizeof(sql), "select 1 from %s where ", relname);
+				appendStringInfo(&sql, "select 1 from %s where ", relname);
 
 			/*---------
 			 * For 'C'ascade action we construct DELETE query
@@ -465,40 +472,23 @@ check_foreign_key(PG_FUNCTION_ARGS)
 					char	   *nv;
 					int			k;
 
-					snprintf(sql, sizeof(sql), "update %s set ", relname);
+					appendStringInfo(&sql, "update %s set ", relname);
 					for (k = 1; k <= nkeys; k++)
 					{
-						int			is_char_type = 0;
-						char	   *type;
-
 						fn = SPI_fnumber(tupdesc, args_temp[k - 1]);
 						nv = SPI_getvalue(newtuple, tupdesc, fn);
-						type = SPI_gettype(tupdesc, fn);
 
-						if ((strcmp(type, "text") && strcmp(type, "varchar") &&
-							 strcmp(type, "char") && strcmp(type, "bpchar") &&
-							 strcmp(type, "date") && strcmp(type, "timestamp")) == 0)
-							is_char_type = 1;
-#ifdef	DEBUG_QUERY
-						elog(DEBUG4, "check_foreign_key Debug value %s type %s %d",
-							 nv, type, is_char_type);
-#endif
-
-						/*
-						 * is_char_type =1 i set ' ' for define a new value
-						 */
-						snprintf(sql + strlen(sql), sizeof(sql) - strlen(sql),
-								 " %s = %s%s%s %s ",
-								 args2[k], (is_char_type > 0) ? "'" : "",
-								 nv, (is_char_type > 0) ? "'" : "", (k < nkeys) ? ", " : "");
-						is_char_type = 0;
+						appendStringInfo(&sql, " %s = %s ",
+										 args2[k], quote_literal_cstr(nv));
+						if (k < nkeys)
+							appendStringInfoString(&sql, ", ");
 					}
-					strcat(sql, " where ");
+					appendStringInfoString(&sql, " where ");
 
 				}
 				else
 					/* DELETE */
-					snprintf(sql, sizeof(sql), "delete from %s where ", relname);
+					appendStringInfo(&sql, "delete from %s where ", relname);
 
 			}
 
@@ -510,25 +500,26 @@ check_foreign_key(PG_FUNCTION_ARGS)
 			 */
 			else if (action == 's')
 			{
-				snprintf(sql, sizeof(sql), "update %s set ", relname);
+				appendStringInfo(&sql, "update %s set ", relname);
 				for (i = 1; i <= nkeys; i++)
 				{
-					snprintf(sql + strlen(sql), sizeof(sql) - strlen(sql),
-							 "%s = null%s",
-							 args2[i], (i < nkeys) ? ", " : "");
+					appendStringInfo(&sql, "%s = null", args2[i]);
+					if (i < nkeys)
+						appendStringInfoString(&sql, ", ");
 				}
-				strcat(sql, " where ");
+				appendStringInfoString(&sql, " where ");
 			}
 
 			/* Construct WHERE qual */
 			for (i = 1; i <= nkeys; i++)
 			{
-				snprintf(sql + strlen(sql), sizeof(sql) - strlen(sql), "%s = $%d %s",
-						 args2[i], i, (i < nkeys) ? "and " : "");
+				appendStringInfo(&sql, "%s = $%d ", args2[i], i);
+				if (i < nkeys)
+					appendStringInfoString(&sql, "and ");
 			}
 
 			/* Prepare plan for query */
-			pplan = SPI_prepare(sql, nkeys, argtypes);
+			pplan = SPI_prepare(sql.data, nkeys, argtypes);
 			if (pplan == NULL)
 				/* internal error */
 				elog(ERROR, "check_foreign_key: SPI_prepare returned %d", SPI_result);
@@ -544,11 +535,14 @@ check_foreign_key(PG_FUNCTION_ARGS)
 			plan->splan[r] = pplan;
 
 			args2 += nkeys + 1; /* to the next relation */
+
+#ifdef DEBUG_QUERY
+			elog(DEBUG4, "check_foreign_key Debug Query is :  %s ", sql.data);
+#endif
+
+			pfree(sql.data);
 		}
 		plan->nplans = nrefs;
-#ifdef	DEBUG_QUERY
-		elog(DEBUG4, "check_foreign_key Debug Query is :  %s ", sql);
-#endif
 	}
 
 	/*


### PR DESCRIPTION
## Summary
Backport the fix for **CVE-2026-6637** — stack buffer overflow + SQL injection in the `refint` contrib module (`check_foreign_key` / `check_primary_key`) — to GP6 (PostgreSQL 9.4 base). Missed by PTT-1125's evaluation of the May 14, 2026 PostgreSQL security release.

Two commits:
- **refint: Fix SQL injection and buffer overruns.** — upstream `2b026df` (Security: CVE-2026-6637); replaces the fixed `sql[8192]` stack buffers with `StringInfo` and escapes all values via `quote_literal_cstr()`.
- **Remove dependency to system calls for memory allocation in refint** — prerequisite upstream `b0b619`, never picked up on this branch.

## Background
GP6's `refint.c` carried the same vulnerable fixed `sql[8192]` buffers and unescaped value interpolation as v7. The CVE-relevant changes are semantically identical to upstream; pre-existing GP6-only divergences in this file (older `%d`/`SPI_result` error strings, `pg_atoi`, `UINT64_FORMAT`) are left intact, so unlike the v7 PRs the result is not byte-identical to upstream REL_14_STABLE but is functionally equivalent.

Not applicable to GP6/9.4 from the same release: CVE-2026-6479 (SSL/GSS recursion) — 9.4 has no GSS startup negotiation path, so the vuln does not exist here.

## Test plan
- `contrib/spi` compiles clean (`-Wall -Werror -DREFINT_VERBOSE`, no warnings).

Refs: PTT-1190
