### PR TITLE
Fix gpload serial column flag assignment

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1910,7 +1910,7 @@ class gpload:
                 if has_seq == str('f') or has_seq==False:
                     has_seq_bool = False
                 if has_seq == str('t') or has_seq==True:
-                    has_sql_bool = True
+                    has_seq_bool = True
                 i = [name,ct,None, has_seq_bool]  
                 # i: [column name, column data type, mapping target, has_sequence]
                 self.into_columns.append(i)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_input_column.py
@@ -184,3 +184,20 @@ def test_77_gpload_merge_capital_letters_standard_conforming_str_off():
     f.write("\\! gpload -f "+mkpath('config/config_file3')+"\n")
     f.write("\\! gpload -f "+mkpath('config/config_file4')+"\n")
     f.close()
+
+
+@prepare_before_test(num=78, times=1)
+def test_78_gpload_insert_target_table_with_serial_column():
+    "78 gpload insert into target table with a serial column"
+    psql_run(cmd='DROP TABLE IF EXISTS serial_column_table', dbname='reuse_gptest')
+    psql_run(cmd='CREATE TABLE serial_column_table(id serial, name text) DISTRIBUTED BY (id)', dbname='reuse_gptest')
+    write_config_file(
+        mode='insert',
+        file='data/external_file_78.txt',
+        table='serial_column_table',
+        delimiter="'|'",
+        preload=False,
+        reuse_tables=False)
+    f = open(mkpath('query78.sql'), 'a')
+    f.write("\\! psql -d reuse_gptest -c \"select count(*) from serial_column_table where id = 1 and name = 'serial-column-row';\"")
+    f.close()

--- a/gpMgmt/bin/gpload_test/gpload2/data/external_file_78.txt
+++ b/gpMgmt/bin/gpload_test/gpload2/data/external_file_78.txt
@@ -1,0 +1,1 @@
+serial-column-row

--- a/gpMgmt/bin/gpload_test/gpload2/query78.ans
+++ b/gpMgmt/bin/gpload_test/gpload2/query78.ans
@@ -1,0 +1,13 @@
+2021-01-05 17:06:16|INFO|gpload session started 2021-01-05 17:06:16
+2021-01-05 17:06:16|INFO|setting schema 'public' for table 'serial_column_table'
+2021-01-05 17:06:16|INFO|started gpfdist -p 8081 -P 8082 -f "/home/cc/repo/gpdb/gpMgmt/bin/gpload_test/gpload2/data/external_file_78.txt" -t 30
+2021-01-05 17:06:16|INFO|running time: 0.13 seconds
+2021-01-05 17:06:16|INFO|rows Inserted          = 1
+2021-01-05 17:06:16|INFO|rows Updated           = 0
+2021-01-05 17:06:16|INFO|data formatting errors = 0
+2021-01-05 17:06:16|INFO|gpload succeeded
+ count 
+-------
+     1
+(1 row)
+


### PR DESCRIPTION
gpload failed with uninitialized value:
-- error on gpload_.log
2026-05-21 06:56:58|INFO|gpload session started 2026-05-21 06:56:58
Traceback (most recent call last):
 File "/usr/edb/whpg7/bin/gpload.py", line 3010, in run
  self.run2()
 File "/usr/edb/whpg7/bin/gpload.py", line 2990, in run2
  self.read_table_metadata()
 File "/usr/edb/whpg7/bin/gpload.py", line 1914, in read_table_metadata
  i = [name,ct,None, has_seq_bool]
           ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'has_seq_bool' where it is not associated with a value


Correct the gpload table metadata logic so SERIAL columns assign has_seq_bool instead of the unused has_sql_bool typo.
Add a gpload regression case that loads into a table with a SERIAL column and verifies the sequence-generated value is inserted correctly.