### PR TITLE
fix trailing-whitespace mismatch in expected/gp_dqa

### DIFF
--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -3653,7 +3653,7 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count
+ count 
 -------
    236
 (1 row)
@@ -3695,7 +3695,7 @@ SELECT count(*) FROM (
   FROM sales GROUP BY cust_no
   HAVING sum(sale_amt) >= 100000 AND count(distinct sale_date) >= 5
 )as sub;
- count
+ count 
 -------
    236
 (1 row)


### PR DESCRIPTION
The "count" column header for two count(*) FROM (... sales ...) queries added by #149 was emitted without a trailing space in the expected file, but psql actually outputs " count " with one trailing space. This makes the diff fail under optimizer=off (the gp_dqa.out path; the gp_dqa_optimizer.out sibling was corrected before the merge of #149).

Two-character fix at lines 3656 and 3698.

The bug surfaces in main's own post-merge CI run for #149 (installcheck / EL8|9 / optimizer=off) 

