### PR TITLE
jit: Fix build with LLVM 21

### DIFF
--- a/src/backend/jit/llvm/llvmjit_inline.cpp
+++ b/src/backend/jit/llvm/llvmjit_inline.cpp
@@ -243,7 +243,11 @@ llvm_build_inline_plan(LLVMContextRef lc, llvm::Module *mod)
 
 		llvm_split_symbol_name(symbolName.data(), &cmodname, &cfuncname);
 
+#if LLVM_VERSION_MAJOR >= 21
+		funcGUID = llvm::GlobalValue::getGUIDAssumingExternalLinkage(cfuncname);
+#else
 		funcGUID = llvm::GlobalValue::getGUID(cfuncname);
+#endif
 
 		/* already processed */
 		if (inlineState.processed)

--- a/src/backend/jit/llvm/llvmjit_wrap.cpp
+++ b/src/backend/jit/llvm/llvmjit_wrap.cpp
@@ -110,7 +110,14 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::orc::ObjectLayer, LLVMOrcObjectLayerRef
 LLVMOrcObjectLayerRef
 LLVMOrcCreateRTDyldObjectLinkingLayerWithSafeSectionMemoryManager(LLVMOrcExecutionSessionRef ES)
 {
+#if LLVM_VERSION_MAJOR >= 21
+	return wrap(new llvm::orc::RTDyldObjectLinkingLayer(
+		*unwrap(ES), [](const llvm::MemoryBuffer&) {
+			return std::make_unique<llvm::backport::SectionMemoryManager>(nullptr, true);
+		}));
+#else
 	return wrap(new llvm::orc::RTDyldObjectLinkingLayer(
 		*unwrap(ES), [] { return std::make_unique<llvm::backport::SectionMemoryManager>(nullptr, true); }));
+#endif
 }
 #endif


### PR DESCRIPTION
## Summary
Backport two upstream PostgreSQL fixes that adapt the LLVM JIT backend to
LLVM 21's API changes. Already on `main`; this brings the stable branch in line.

## Background
LLVM 21 made two source-incompatible API changes:

1. `RTDyldObjectLinkingLayer`'s constructor arguments changed, breaking the
   backported `SectionMemoryManager` (commit 9044fc1d) — fixed upstream by
   `0dceba21d74` "jit: Adjust AArch64-only code for LLVM 21." (backpatch-through 14).
2. `llvm::GlobalValue::getGUID()` was renamed to `getGUIDAssumingExternalLinkage()`
   — fixed upstream by `282d0bdee61` "jit: fix build with LLVM-21".

Both hunks are guarded behind `#if LLVM_VERSION_MAJOR >= 21`, so builds on older
LLVM are unaffected. The code change is byte-identical to upstream / `main`.
