### PR TITLE
feature: Add gpAdminLogs logging support to gpcheckperf

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -30,18 +30,24 @@ Usage: gpcheckperf <options>
     --duration : how long to run network test (default 5 seconds)
     --netperf  : use netperf instead of gpnetbenchServer/gpnetbenchClient
     --buffer-size : the size of the send buffer in kilobytes ( default 8 kilobytes)
+
+All output is also written to ~/gpAdminLogs/gpcheckperf_<date>.log
 """
 
 import datetime
+import logging
 import os
 import sys
 import re
+import builtins
 
 sys.path.append(sys.path[0] + '/lib')
 try:
     import getopt, math, io, stat, subprocess, signal
+    from gppylib import gplog
     from gppylib.gpparseopts import OptParser
     from gppylib.util import ssh_utils
+    from gppylib.commands.unix import getLocalHostname, getUserName
     from functools import reduce
 except ImportError as e:
     sys.exit('Error: unable to import module: ' + str(e))
@@ -53,6 +59,28 @@ if GPHOME is None:
 USER = os.getenv('USER')
 if USER is None or USER == ' ':
     sys.exit('Please set USER environment variable')
+
+
+# Keep a reference to the builtin print so we can mirror everything that is
+# printed to stdout into the gpAdminLogs logfile without changing stdout.
+_builtin_print = builtins.print
+
+
+def print(*args, **kwargs):
+    """Drop-in replacement for the builtin print.
+
+    Behaves exactly like the builtin print on stdout, but additionally mirrors
+    the message to the gpcheckperf logfile under ~/gpAdminLogs (file only, so
+    stdout is never written to twice). Logging to the file is a no-op until
+    setup_tool_logging() has been called in main().
+    """
+    _builtin_print(*args, **kwargs)
+    if kwargs.get('file', sys.stdout) not in (sys.stdout, None):
+        return
+    sep = kwargs.get('sep', ' ')
+    msg = sep.join(str(a) for a in args)
+    if msg:
+        gplog.log_to_file_only(msg)
 
 
 def usage(exitarg):
@@ -965,6 +993,11 @@ def printResult(title, result):
 
 
 def main():
+    # Set up logging to ~/gpAdminLogs/gpcheckperf_<date>.log,
+    # matching the convention used by gpstart/gpstop/gpcheckcat. This must
+    # happen before parseCommandLine() so the resolved command line is logged.
+    gplog.setup_tool_logging('gpcheckperf', getLocalHostname(), getUserName())
+
     try:
         parseCommandLine()
         runSetup()
@@ -1011,8 +1044,16 @@ def main():
 
             runTeardown()
 
+        print('Log file: %s' % gplog.get_logfile())
+
     except KeyboardInterrupt:
         print('[Abort] Keyboard Interrupt ...')
+    except SystemExit as e:
+        # Capture early-exit error messages (sys.exit('[Error] ...')) in the
+        # logfile before propagating; stdout/stderr behavior is unchanged.
+        if isinstance(e.code, str):
+            gplog.log_to_file_only(e.code, logging.ERROR)
+        raise
 
 if __name__ == '__main__':
      main()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
@@ -1,6 +1,7 @@
 import imp
 import os
 import sys
+import tempfile
 from mock import patch
 from gppylib.test.unit.gp_unittest import GpTestCase,run_tests
 
@@ -96,6 +97,25 @@ class GpCheckPerf(GpTestCase):
         self.assertEqual(mbps, exp_mbps)
         self.assertEqual(time, exp_time)
         self.assertEqual(bytes, exp_bytes)
+
+    def test_output_is_mirrored_to_logfile(self):
+        # gpcheckperf mirrors everything printed to stdout into a logfile under
+        # gpAdminLogs. Point logging at a temp dir and verify the logfile is
+        # created and captures the RESULT block.
+        logdir = tempfile.mkdtemp()
+        gplog = self.subject.gplog
+        gplog.setup_tool_logging('gpcheckperf', 'localhost', 'testuser', logdir=logdir)
+
+        self.subject.print('====================')
+        self.subject.print('==  RESULT 2026-06-23T00:00:00')
+        self.subject.print(' disk write tot bandwidth (MB/s): 123.45')
+
+        logfile = gplog.get_logfile()
+        self.assertTrue(logfile.startswith(logdir))
+        with open(logfile) as f:
+            contents = f.read()
+        self.assertIn('RESULT', contents)
+        self.assertIn('disk write tot bandwidth (MB/s): 123.45', contents)
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/doc/gpcheckperf_help
+++ b/gpMgmt/doc/gpcheckperf_help
@@ -87,6 +87,12 @@ already.
 Note that gpcheckperf calls to gpssh and gpscp, so these 
 Greenplum utilities must also be in your $PATH.
 
+In addition to printing results to the screen, gpcheckperf writes
+all of its output, including the final RESULT block, to a log file
+in ~/gpAdminLogs/gpcheckperf_<date>.log. Running gpcheckperf more
+than once on the same day appends to the same dated log file. This
+provides a historical record of performance results for later review.
+
 *****************************************************
 OPTIONS
 *****************************************************

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -94,3 +94,12 @@ Feature: Tests for gpcheckperf
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "--buffer-size value is not specified or invalid. Using default \(8 kilobytes\)" to stdout
     And   gpcheckperf should print "avg = " to stdout
+
+    @concourse_cluster
+    Scenario: gpcheckperf writes output to gpAdminLogs
+      Given the database is running
+      When  the user runs "gpcheckperf -h cdw -r M -d /data/gpdata/ --duration=10s -v"
+      Then  gpcheckperf should return a return code of 0
+      And   verify that the utility gpcheckperf ever does logging into the user's "gpAdminLogs" directory
+      And   gpcheckperf should print "RESULT" to logfile
+      And   gpcheckperf should print "Log file:" to stdout


### PR DESCRIPTION
### Summary
`gpcheckperf` only wrote its output to stdout, leaving no historical records once the terminal scrollback was gone.

### Key Changes
* **Logging Integration:** Initialized `gplog.setup_tool_logging` early in `main()` so the resolved command line, banners and the full `RESULT` block are automatically captured
* **Stdout Mirroring:** Added a thin module-level wrapper around the builtin `print()` that calls `gplog.log_to_file_only()`. This ensures that stdout output remains byte-identical to before (no double printing in the console), while everything is mirrored to `~/gpAdminLogs/gpcheckperf_<date>.log`
* **Documentation:** Updated `gpcheckperf_help` to mention the new logfile location and append behavior
* **Testing:** Added a new unit test `test_output_is_mirrored_to_logfile` in `test_unit_gpcheckperf.py` to assert logfile creation and correct content capturing