### PR TITLE
fix: uninitialized current table oid in execCurrentOf

### DIFF
--- a/getversion
+++ b/getversion
@@ -10,7 +10,7 @@ BUILDNUMBER=dev
 # Call git describe, and convert it to a semi-semantic version, like
 # 5.0.0-alpha.0+dev.52.g123abc
 generate_dev_version() {
-    git describe | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'
+    git describe --tags | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'
 }
 
 # If we are in a Git repository and have git installed, build the version
@@ -22,7 +22,7 @@ if type git >/dev/null 2>&1 && [ -d '.git' ] ; then
 	# unreachable even if we have pulled the tags. If we can reach it,
 	# overwrite the VERSION from autoconf with the output, else append
 	# HEAD commit info
-	if git describe >/dev/null 2>&1 ; then
+	if git describe --tags >/dev/null 2>&1 ; then
 		VERSION=$(generate_dev_version)
 	else
 		VERSION+=+

--- a/src/backend/executor/execCurrent.c
+++ b/src/backend/executor/execCurrent.c
@@ -53,7 +53,7 @@ execCurrentOf(CurrentOfExpr *cexpr,
 			  ItemPointer current_tid)
 {
 	int			current_gp_segment_id = -1;
-	Oid			current_table_oid;
+	Oid			current_table_oid = InvalidOid;
 
 	/*
 	 * In an executor node, the dispatcher should've included the current

--- a/src/test/regress/expected/cursor.out
+++ b/src/test/regress/expected/cursor.out
@@ -711,3 +711,35 @@ SELECT * FROM cursor_initplan ORDER BY a;
 (10 rows)
 
 DROP TABLE cursor_initplan;
+--
+-- WHERE CURRENT OF on a non-partitioned table evaluated in utility mode
+-- (Gp_role != GP_ROLE_EXECUTE).  Exercises the execCurrentOf() out-param
+-- contract: getCurrentOf() only writes *current_table_oid when the cursor
+-- carries tableoid junk metadata, which DECLARE CURSOR planning omits for
+-- non-partitioned tables.  Before this was fixed the local in
+-- execCurrentOf() was uninitialised, so the equality check against
+-- table_oid could read stack garbage.
+--
+-- Feed the SQL on stdin, not via psql -c: on PG12-era psql a multi-statement
+-- -c string runs as a single query and prints only the last command's result,
+-- which would hide the UPDATE/SELECT output below.
+\! echo "DROP TABLE IF EXISTS cursor_wco_nonpart; CREATE TABLE cursor_wco_nonpart (id int, v text); INSERT INTO cursor_wco_nonpart VALUES (1, 'a'); BEGIN; DECLARE c CURSOR FOR SELECT * FROM cursor_wco_nonpart FOR UPDATE; FETCH c; UPDATE cursor_wco_nonpart SET v = 'modified' WHERE CURRENT OF c; COMMIT; SELECT id, v FROM cursor_wco_nonpart; DROP TABLE cursor_wco_nonpart;" | PGOPTIONS='-c gp_role=utility' psql -X -d regression -h "$PGHOST" -p $PGPORT
+NOTICE:  table "cursor_wco_nonpart" does not exist, skipping
+DROP TABLE
+CREATE TABLE
+INSERT 0 1
+BEGIN
+DECLARE CURSOR
+ id | v 
+----+---
+  1 | a
+(1 row)
+
+UPDATE 1
+COMMIT
+ id |    v     
+----+----------
+  1 | modified
+(1 row)
+
+DROP TABLE

--- a/src/test/regress/sql/cursor.sql
+++ b/src/test/regress/sql/cursor.sql
@@ -431,3 +431,17 @@ LANGUAGE 'plpgsql';
 SELECT func_test_cursor();
 SELECT * FROM cursor_initplan ORDER BY a;
 DROP TABLE cursor_initplan;
+
+--
+-- WHERE CURRENT OF on a non-partitioned table evaluated in utility mode
+-- (Gp_role != GP_ROLE_EXECUTE).  Exercises the execCurrentOf() out-param
+-- contract: getCurrentOf() only writes *current_table_oid when the cursor
+-- carries tableoid junk metadata, which DECLARE CURSOR planning omits for
+-- non-partitioned tables.  Before this was fixed the local in
+-- execCurrentOf() was uninitialised, so the equality check against
+-- table_oid could read stack garbage.
+--
+-- Feed the SQL on stdin, not via psql -c: on PG12-era psql a multi-statement
+-- -c string runs as a single query and prints only the last command's result,
+-- which would hide the UPDATE/SELECT output below.
+\! echo "DROP TABLE IF EXISTS cursor_wco_nonpart; CREATE TABLE cursor_wco_nonpart (id int, v text); INSERT INTO cursor_wco_nonpart VALUES (1, 'a'); BEGIN; DECLARE c CURSOR FOR SELECT * FROM cursor_wco_nonpart FOR UPDATE; FETCH c; UPDATE cursor_wco_nonpart SET v = 'modified' WHERE CURRENT OF c; COMMIT; SELECT id, v FROM cursor_wco_nonpart; DROP TABLE cursor_wco_nonpart;" | PGOPTIONS='-c gp_role=utility' psql -X -d regression -h "$PGHOST" -p $PGPORT


### PR DESCRIPTION
There's a potential QD path on non-partitioned tables that may read uninitialized values otherwise.

In addition, the `getversion` script is updated to take into account lightweight tags too. Without that `version()` would give a misleading value, i.e. give `7.2.1` (the last annotated tag) even on later versions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
