### PR TITLE
fix(aoco): probe the placeholder column during unique checks

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -3190,6 +3190,58 @@ get_anchor_col(AOCSFileSegInfo **segInfos, int nseg, int natts,
 	return scancol_proj != -1 ? scancol_proj : (scancol_all == -1 ? 0 : scancol_all);
 }
 
+/*
+ * Choose the column whose block directory entries are consulted during unique
+ * constraint checks, and for which insert commands persist their placeholder
+ * block directory row (see AppendOnlyBlockDirectory_InsertPlaceholder()).
+ *
+ * Writers and readers must agree on this column: a reader looking up a
+ * different column than the one covered by a concurrent (or same-command)
+ * writer's placeholder row would miss in-progress conflicts. The choice
+ * therefore has to be deterministic and independent of mutable state such as
+ * segfile eofs (which is what rules out get_anchor_col() here).
+ *
+ * The column also has to be "complete" (see get_anchor_col()): an
+ * incomplete column's block directory does not cover rows that predate its
+ * missing-mode ADD COLUMN, so consulting it would miss conflicts with those
+ * rows. We prefer the first non-dropped complete column, but fall back to a
+ * dropped one - block directory entries are written even for dropped columns.
+ */
+int
+aocs_unique_check_col(Relation aocsrel)
+{
+	int			natts = RelationGetNumberOfAttributes(aocsrel);
+	bool	   *column_not_complete;
+	int			checkcol = -1;
+
+	column_not_complete = ExistValidLastrownums(RelationGetRelid(aocsrel), natts);
+
+	for (int i = 0; i < natts; i++)
+	{
+		if (column_not_complete[i])
+			continue;
+
+		if (!TupleDescAttr(RelationGetDescr(aocsrel), i)->attisdropped)
+		{
+			checkcol = i;
+			break;
+		}
+
+		if (checkcol == -1)
+			checkcol = i;
+	}
+
+	pfree(column_not_complete);
+
+	if (checkcol == -1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not find a complete column for unique check block directory lookups for relation \"%s\"",
+						RelationGetRelationName(aocsrel))));
+
+	return checkcol;
+}
+
 /* 
  * A helper for aocs_writecol_writesegfiles(). It evaluates expression stored in 
  * the 'exprstate' field of the 'newvals', and store the values in 'slot'. In

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -355,28 +355,21 @@ get_or_create_aoco_insert_descriptor(const Relation relation, int64 num_rows)
 		 * AppendOnlyBlockDirectory_InsertPlaceholder() for details.
 		 *
 		 * Note: For AOCO tables, we need to only insert a placeholder block
-		 * directory row for the 1st non-dropped column. This is because
-		 * during a uniqueness check, only the first non-dropped column's block
-		 * directory entry is consulted. (See AppendOnlyBlockDirectory_CoversTuple())
+		 * directory row for the column that uniqueness checks consult, as
+		 * determined by aocs_unique_check_col().
+		 * (See AppendOnlyBlockDirectory_CoversTuple())
 		 */
 		if (relationHasUniqueIndex(relation))
 		{
-			int 				firstNonDroppedColumn = -1;
+			int 				uniqueCheckCol;
 			int64 				firstRowNum;
 			DatumStreamWrite 	*dsw;
 			BufferedAppend 		*bufferedAppend;
 			int64 				fileOffset;
 
-			for(int i = 0; i < relation->rd_att->natts; i++)
-			{
-				if (!relation->rd_att->attrs[i].attisdropped) {
-					firstNonDroppedColumn = i;
-					break;
-				}
-			}
-			Assert(firstNonDroppedColumn != -1);
+			uniqueCheckCol = aocs_unique_check_col(relation);
 
-			dsw = insertDesc->ds[firstNonDroppedColumn];
+			dsw = insertDesc->ds[uniqueCheckCol];
 			firstRowNum = dsw->blockFirstRowNum;
 			bufferedAppend = &dsw->ao_write.bufferedAppend;
 			fileOffset = BufferedAppendNextBufferPosition(bufferedAppend);
@@ -384,7 +377,7 @@ get_or_create_aoco_insert_descriptor(const Relation relation, int64 num_rows)
 			AppendOnlyBlockDirectory_InsertPlaceholder(&insertDesc->blockDirectory,
 													   firstRowNum,
 													   fileOffset,
-													   firstNonDroppedColumn);
+													   uniqueCheckCol);
 		}
 		state->insertDesc = insertDesc;
 		MemoryContextSwitchTo(oldcxt);

--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -238,6 +238,65 @@ test__get_anchor_col(void **state)
 	assert_int_equal(col, 2);
 }
 
+/*
+ * Ensure that the column consulted by unique constraint checks is picked
+ * deterministically: the first non-dropped complete column, falling back to
+ * a dropped complete column, while never picking an incomplete column.
+ */
+static void
+test__aocs_unique_check_col(void **state)
+{
+	RelationData reldata;
+	FormData_pg_class pgclass;
+	int numcols = 3;
+	bool *lastrownums_exist;
+
+	reldata.rd_rel = &pgclass;
+	reldata.rd_id = 12345;
+	reldata.rd_rel->relnatts = numcols;
+	reldata.rd_att = (TupleDesc) palloc0(sizeof(TupleDescData) +
+										 sizeof(FormData_pg_attribute) * numcols);
+	reldata.rd_att->natts = numcols;
+
+	/* all columns complete and non-dropped: the first column is picked */
+	lastrownums_exist = (bool *) palloc0(numcols * sizeof(bool));
+	expect_any(ExistValidLastrownums, relid);
+	expect_any(ExistValidLastrownums, natts);
+	will_return(ExistValidLastrownums, lastrownums_exist);
+	assert_int_equal(aocs_unique_check_col(&reldata), 0);
+
+	/* first column dropped: the first non-dropped complete column is picked */
+	TupleDescAttr(reldata.rd_att, 0)->attisdropped = true;
+	lastrownums_exist = (bool *) palloc0(numcols * sizeof(bool));
+	expect_any(ExistValidLastrownums, relid);
+	expect_any(ExistValidLastrownums, natts);
+	will_return(ExistValidLastrownums, lastrownums_exist);
+	assert_int_equal(aocs_unique_check_col(&reldata), 1);
+
+	/* incomplete columns are skipped over */
+	TupleDescAttr(reldata.rd_att, 0)->attisdropped = false;
+	lastrownums_exist = (bool *) palloc0(numcols * sizeof(bool));
+	lastrownums_exist[0] = true;
+	lastrownums_exist[1] = true;
+	expect_any(ExistValidLastrownums, relid);
+	expect_any(ExistValidLastrownums, natts);
+	will_return(ExistValidLastrownums, lastrownums_exist);
+	assert_int_equal(aocs_unique_check_col(&reldata), 2);
+
+	/*
+	 * If the only complete column is a dropped one, fall back to it (block
+	 * directory entries are written even for dropped columns).
+	 */
+	TupleDescAttr(reldata.rd_att, 0)->attisdropped = true;
+	lastrownums_exist = (bool *) palloc0(numcols * sizeof(bool));
+	lastrownums_exist[1] = true;
+	lastrownums_exist[2] = true;
+	expect_any(ExistValidLastrownums, relid);
+	expect_any(ExistValidLastrownums, natts);
+	will_return(ExistValidLastrownums, lastrownums_exist);
+	assert_int_equal(aocs_unique_check_col(&reldata), 0);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -246,7 +305,8 @@ main(int argc, char *argv[])
 	const		UnitTest tests[] = {
 		unit_test(test__aocs_begin_headerscan),
 		unit_test(test__aocs_writecol_init),
-		unit_test(test__get_anchor_col)
+		unit_test(test__get_anchor_col),
+		unit_test(test__aocs_unique_check_col)
 	};
 
 	MemoryContextInit();

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -337,7 +337,26 @@ AppendOnlyBlockDirectory_Init_forUniqueChecks(
 
 	blockDirectory->blkdirIdx = index_open(blkdiridxid, AccessShareLock);
 
-	init_internal_proj(blockDirectory, NULL, blockDirectory->isAOCol);
+	/*
+	 * For CO tables, uniqueness checks only ever consult the block directory
+	 * entries of the designated unique-check column: the same column for
+	 * which insert commands persist their placeholder rows (see
+	 * AppendOnlyBlockDirectory_InsertPlaceholder()). We must not pick the
+	 * anchor column here: its choice depends on segfile eofs, which change
+	 * as data is inserted, so a reader could end up consulting a different
+	 * column than the one covered by a concurrent (or same-command) writer's
+	 * placeholder row and miss in-progress conflicts.
+	 */
+	if (blockDirectory->isAOCol)
+	{
+		bool	   *proj = palloc0(numColumnGroups * sizeof(bool));
+
+		proj[aocs_unique_check_col(aoRel)] = true;
+		init_internal_proj(blockDirectory, proj, false);
+		pfree(proj);
+	}
+	else
+		init_internal_proj(blockDirectory, NULL, false);
 
 	init_internal(blockDirectory);
 }
@@ -1054,15 +1073,21 @@ AppendOnlyBlockDirectory_GetEntryForPartialScan(AppendOnlyBlockDirectory *blockD
  * Note about AOCO tables:
  * For AOCO tables, there are multiple block directory entries for each tid.
  * However, it is currently sufficient to check the block directory entry for
- * just one of these columns. We do so for the "anchor column" which is
- * picked using the same logic as regular table scan. Note that if we write a 
- * placeholder row for the anchor column being picked, there is a
- * guarantee that if there is a conflict on the placeholder row, the covering
- * block directory entry will be based on the same column i (as columnar DDL
- * changes need exclusive locks and placeholder rows can't be seen after tx end)
- * (We could just have checked the covers condition for column 0, as block
- * directory entries are inserted even for dropped columns. But, this may change
- * one day, and we want our code to be future-proof)
+ * just one of these columns, which is whatever column ended up first in
+ * proj_atts during init:
+ *
+ * - For uniqueness checks, that is the unique-check column (see
+ *   aocs_unique_check_col()). It is vital that it matches the column for
+ *   which insert commands persist their placeholder rows, or we would miss
+ *   conflicts with in-progress inserts. This is guaranteed because the
+ *   choice is deterministic and independent of mutable state, and because
+ *   columnar DDL changes (which could change the choice) need exclusive
+ *   locks while placeholder rows can't be seen after tx end.
+ *
+ * - For index only scans, that is the "anchor column" which is picked using
+ *   the same logic as regular table scans. Only committed rows (with real,
+ *   all-column block directory entries) matter there, so any complete
+ *   column works.
  */
 bool
 AppendOnlyBlockDirectory_CoversTuple(

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -413,8 +413,12 @@ typedef struct AOCSWriteColumnDescData
 typedef AOCSWriteColumnDescData *AOCSWriteColumnDesc;
 
 /* function to help find the anchor column to scan */
-extern int 
+extern int
 get_anchor_col(AOCSFileSegInfo **segInfos, int nseg, int natts, Relation aocsrel, AttrNumber *proj_atts, AttrNumber num_proj_atts);
+
+/* function to find the column consulted by unique constraint checks */
+extern int
+aocs_unique_check_col(Relation aocsrel);
 
 /* ----------------
  *		function prototypes for appendoptimized columnar access method

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -520,3 +520,131 @@ ROLLBACK
 
 DROP TABLE unique_index_ao_column;
 DROP TABLE
+
+--------------------------------------------------------------------------------
+--------------- Tests for the unique-check column choice ------------------------
+--------------------------------------------------------------------------------
+
+-- The column whose block directory entries are consulted during uniqueness
+-- checks must be the same column for which insert commands persist their
+-- placeholder row, and its choice must not depend on mutable state such as
+-- segfile eofs (see aocs_unique_check_col()).
+--
+-- These tests use multi-column tables with a highly-compressible constant
+-- column: after a bulk load, that column has the smallest eof, which used to
+-- make readers consult it (as the min-eof "anchor" column) while writers
+-- placed their placeholder row on the first non-dropped column, letting
+-- same-command and concurrent duplicates slip through undetected.
+
+-- Case A: same-command and cross-command duplicates after a bulk load.
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint, c bigint) USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+CREATE TABLE
+INSERT INTO unique_index_ao_column SELECT i, i, 1 FROM generate_series(1, 10000) i;
+INSERT 0 10000
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 0, 1 FROM (VALUES (-1), (-1)) v(x);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg2 127.0.0.1:7004 pid=2145844)
+DETAIL:  Key (a)=(-1) already exists.
+-- should conflict (cross command, with a committed row)
+INSERT INTO unique_index_ao_column VALUES (-2, 0, 1);
+INSERT 0 1
+INSERT INTO unique_index_ao_column VALUES (-2, 0, 1);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg1 127.0.0.1:7003 pid=2145843)
+DETAIL:  Key (a)=(-2) already exists.
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 0, 1);
+INSERT 0 1
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+ a  | count 
+----+-------
+ -3 | 1     
+ -2 | 1     
+(2 rows)
+DROP TABLE unique_index_ao_column;
+DROP TABLE
+
+-- Case B: conflict with a concurrent to-be-committed transaction after a bulk
+-- load (only the placeholder row can reveal the in-progress conflict).
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint, c bigint) USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+CREATE TABLE
+INSERT INTO unique_index_ao_column SELECT i, i, 1 FROM generate_series(1, 10000) i;
+INSERT 0 10000
+1: BEGIN;
+BEGIN
+1: INSERT INTO unique_index_ao_column VALUES (-1, 0, 1);
+INSERT 0 1
+-- should block on tx 1's in-progress insert
+2&: INSERT INTO unique_index_ao_column VALUES (-1, 0, 1);  <waiting ...>
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg2 127.0.0.1:7004 pid=2145939)
+DETAIL:  Key (a)=(-1) already exists.
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+ a  | count 
+----+-------
+ -1 | 1     
+(1 row)
+DROP TABLE unique_index_ao_column;
+DROP TABLE
+
+-- Case C: with the first column dropped, the unique-check column moves to the
+-- first non-dropped complete column, on both the write and the read side.
+CREATE TABLE unique_index_ao_column (dropme int, a bigint unique, c bigint) USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+CREATE TABLE
+INSERT INTO unique_index_ao_column SELECT 0, i, 1 FROM generate_series(1, 10000) i;
+INSERT 0 10000
+ALTER TABLE unique_index_ao_column DROP COLUMN dropme;
+ALTER TABLE
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 1 FROM (VALUES (-1), (-1)) v(x);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg0 127.0.0.1:7002 pid=2145842)
+DETAIL:  Key (a)=(-1) already exists.
+-- should conflict (cross command, with a committed row)
+INSERT INTO unique_index_ao_column VALUES (1, 1);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg2 127.0.0.1:7004 pid=2145844)
+DETAIL:  Key (a)=(1) already exists.
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 1);
+INSERT 0 1
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+ a  | count 
+----+-------
+ -3 | 1     
+(1 row)
+DROP TABLE unique_index_ao_column;
+DROP TABLE
+
+-- Case D: a column added in missing mode is "incomplete": its block directory
+-- does not cover rows predating the ADD COLUMN, so it must never be picked as
+-- the unique-check column even though it has the smallest eof.
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint) USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+CREATE TABLE
+INSERT INTO unique_index_ao_column SELECT i, i FROM generate_series(1, 10000) i;
+INSERT 0 10000
+ALTER TABLE unique_index_ao_column ADD COLUMN c int DEFAULT 1;
+ALTER TABLE
+-- the added column is incomplete (lastrownums is set)
+SELECT attnum FROM pg_attribute_encoding WHERE attrelid = 'unique_index_ao_column'::regclass AND lastrownums IS NOT NULL;
+ attnum 
+--------
+ 3      
+(1 row)
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 0, 1 FROM (VALUES (-1), (-1)) v(x);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg0 127.0.0.1:7002 pid=2145842)
+DETAIL:  Key (a)=(-1) already exists.
+-- should conflict with a row predating the ADD COLUMN
+INSERT INTO unique_index_ao_column VALUES (1, 0, 1);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg0 127.0.0.1:7002 pid=2145842)
+DETAIL:  Key (a)=(1) already exists.
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 0, 1);
+INSERT 0 1
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+ a  | count 
+----+-------
+ -3 | 1     
+(1 row)
+DROP TABLE unique_index_ao_column;
+DROP TABLE

--- a/src/test/isolation2/sql/aocs_unique_index.sql
+++ b/src/test/isolation2/sql/aocs_unique_index.sql
@@ -342,3 +342,80 @@ INSERT INTO unique_index_ao_column VALUES(2);
 2: ABORT;
 
 DROP TABLE unique_index_ao_column;
+
+--------------------------------------------------------------------------------
+--------------- Tests for the unique-check column choice ------------------------
+--------------------------------------------------------------------------------
+
+-- The column whose block directory entries are consulted during uniqueness
+-- checks must be the same column for which insert commands persist their
+-- placeholder row, and its choice must not depend on mutable state such as
+-- segfile eofs (see aocs_unique_check_col()).
+--
+-- These tests use multi-column tables with a highly-compressible constant
+-- column: after a bulk load, that column has the smallest eof, which used to
+-- make readers consult it (as the min-eof "anchor" column) while writers
+-- placed their placeholder row on the first non-dropped column, letting
+-- same-command and concurrent duplicates slip through undetected.
+
+-- Case A: same-command and cross-command duplicates after a bulk load.
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint, c bigint)
+    USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_ao_column SELECT i, i, 1 FROM generate_series(1, 10000) i;
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 0, 1 FROM (VALUES (-1), (-1)) v(x);
+-- should conflict (cross command, with a committed row)
+INSERT INTO unique_index_ao_column VALUES (-2, 0, 1);
+INSERT INTO unique_index_ao_column VALUES (-2, 0, 1);
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 0, 1);
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+DROP TABLE unique_index_ao_column;
+
+-- Case B: conflict with a concurrent to-be-committed transaction after a bulk
+-- load (only the placeholder row can reveal the in-progress conflict).
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint, c bigint)
+    USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_ao_column SELECT i, i, 1 FROM generate_series(1, 10000) i;
+1: BEGIN;
+1: INSERT INTO unique_index_ao_column VALUES (-1, 0, 1);
+-- should block on tx 1's in-progress insert
+2&: INSERT INTO unique_index_ao_column VALUES (-1, 0, 1);
+1: COMMIT;
+2<:
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+DROP TABLE unique_index_ao_column;
+
+-- Case C: with the first column dropped, the unique-check column moves to the
+-- first non-dropped complete column, on both the write and the read side.
+CREATE TABLE unique_index_ao_column (dropme int, a bigint unique, c bigint)
+    USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_ao_column SELECT 0, i, 1 FROM generate_series(1, 10000) i;
+ALTER TABLE unique_index_ao_column DROP COLUMN dropme;
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 1 FROM (VALUES (-1), (-1)) v(x);
+-- should conflict (cross command, with a committed row)
+INSERT INTO unique_index_ao_column VALUES (1, 1);
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 1);
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+DROP TABLE unique_index_ao_column;
+
+-- Case D: a column added in missing mode is "incomplete": its block directory
+-- does not cover rows predating the ADD COLUMN, so it must never be picked as
+-- the unique-check column even though it has the smallest eof.
+CREATE TABLE unique_index_ao_column (a bigint unique, b bigint)
+    USING ao_column WITH (compresstype=zstd) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_ao_column SELECT i, i FROM generate_series(1, 10000) i;
+ALTER TABLE unique_index_ao_column ADD COLUMN c int DEFAULT 1;
+-- the added column is incomplete (lastrownums is set)
+SELECT attnum FROM pg_attribute_encoding
+    WHERE attrelid = 'unique_index_ao_column'::regclass AND lastrownums IS NOT NULL;
+-- should conflict (same command)
+INSERT INTO unique_index_ao_column SELECT v.x, 0, 1 FROM (VALUES (-1), (-1)) v(x);
+-- should conflict with a row predating the ADD COLUMN
+INSERT INTO unique_index_ao_column VALUES (1, 0, 1);
+-- should not conflict
+INSERT INTO unique_index_ao_column VALUES (-3, 0, 1);
+SELECT a, count(*) FROM unique_index_ao_column WHERE a < 0 GROUP BY a ORDER BY a;
+DROP TABLE unique_index_ao_column;


### PR DESCRIPTION
Unique indexes on AOCO tables could miss conflicts and let duplicate keys through, observed in the field as duplicated primary keys after gpfdist loads.

AO unique checks work by probing the block directory for an entry covering the conflicting tid. Within an insert command the real block directory rows are not persisted yet, so the check relies on the placeholder row written at the start of the insert. The writer puts that placeholder on the first non-dropped column, but since 3986f926164 the reader consults the "anchor" column, i.e. the complete column with the smallest eof. Once a bulk load skews the segfile eofs so that the smallest column is no longer the first one (think of a well-compressed constant column), the reader probes a column the placeholder was never written to, finds nothing, and concludes there is no conflict. Both same-command and concurrent-transaction duplicates slip through. AOROW is unaffected: it has a single column group, so writer and reader cannot diverge.

Fix by introducing aocs_unique_check_col(), which picks the first non-dropped complete column (falling back to a dropped complete one), and using it on both sides: the placeholder write and the unique-check lookup. The choice is deterministic and independent of segfile eofs. Completeness matters because a column added in missing mode has no block directory coverage for rows predating the ADD COLUMN. Index-only scans keep using the anchor column, which is fine as they only look at committed rows with real block directory entries on every column.

The existing isolation2 tests only used single-column tables, where the anchor is always column 0 and the divergence cannot happen. Add cases with multi-column tables covering same-command, cross-command and concurrent duplicates, plus dropped-first-column and missing-mode ADD COLUMN variants, and a unit test for the column choice.