### PR TITLE
fix(planner): lift correlated quals above Motion for Entry tables to prevent crash

### DIFF
--- a/.abi-check/7.0.0/postgres.types.ignore
+++ b/.abi-check/7.0.0/postgres.types.ignore
@@ -8,3 +8,4 @@ struct AppendOnlyFetchDescData
 struct AppendOnlyInsertDescData
 struct CreateForeignTableStmt
 enum PMSignalReason
+struct PlannerConfig

--- a/.abi-check/7.1.0/postgres.types.ignore
+++ b/.abi-check/7.1.0/postgres.types.ignore
@@ -8,3 +8,4 @@ struct AOCSWriteColumnDescData
 struct AppendOnlyFetchDescData
 struct AppendOnlyInsertDescData
 struct ResGroupCaps
+struct PlannerConfig

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -161,6 +161,7 @@ static void remove_unused_subquery_outputs(Query *subquery, RelOptInfo *rel);
 
 static void bring_to_outer_query(PlannerInfo *root, RelOptInfo *rel, List *outer_quals);
 static void bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel);
+static void bring_to_entry(PlannerInfo *root, RelOptInfo *rel);
 static bool is_query_contain_limit_groupby(Query *parse);
 static void handle_gen_seggen_volatile_path(PlannerInfo *root, RelOptInfo *rel);
 
@@ -646,6 +647,138 @@ bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel)
 }
 
 /*
+ * The following function "steals" ideas and most of the code from the
+ * function bring_to_singleQE.
+ *
+ * Decorate the Paths of 'rel' with Motions to bring the relation's result to
+ * Entry (coordinator) locus.  This is used when the query references a
+ * correlated SubPlan that must execute on the coordinator -- it scans a
+ * coordinator-only (Entry) catalog and needs an outer correlation parameter,
+ * which cannot be passed across a Motion.  A correlated SubPlan runs in the
+ * slice that produces its parameter, so the rel that produces the parameter
+ * must be gathered to the coordinator here; the SubPlan, applied above this
+ * Motion, then runs on the coordinator where the catalog is local and the
+ * parameter is available.  See force_entry in distribute_restrictinfo_to_rels().
+ *
+ * Two kinds of quals must be evaluated above the Motion rather than at the
+ * scan (which is below the Motion, on the segments):
+ *
+ *  - A correlated SubPlan that sits in a WHERE qual lives in
+ *    rel->baserestrictinfo.  Pull the SubPlan-bearing quals out so they are
+ *    applied above the Motion; plain quals (no SubPlan) stay at the scan, where
+ *    they can still filter before the gather.  (SubPlans in the target list or
+ *    in HAVING are already evaluated above the scan, hence above this Motion,
+ *    so they need no special handling here.)
+ *
+ *  - Outer-correlated quals that rel_need_to_separate_outer_query_restrictinfos()
+ *    diverted to rel->upperrestrictinfo (e.g. an equivalence-class-derived
+ *    "t2.b = outer.x" filter on a distributed rel).  Normally bring_to_outer_query()
+ *    applies these above the Motion, but the force_entry branch in
+ *    set_rel_pathlist() runs in its place -- so we must apply them here too,
+ *    otherwise they are silently dropped and the subquery's join degenerates
+ *    into a Cartesian product.
+ *
+ * Both, like bring_to_outer_query() does with upperrestrictinfo, are re-applied
+ * in a Result node above the Motion (at Entry locus, where the outer parameter
+ * is available on the coordinator).
+ */
+static void
+bring_to_entry(PlannerInfo *root, RelOptInfo *rel)
+{
+	List	   *origpathlist;
+	List	   *above_motion_quals = NIL;
+	List	   *scan_quals = NIL;
+	ListCell   *lc;
+
+	foreach(lc, rel->baserestrictinfo)
+	{
+		RestrictInfo *ri = (RestrictInfo *) lfirst(lc);
+
+		if (contain_subplans((Node *) ri->clause))
+			above_motion_quals = lappend(above_motion_quals, ri);
+		else
+			scan_quals = lappend(scan_quals, ri);
+	}
+	rel->baserestrictinfo = scan_quals;
+
+	/* Correlated quals separated into upperrestrictinfo go above the Motion. */
+	above_motion_quals = list_concat(above_motion_quals,
+									 list_copy(rel->upperrestrictinfo));
+	rel->upperrestrictinfo = NIL;
+
+	origpathlist = rel->pathlist;
+	rel->cheapest_startup_path = NULL;
+	rel->cheapest_total_path = NULL;
+	rel->cheapest_unique_path = NULL;
+	rel->cheapest_parameterized_paths = NIL;
+	rel->pathlist = NIL;
+
+	foreach(lc, origpathlist)
+	{
+		Path	     *origpath = (Path *) lfirst(lc);
+		Path	     *path;
+		CdbPathLocus  target_locus;
+
+		if (CdbPathLocus_IsGeneral(origpath->locus) ||
+			CdbPathLocus_IsEntry(origpath->locus))
+			path = origpath;
+		else
+		{
+			/*
+			 * Cannot pass a param through motion, so if this is a parameterized
+			 * path, we can't use it.
+			 */
+			if (origpath->param_info)
+				continue;
+
+			/*
+			 * param_info cannot cover the case that an index path's orderbyclauses
+			 * See github issue: https://github.com/greenplum-db/gpdb/issues/9733
+			 */
+			if (IsA(origpath, IndexPath))
+			{
+				IndexPath *ipath = (IndexPath *) origpath;
+				if (contains_outer_params((Node *) ipath->indexorderbys,
+										  (void *) root))
+					continue;
+			}
+
+			CdbPathLocus_MakeEntry(&target_locus);
+
+			path = cdbpath_create_motion_path(root,
+											  origpath,
+											  NIL, // DESTROY pathkeys
+											  false,
+											  target_locus);
+
+			/*
+			 * Shield the Motion with an (unparameterized) Materialize, exactly
+			 * as bring_to_singleQE() does.  A correlated SubPlan is rescanned
+			 * once per outer row, and the lifted correlated qual we attach just
+			 * below makes the path above this Motion parameterized.  Without the
+			 * Materialize here -- whose subtree is just the Motion and therefore
+			 * has no parameter dependency -- a rescan would propagate down to
+			 * the Motion itself ("illegal rescan of motion node").  With it, the
+			 * Motion runs once and rescans replay the materialized tuples.
+			 */
+			path = (Path *) create_material_path(root, rel, path);
+		}
+
+		/* Evaluate the lifted quals (SubPlan-bearing + correlated) above the Motion. */
+		if (above_motion_quals)
+			path = (Path *) create_projection_path_with_quals(root,
+															  rel,
+															  path,
+															  path->parent->reltarget,
+															  above_motion_quals,
+															  true);
+
+		add_path(rel, path);
+	}
+	set_cheapest(rel);
+}
+
+/*
  * handle_gen_seggen_volatile_path
  *
  * Only use for base replicated rel.
@@ -767,7 +900,21 @@ set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	if (set_rel_pathlist_hook)
 		(*set_rel_pathlist_hook) (root, rel, rti, rte);
 
-	if (rel->upperrestrictinfo)
+	if (root->config->force_entry ||
+		bms_is_member(rti, root->config->force_entry_rels))
+	{
+		/*
+		 * CDB: gather this rel to Entry (coordinator) locus so a correlated
+		 * SubPlan over a coordinator-only Entry catalog runs on the coordinator.
+		 * force_entry forces every base rel of this query (used for the
+		 * SubPlan's own subquery, so its whole join stays on the coordinator);
+		 * force_entry_rels forces only the specific rel(s) that supply the
+		 * correlation parameter (used in the parent query, so unrelated base
+		 * rels stay distributed).  See distribute_restrictinfo_to_rels().
+		 */
+		bring_to_entry(root, rel);
+	}
+	else if (rel->upperrestrictinfo)
 		bring_to_outer_query(root, rel, rel->upperrestrictinfo);
 	else if (root->config->force_singleQE)
 	{

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -38,6 +38,7 @@
 
 #include "access/heapam.h"
 #include "cdb/cdbmutate.h"
+#include "cdb/cdbvars.h"
 #include "nodes/makefuncs.h"
 #include "parser/parsetree.h"
 
@@ -2262,6 +2263,94 @@ check_redundant_nullability_qual(PlannerInfo *root, Node *clause)
 	return false;
 }
 
+/*
+ * Returns true if the query scans a distributed (partitioned or replicated)
+ * relation -- i.e. one that needs a Motion when joined with a coordinator-only
+ * (Entry) table.  Used to detect the Entry-correlated-SubPlan case that forces
+ * the outer query to Entry (coordinator) locus; see force_entry handling in
+ * distribute_restrictinfo_to_rels().
+ */
+static bool
+subquery_contains_distributed_rel(PlannerInfo *root)
+{
+	int			rti;
+
+	for (rti = 1; rti < root->simple_rel_array_size; rti++)
+	{
+		RelOptInfo *brel = root->simple_rel_array[rti];
+
+		if (brel == NULL || brel->reloptkind != RELOPT_BASEREL)
+			continue;
+
+		if (brel->rtekind == RTE_RELATION && brel->cdbpolicy != NULL &&
+			(GpPolicyIsPartitioned(brel->cdbpolicy) ||
+			 GpPolicyIsReplicated(brel->cdbpolicy)))
+			return true;
+	}
+
+	return false;
+}
+
+/* Collect the PARAM_EXEC parameter ids referenced anywhere in an expression. */
+static bool
+collect_param_exec_ids_walker(Node *node, Bitmapset **paramids)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Param))
+	{
+		Param	   *p = (Param *) node;
+
+		if (p->paramkind == PARAM_EXEC)
+			*paramids = bms_add_member(*paramids, p->paramid);
+	}
+	return expression_tree_walker(node, collect_param_exec_ids_walker,
+								  (void *) paramids);
+}
+
+/*
+ * For a subquery restriction 'clause' that references outer-query correlation
+ * parameters, mark -- on the parent query level -- exactly the base relations
+ * that supply those parameters, so only those rels are forced to Entry
+ * (coordinator) locus.  This keeps the fix narrow instead of dragging every
+ * base rel of the parent layer to the coordinator.
+ *
+ * The mapping from a PARAM_EXEC id back to the parent Var (whose varno is the
+ * parent RT index) lives in parent_root->plan_params, populated when the
+ * correlation Var was replaced by the parameter (see assign_param_for_var()).
+ */
+static void
+force_entry_param_source_rels(PlannerInfo *subroot, Node *clause)
+{
+	PlannerInfo *parent = subroot->parent_root;
+	Bitmapset  *paramids = NULL;
+	ListCell   *l;
+
+	if (parent == NULL)
+		return;
+
+	collect_param_exec_ids_walker(clause, &paramids);
+	if (bms_is_empty(paramids))
+		return;
+
+	foreach(l, parent->plan_params)
+	{
+		PlannerParamItem *pitem = (PlannerParamItem *) lfirst(l);
+
+		if (!bms_is_member(pitem->paramId, paramids))
+			continue;
+		if (IsA(pitem->item, Var))
+		{
+			Var		   *var = (Var *) pitem->item;
+
+			parent->config->force_entry_rels =
+				bms_add_member(parent->config->force_entry_rels, var->varno);
+		}
+	}
+
+	bms_free(paramids);
+}
+
 static bool
 rel_need_to_separate_outer_query_restrictinfos(PlannerInfo *root, RelOptInfo *rel)
 {
@@ -2343,8 +2432,81 @@ distribute_restrictinfo_to_rels(PlannerInfo *root,
 												 restrictinfo);
 			}
 			else
+			{
+				/*
+				 * GPDB: Detect a correlated restriction on a coordinator-only
+				 * (Entry) table inside a subquery that also scans a distributed
+				 * relation -- e.g. a correlated subquery joining
+				 * gp_segment_configuration with a distributed table.  Such a
+				 * SubPlan must execute entirely on the coordinator: it scans an
+				 * Entry catalog (whose rows only exist there) and it needs the
+				 * outer correlation parameter, which GPDB cannot pass across a
+				 * Motion.
+				 *
+				 * Two things must hold, so we force Entry (coordinator) locus:
+				 *
+				 * 1. The subquery itself must perform its join on the
+				 *    coordinator.  Otherwise the planner is free to Broadcast the
+				 *    Entry table to the segments and join there, pushing the
+				 *    correlated qual (and its parameter) below that Motion --
+				 *    which crashes the executor.  Forcing the subquery's
+				 *    distributed rels (e.g. gp_tmp) to Entry makes the join
+				 *    Entry-vs-Entry on the coordinator, with no Motion beneath
+				 *    the parameterized qual.  (force_entry, this subquery's
+				 *    config.)
+				 *
+				 * 2. The parent query must produce the correlation parameter on
+				 *    the coordinator, so the SubPlan is referenced above the outer
+				 *    gather Motion and runs there -- otherwise it runs in the
+				 *    segment slice that produced the parameter.  We force ONLY the
+				 *    parent rel(s) that actually supply the parameter, not every
+				 *    base rel of that layer (force_entry_rels, parent's config).
+				 *
+				 * See force_entry / force_entry_rels handling in
+				 * set_rel_pathlist() and bring_to_entry().
+				 */
+				if (Gp_role == GP_ROLE_DISPATCH &&
+					root->parent_root != NULL &&
+					restrictinfo->contain_outer_query_references &&
+					rel->rtekind == RTE_RELATION &&
+					(rel->cdbpolicy == NULL ||
+					 GpPolicyIsEntry(rel->cdbpolicy)) &&
+					subquery_contains_distributed_rel(root))
+				{
+					root->config->force_entry = true;
+					force_entry_param_source_rels(root,
+												  (Node *) restrictinfo->clause);
+				}
+
+				/*
+				 * If this rel will be gathered to Entry because it supplies a
+				 * correlated SubPlan's parameter (force_entry_rels was set, while
+				 * planning that SubPlan's subquery, above), and this qual carries
+				 * the SubPlan, then the parameter columns must survive the gather
+				 * Motion.  Add them to the targetlist now -- mirroring the
+				 * upperrestrictinfo branch above -- otherwise the qual, once
+				 * lifted above the Motion by bring_to_entry(), references a Var
+				 * that is absent from the Motion's output ("variable not found in
+				 * subplan target list"), e.g. for count(*) where no column of the
+				 * rel is otherwise selected.
+				 */
+				if (root->config->force_entry_rels != NULL &&
+					bms_is_member(rel->relid, root->config->force_entry_rels) &&
+					contain_subplans((Node *) restrictinfo->clause))
+				{
+					List	   *vars = pull_var_clause((Node *) restrictinfo->clause,
+													   PVC_RECURSE_AGGREGATES |
+													   PVC_RECURSE_PLACEHOLDERS);
+
+					add_vars_to_targetlist_x(root, vars, relids,
+											 false, /* create_new_ph */
+											 true /* force */);
+					list_free(vars);
+				}
+
 				rel->baserestrictinfo = lappend(rel->baserestrictinfo,
 												restrictinfo);
+			}
 			/* Update security level info */
 			rel->baserestrict_min_security = Min(rel->baserestrict_min_security,
 												 restrictinfo->security_level);

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -334,6 +334,10 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->force_singleQE = false;
 
+	c1->force_entry = false;
+
+	c1->force_entry_rels = NULL;
+
 	c1->may_rescan = false;
 
 	return c1;

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -377,6 +377,23 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 	if (Gp_role == GP_ROLE_DISPATCH)
 		config->is_under_subplan = true;
 
+	/*
+	 * Note: force_entry (the whole-query flag) is intentionally NOT cleared
+	 * here.  When this query level must run on the coordinator (Entry locus)
+	 * because it references a correlated SubPlan over a coordinator-only Entry
+	 * catalog, that constraint has to propagate into the SubPlan's own subquery
+	 * as well: its distributed rels must be gathered to Entry so the whole join
+	 * happens on the coordinator and the correlation parameter never crosses a
+	 * Motion.  The flag is also set directly on the subquery's config in
+	 * distribute_restrictinfo_to_rels() when the Entry-correlated pattern is
+	 * detected within it.
+	 *
+	 * force_entry_rels, on the other hand, MUST be cleared: it holds RT indexes
+	 * of the parent query level, which are meaningless (and would force the
+	 * wrong rels) in the subquery's own RT-index space.
+	 */
+	config->force_entry_rels = NULL;
+
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		/*

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -26,6 +26,29 @@ typedef struct PlannerConfig
 	bool        force_singleQE; /* True for forcing gather the base rel to singleQE, if it needs a motion */
 
 	bool        may_rescan; /* true means the subquery may be rescanned. */
+
+	/*
+	 * NB: keep force_entry and force_entry_rels LAST in this struct, and only
+	 * ever append new fields after them.  Appending preserves the byte offsets
+	 * of every pre-existing field, which the ABI compliance check requires.
+	 * Do not move them into the middle of the struct.
+	 *
+	 * These handle a correlated SubPlan that scans a coordinator-only (Entry)
+	 * catalog joined with a distributed table: it must run on the coordinator,
+	 * since the catalog rows only exist there and the correlation parameter
+	 * cannot cross a Motion.
+	 *
+	 * force_entry: force ALL of this query's base rels to Entry (coordinator)
+	 * locus.  Set on the SubPlan's own subquery so its whole join executes on
+	 * the coordinator (no Broadcast of the Entry table to the segments).
+	 *
+	 * force_entry_rels: force ONLY these specific base rels (by RT index) to
+	 * Entry.  Set on the outer (parent) query for just the rel(s) that supply
+	 * the correlation parameter, so the SubPlan runs on the coordinator without
+	 * dragging unrelated base rels of that query level to the coordinator too.
+	 */
+	bool        force_entry;
+	struct Bitmapset *force_entry_rels;
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -4592,3 +4592,147 @@ select count(*) from foo where a > (select regr_count(x, y) from bar where foo.a
 
 drop table foo;
 drop table bar;
+--
+-- EntryDB path: a correlated subquery that joins a coordinator-only (Entry)
+-- catalog table (gp_segment_configuration) with a distributed table.  Such a
+-- SubPlan must execute on the coordinator: it scans an Entry catalog (whose
+-- rows only exist there) and needs the outer correlation parameter, which GPDB
+-- cannot pass across a Motion.  A correlated SubPlan runs in the slice that
+-- produces its parameter, so when the outer query scans the parameter-producing
+-- table on the segments, the SubPlan runs there too -- scanning the catalog on
+-- the segments (wrong/empty data) or crashing when the parameter crosses a
+-- Motion.  The planner now forces the outer query's base rels to Entry
+-- (coordinator) locus (force_entry, see distribute_restrictinfo_to_rels() and
+-- bring_to_entry()), so the parameter is produced on the coordinator and the
+-- SubPlan is evaluated above the gather Motion, where the catalog is local.
+-- This is exercised below with the SubPlan in the target list, in WHERE and in
+-- HAVING.
+--
+create table gp_entry_outer(x int) distributed by (x);
+insert into gp_entry_outer values (1), (2), (3);
+create table gp_tmp(a int, b int, c int) distributed by (a);
+insert into gp_tmp select i, i, i from generate_series(1, 10) i;
+create table gp_segment(a int, b text) distributed by (a);
+insert into gp_segment values (1, 'no_such_host');
+-- Correlated on dbid: for each outer x, count catalog rows whose dbid = x and
+-- whose dbid also appears in the distributed gp_tmp (1..10).  dbids 1, 2 and 3
+-- always exist, so each outer row yields exactly 1 -- deterministic regardless
+-- of the cluster's segment count.
+select x, (select count(*)
+           from gp_segment_configuration s
+           join gp_tmp t2 on s.dbid = t2.b
+           where s.dbid = gp_entry_outer.x) as cnt
+from gp_entry_outer order by x;
+ x | cnt 
+---+-----
+ 1 |   1
+ 2 |   1
+ 3 |   1
+(3 rows)
+
+-- The original report shape (correlated on hostname).  Use a hostname that does
+-- not exist so the count is a deterministic 0 on any cluster.
+select (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.hostname = gp_segment.b) from gp_segment;
+ count 
+-------
+     0
+(1 row)
+
+-- Same correlated SubPlan in a WHERE clause: the SubPlan-bearing qual is lifted
+-- above the Entry gather.  All three outer rows qualify (count 1 > 0).
+select x from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0
+order by x;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+-- Same WHERE-clause SubPlan under a bare count(*), where no column of the outer
+-- rel is otherwise selected.  The correlation Var must still be carried through
+-- the gather Motion (regression: "variable not found in subplan target list").
+-- All three outer rows qualify, so the count is 3.
+--
+-- Also lock the plan shape so a future change that silently moves the SubPlan
+-- back below the Motion is caught even if it no longer errors.  The fix is in
+-- the Postgres planner, so scope the EXPLAIN to it with SET LOCAL inside a
+-- transaction (self-restoring); that way both the planner and the ORCA expected
+-- files show the same plan.  costs are omitted -- they are not stable across
+-- cluster sizes.
+begin;
+set local optimizer = off;
+explain (costs off)
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Aggregate
+   ->  Result
+         Filter: ((SubPlan 1) > 0)
+         ->  Materialize
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on gp_entry_outer o
+         SubPlan 1
+           ->  Aggregate
+                 ->  Nested Loop
+                       ->  Seq Scan on gp_segment_configuration s
+                             Filter: (dbid = o.x)
+                       ->  Materialize
+                             ->  Result
+                                   Filter: (t2.b = o.x)
+                                   ->  Materialize
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                               ->  Seq Scan on gp_tmp t2
+ Optimizer: Postgres-based planner
+(18 rows)
+
+rollback;
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+ count 
+-------
+     3
+(1 row)
+
+-- ... and in a HAVING clause, correlated on the grouping key.
+select o.x from gp_entry_outer o
+group by o.x
+having (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.dbid = o.x) > 0
+order by o.x;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+-- A correlated scan of the Entry catalog with no join (no Motion in the
+-- subplan) must keep working unchanged.
+select (select count(*)
+        from gp_segment_configuration s
+        where s.hostname = gp_segment.b) from gp_segment;
+ count 
+-------
+     0
+(1 row)
+
+drop table gp_entry_outer;
+drop table gp_segment;
+drop table gp_tmp;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -4711,3 +4711,147 @@ select count(*) from foo where a > (select regr_count(x, y) from bar where foo.a
 
 drop table foo;
 drop table bar;
+--
+-- EntryDB path: a correlated subquery that joins a coordinator-only (Entry)
+-- catalog table (gp_segment_configuration) with a distributed table.  Such a
+-- SubPlan must execute on the coordinator: it scans an Entry catalog (whose
+-- rows only exist there) and needs the outer correlation parameter, which GPDB
+-- cannot pass across a Motion.  A correlated SubPlan runs in the slice that
+-- produces its parameter, so when the outer query scans the parameter-producing
+-- table on the segments, the SubPlan runs there too -- scanning the catalog on
+-- the segments (wrong/empty data) or crashing when the parameter crosses a
+-- Motion.  The planner now forces the outer query's base rels to Entry
+-- (coordinator) locus (force_entry, see distribute_restrictinfo_to_rels() and
+-- bring_to_entry()), so the parameter is produced on the coordinator and the
+-- SubPlan is evaluated above the gather Motion, where the catalog is local.
+-- This is exercised below with the SubPlan in the target list, in WHERE and in
+-- HAVING.
+--
+create table gp_entry_outer(x int) distributed by (x);
+insert into gp_entry_outer values (1), (2), (3);
+create table gp_tmp(a int, b int, c int) distributed by (a);
+insert into gp_tmp select i, i, i from generate_series(1, 10) i;
+create table gp_segment(a int, b text) distributed by (a);
+insert into gp_segment values (1, 'no_such_host');
+-- Correlated on dbid: for each outer x, count catalog rows whose dbid = x and
+-- whose dbid also appears in the distributed gp_tmp (1..10).  dbids 1, 2 and 3
+-- always exist, so each outer row yields exactly 1 -- deterministic regardless
+-- of the cluster's segment count.
+select x, (select count(*)
+           from gp_segment_configuration s
+           join gp_tmp t2 on s.dbid = t2.b
+           where s.dbid = gp_entry_outer.x) as cnt
+from gp_entry_outer order by x;
+ x | cnt 
+---+-----
+ 1 |   1
+ 2 |   1
+ 3 |   1
+(3 rows)
+
+-- The original report shape (correlated on hostname).  Use a hostname that does
+-- not exist so the count is a deterministic 0 on any cluster.
+select (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.hostname = gp_segment.b) from gp_segment;
+ count 
+-------
+     0
+(1 row)
+
+-- Same correlated SubPlan in a WHERE clause: the SubPlan-bearing qual is lifted
+-- above the Entry gather.  All three outer rows qualify (count 1 > 0).
+select x from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0
+order by x;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+-- Same WHERE-clause SubPlan under a bare count(*), where no column of the outer
+-- rel is otherwise selected.  The correlation Var must still be carried through
+-- the gather Motion (regression: "variable not found in subplan target list").
+-- All three outer rows qualify, so the count is 3.
+--
+-- Also lock the plan shape so a future change that silently moves the SubPlan
+-- back below the Motion is caught even if it no longer errors.  The fix is in
+-- the Postgres planner, so scope the EXPLAIN to it with SET LOCAL inside a
+-- transaction (self-restoring); that way both the planner and the ORCA expected
+-- files show the same plan.  costs are omitted -- they are not stable across
+-- cluster sizes.
+begin;
+set local optimizer = off;
+explain (costs off)
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Aggregate
+   ->  Result
+         Filter: ((SubPlan 1) > 0)
+         ->  Materialize
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on gp_entry_outer o
+         SubPlan 1
+           ->  Aggregate
+                 ->  Nested Loop
+                       ->  Seq Scan on gp_segment_configuration s
+                             Filter: (dbid = o.x)
+                       ->  Materialize
+                             ->  Result
+                                   Filter: (t2.b = o.x)
+                                   ->  Materialize
+                                         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                               ->  Seq Scan on gp_tmp t2
+ Optimizer: Postgres-based planner
+(18 rows)
+
+rollback;
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+ count 
+-------
+     3
+(1 row)
+
+-- ... and in a HAVING clause, correlated on the grouping key.
+select o.x from gp_entry_outer o
+group by o.x
+having (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.dbid = o.x) > 0
+order by o.x;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+-- A correlated scan of the Entry catalog with no join (no Motion in the
+-- subplan) must keep working unchanged.
+select (select count(*)
+        from gp_segment_configuration s
+        where s.hostname = gp_segment.b) from gp_segment;
+ count 
+-------
+     0
+(1 row)
+
+drop table gp_entry_outer;
+drop table gp_segment;
+drop table gp_tmp;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1684,3 +1684,90 @@ select count(*) from foo where a > (select regr_count(x, y) from bar where foo.a
 
 drop table foo;
 drop table bar;
+
+--
+-- EntryDB path: a correlated subquery that joins a coordinator-only (Entry)
+-- catalog table (gp_segment_configuration) with a distributed table.  Such a
+-- SubPlan must execute on the coordinator: it scans an Entry catalog (whose
+-- rows only exist there) and needs the outer correlation parameter, which GPDB
+-- cannot pass across a Motion.  A correlated SubPlan runs in the slice that
+-- produces its parameter, so when the outer query scans the parameter-producing
+-- table on the segments, the SubPlan runs there too -- scanning the catalog on
+-- the segments (wrong/empty data) or crashing when the parameter crosses a
+-- Motion.  The planner now forces the outer query's base rels to Entry
+-- (coordinator) locus (force_entry, see distribute_restrictinfo_to_rels() and
+-- bring_to_entry()), so the parameter is produced on the coordinator and the
+-- SubPlan is evaluated above the gather Motion, where the catalog is local.
+-- This is exercised below with the SubPlan in the target list, in WHERE and in
+-- HAVING.
+--
+create table gp_entry_outer(x int) distributed by (x);
+insert into gp_entry_outer values (1), (2), (3);
+create table gp_tmp(a int, b int, c int) distributed by (a);
+insert into gp_tmp select i, i, i from generate_series(1, 10) i;
+create table gp_segment(a int, b text) distributed by (a);
+insert into gp_segment values (1, 'no_such_host');
+-- Correlated on dbid: for each outer x, count catalog rows whose dbid = x and
+-- whose dbid also appears in the distributed gp_tmp (1..10).  dbids 1, 2 and 3
+-- always exist, so each outer row yields exactly 1 -- deterministic regardless
+-- of the cluster's segment count.
+select x, (select count(*)
+           from gp_segment_configuration s
+           join gp_tmp t2 on s.dbid = t2.b
+           where s.dbid = gp_entry_outer.x) as cnt
+from gp_entry_outer order by x;
+-- The original report shape (correlated on hostname).  Use a hostname that does
+-- not exist so the count is a deterministic 0 on any cluster.
+select (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.hostname = gp_segment.b) from gp_segment;
+-- Same correlated SubPlan in a WHERE clause: the SubPlan-bearing qual is lifted
+-- above the Entry gather.  All three outer rows qualify (count 1 > 0).
+select x from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0
+order by x;
+-- Same WHERE-clause SubPlan under a bare count(*), where no column of the outer
+-- rel is otherwise selected.  The correlation Var must still be carried through
+-- the gather Motion (regression: "variable not found in subplan target list").
+-- All three outer rows qualify, so the count is 3.
+--
+-- Also lock the plan shape so a future change that silently moves the SubPlan
+-- back below the Motion is caught even if it no longer errors.  The fix is in
+-- the Postgres planner, so scope the EXPLAIN to it with SET LOCAL inside a
+-- transaction (self-restoring); that way both the planner and the ORCA expected
+-- files show the same plan.  costs are omitted -- they are not stable across
+-- cluster sizes.
+begin;
+set local optimizer = off;
+explain (costs off)
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+rollback;
+select count(*) from gp_entry_outer o
+where (select count(*)
+       from gp_segment_configuration s
+       join gp_tmp t2 on s.dbid = t2.b
+       where s.dbid = o.x) > 0;
+-- ... and in a HAVING clause, correlated on the grouping key.
+select o.x from gp_entry_outer o
+group by o.x
+having (select count(*)
+        from gp_segment_configuration s
+        join gp_tmp t2 on s.dbid = t2.b
+        where s.dbid = o.x) > 0
+order by o.x;
+-- A correlated scan of the Entry catalog with no join (no Motion in the
+-- subplan) must keep working unchanged.
+select (select count(*)
+        from gp_segment_configuration s
+        where s.hostname = gp_segment.b) from gp_segment;
+drop table gp_entry_outer;
+drop table gp_segment;
+drop table gp_tmp;


### PR DESCRIPTION
## Summary
Fixes a backend crash that occurs when executing correlated subqueries that join a coordinator-only catalog table (such as `gp_segment_configuration`) with a distributed table.

## Step to reproduce
```sql
create table gp_segment(a int, b text);
create table gp_tmp(a int, b int, c int);
insert into gp_tmp select i, i, i from generate_series(1, 10) i;
insert into gp_segment select 1, hostname from gp_segment_configuration limit 1;

-- This query used to crash the backend:
select (select count(*) from gp_segment_configuration s join gp_tmp t2 on s.dbid = t2.b where s.hostname = gp_segment.b) from gp_segment;
```
## Solution
This PR introduces a mechanism to keep Entry-correlated subqueries local to the coordinator where the parameter is available:

1. **Subquery Detection:** Added `subquery_contains_distributed_rel()` to detect if a subquery scans any partitioned or replicated relations that require a `Motion`.
2. **Forcing Single QE:** In `initsplan.c`, if a correlated restriction targets an Entry table and the subquery contains a distributed relation, we set `root->config->force_singleQE = true`.
3. **Lifting above Motion:** In `grouping_planner()`, we use `tlist_has_entry_correlated_subplan()` to check if the final target list references such a subplan. If found, we explicitly inject a `Gather Motion` to pull the scan/join results to the coordinator (`entryLocus`) **before** the target list is evaluated. This ensures the SubPlan runs above the final Motion where the correlation parameter is natively accessible.