### PR TITLE
Fix "out of scanning scope" error on AO/AOCS index fetch concurrent with VACUUM

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -2261,18 +2261,19 @@ aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 
 	Assert(segmentFileNum >= 0);
 
-	if (aocsFetchDesc->lastSequence[segmentFileNum] == InvalidAORowNum)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("Row No. %ld in segment file No. %d is out of scanning scope for target relfilenode %u.",
-				 		rowNum, segmentFileNum, aocsFetchDesc->relation->rd_node.relNode)));
-
 	/*
 	 * skip if the rowNum is not discoverable:
-	 * 1. rowNum is 0 which is invalid.
-	 * 2. rowNum bigger than lastsequence of the segment.
+	 * 1. the segment file was first used after this fetch descriptor was
+	 *    initialized (lastSequence is InvalidAORowNum): e.g. a concurrent
+	 *    VACUUM compaction picked a brand-new segfile as its insertion
+	 *    target and the index already contains entries for the moved
+	 *    tuples.  None of those tuples can be visible to our snapshot,
+	 *    so treat this as "not found" just like the cases below.
+	 * 2. rowNum is 0 which is invalid.
+	 * 3. rowNum bigger than lastsequence of the segment.
 	 */
-	if (rowNum == 0 || rowNum > aocsFetchDesc->lastSequence[segmentFileNum])
+	if (aocsFetchDesc->lastSequence[segmentFileNum] == InvalidAORowNum ||
+		rowNum == 0 || rowNum > aocsFetchDesc->lastSequence[segmentFileNum])
 	{
 		if (slot != NULL)
 			slot = ExecClearTuple(slot);

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2595,12 +2595,6 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 
 	Assert(segmentFileNum >= 0);
 
-	if (aoFetchDesc->lastSequence[segmentFileNum] == InvalidAORowNum)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("Row No. %ld in segment file No. %d is out of scanning scope for target relfilenode %u.",
-				 		rowNum, segmentFileNum, aoFetchDesc->relation->rd_node.relNode)));
-
 	/*
 	 * This is an improvement for brin. BRIN index stores ranges of TIDs in
 	 * terms of block numbers and not specific TIDs, so it's possible that the
@@ -2610,8 +2604,16 @@ appendonly_fetch(AppendOnlyFetchDesc aoFetchDesc,
 	 * miss will occur. And we need to search the btree on block directory
 	 * table. This is a vary slow operation. So a fast return path was added
 	 * here. If the rowNum is bigger than lastsequence, skip it.
+	 *
+	 * Likewise, if the segment file was first used only after this fetch
+	 * descriptor was initialized (lastSequence is InvalidAORowNum): e.g. a
+	 * concurrent VACUUM compaction picked a brand-new segfile as its
+	 * insertion target and the index already contains entries for the moved
+	 * tuples.  None of those tuples can be visible to our snapshot, so
+	 * treat this as "not found" as well.
 	 */
-	if (rowNum > aoFetchDesc->lastSequence[segmentFileNum])
+	if (aoFetchDesc->lastSequence[segmentFileNum] == InvalidAORowNum ||
+		rowNum > aoFetchDesc->lastSequence[segmentFileNum])
 	{
 		if (slot != NULL)
 		{

--- a/src/test/isolation2/input/uao/index_fetch_while_vacuum.source
+++ b/src/test/isolation2/input/uao/index_fetch_while_vacuum.source
@@ -1,0 +1,50 @@
+-- @Description Tests that a concurrent VACUUM compaction does not break an
+-- already-running index fetch on the same table.
+--
+-- The reader opens a cursor over a nestloop join whose inner side fetches
+-- tuples through the btree index; the AO fetch descriptor (and its cached
+-- list of segfiles) is initialized at the first MOVE. The concurrent
+-- DELETE + VACUUM then compacts the table, moving the surviving tuples into
+-- a segfile that did not exist when the fetch descriptor was created, while
+-- the btree immediately contains entries pointing into that new segfile.
+-- Draining the cursor re-executes the inner index scan and must treat those
+-- entries as invisible ("not found") instead of raising the "out of scanning
+-- scope" error: none of the moved tuples can be visible to the reader's
+-- snapshot anyway.
+DROP TABLE IF EXISTS ao_lu;
+DROP TABLE IF EXISTS ao_probe;
+CREATE TABLE ao_lu (cust_no int, birth_y text, filler text) USING @amname@ DISTRIBUTED BY (cust_no);
+INSERT INTO ao_lu SELECT g, (1950 + g % 60)::text, repeat('x', 200) FROM generate_series(1, 300000) g;
+CREATE INDEX ao_lu_cust_no_idx ON ao_lu (cust_no);
+CREATE TABLE ao_probe (cust_no int) DISTRIBUTED BY (cust_no);
+INSERT INTO ao_probe SELECT g FROM generate_series(1, 100000) g;
+ANALYZE ao_lu;
+ANALYZE ao_probe;
+
+1: SET optimizer = off;
+1: SET enable_seqscan = off;
+1: SET enable_hashjoin = off;
+1: SET enable_mergejoin = off;
+1: SET enable_nestloop = on;
+1: BEGIN;
+1: DECLARE cur CURSOR FOR SELECT a.cust_no, b.birth_y FROM ao_probe a JOIN ao_lu b ON a.cust_no = b.cust_no;
+-- pull one row through the cursor so the reader's fetch descriptor and its
+-- segfile list are initialized before the concurrent vacuum runs
+1: MOVE 1 IN cur;
+-- delete ~1/3 of the tuples and vacuum: compaction moves the surviving
+-- tuples into a brand-new segfile and marks the old one AWAITING_DROP (the
+-- reader's open snapshot prevents recycling it within this vacuum)
+2: DELETE FROM ao_lu WHERE cust_no % 3 = 0;
+2: VACUUM ao_lu;
+-- drain the cursor: the inner index scans now also return TIDs pointing
+-- into the new segfile; expect no error and the full pre-DELETE row count
+1: MOVE ALL IN cur;
+1: CLOSE cur;
+1: COMMIT;
+-- a fresh query sees the post-DELETE data
+1: SELECT count(*) FROM ao_probe a JOIN ao_lu b ON a.cust_no = b.cust_no;
+1q:
+2q:
+
+DROP TABLE ao_lu;
+DROP TABLE ao_probe;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -124,6 +124,7 @@ test: uao/cursor_withhold_row
 test: uao/cursor_withhold2_row
 test: uao/delete_while_vacuum_row
 test: uao/index_build_relstats_row
+test: uao/index_fetch_while_vacuum_row
 test: uao/index_only_scan_row
 test: uao/insert_policy_row
 test: uao/insert_while_vacuum_row
@@ -192,6 +193,7 @@ test: uao/cursor_withhold_column
 test: uao/cursor_withhold2_column
 test: uao/delete_while_vacuum_column
 test: uao/index_build_relstats_column
+test: uao/index_fetch_while_vacuum_column
 test: uao/index_only_scan_column
 test: uao/insert_policy_column
 test: uao/insert_while_vacuum_column

--- a/src/test/isolation2/output/uao/index_fetch_while_vacuum.source
+++ b/src/test/isolation2/output/uao/index_fetch_while_vacuum.source
@@ -1,0 +1,78 @@
+-- @Description Tests that a concurrent VACUUM compaction does not break an
+-- already-running index fetch on the same table.
+--
+-- The reader opens a cursor over a nestloop join whose inner side fetches
+-- tuples through the btree index; the AO fetch descriptor (and its cached
+-- list of segfiles) is initialized at the first MOVE. The concurrent
+-- DELETE + VACUUM then compacts the table, moving the surviving tuples into
+-- a segfile that did not exist when the fetch descriptor was created, while
+-- the btree immediately contains entries pointing into that new segfile.
+-- Draining the cursor re-executes the inner index scan and must treat those
+-- entries as invisible ("not found") instead of raising the "out of scanning
+-- scope" error: none of the moved tuples can be visible to the reader's
+-- snapshot anyway.
+DROP TABLE IF EXISTS ao_lu;
+DROP TABLE
+DROP TABLE IF EXISTS ao_probe;
+DROP TABLE
+CREATE TABLE ao_lu (cust_no int, birth_y text, filler text) USING @amname@ DISTRIBUTED BY (cust_no);
+CREATE TABLE
+INSERT INTO ao_lu SELECT g, (1950 + g % 60)::text, repeat('x', 200) FROM generate_series(1, 300000) g;
+INSERT 0 300000
+CREATE INDEX ao_lu_cust_no_idx ON ao_lu (cust_no);
+CREATE INDEX
+CREATE TABLE ao_probe (cust_no int) DISTRIBUTED BY (cust_no);
+CREATE TABLE
+INSERT INTO ao_probe SELECT g FROM generate_series(1, 100000) g;
+INSERT 0 100000
+ANALYZE ao_lu;
+ANALYZE
+ANALYZE ao_probe;
+ANALYZE
+
+1: SET optimizer = off;
+SET
+1: SET enable_seqscan = off;
+SET
+1: SET enable_hashjoin = off;
+SET
+1: SET enable_mergejoin = off;
+SET
+1: SET enable_nestloop = on;
+SET
+1: BEGIN;
+BEGIN
+1: DECLARE cur CURSOR FOR SELECT a.cust_no, b.birth_y FROM ao_probe a JOIN ao_lu b ON a.cust_no = b.cust_no;
+DECLARE CURSOR
+-- pull one row through the cursor so the reader's fetch descriptor and its
+-- segfile list are initialized before the concurrent vacuum runs
+1: MOVE 1 IN cur;
+MOVE 1
+-- delete ~1/3 of the tuples and vacuum: compaction moves the surviving
+-- tuples into a brand-new segfile and marks the old one AWAITING_DROP (the
+-- reader's open snapshot prevents recycling it within this vacuum)
+2: DELETE FROM ao_lu WHERE cust_no % 3 = 0;
+DELETE 100000
+2: VACUUM ao_lu;
+VACUUM
+-- drain the cursor: the inner index scans now also return TIDs pointing
+-- into the new segfile; expect no error and the full pre-DELETE row count
+1: MOVE ALL IN cur;
+MOVE 99999
+1: CLOSE cur;
+CLOSE CURSOR
+1: COMMIT;
+COMMIT
+-- a fresh query sees the post-DELETE data
+1: SELECT count(*) FROM ao_probe a JOIN ao_lu b ON a.cust_no = b.cust_no;
+ count 
+-------
+ 66667 
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+DROP TABLE ao_lu;
+DROP TABLE
+DROP TABLE ao_probe;
+DROP TABLE


### PR DESCRIPTION
## Problem

A query doing an index fetch on an AO/AOCS table can fail with

```
ERROR:  Row No. 1675 in segment file No. 2 is out of scanning scope for target relfilenode 24898. (aocsam.c:2267)
```

when a `VACUUM` of the same table runs concurrently. Typical trigger: a
long-running `UPDATE ... FROM <aoco_table>` whose inner side is a bitmap index
scan, overlapping a scheduled `VACUUM` of that table. Reported from a
production system; reproduced on a stock demo cluster in under 2 seconds with
the stress script described below.

## Root cause

Commit 61323b178e ("Initialize lastSequence only for the target scanning
segments during index scan.") narrowed the `lastSequence[]` initialization in
the AO/AOCS fetch descriptor from all 128 possible segnos to only the segfiles
visible in pg_aoseg/pg_aocsseg at initialization time, and turned a hit on any
other segno into the XX000 error above.

The fetch descriptor (and its cached segfile list) is initialized at the
*first fetch* of the scan and lives for the whole scan. While the scan is
running, a concurrent VACUUM compaction (or any concurrent insert) may pick a
**brand-new segfile** as its insertion target. The btree immediately contains
physically visible entries for the moved tuples, so a long-running index fetch
(e.g. a nestloop rescanning its inner bitmap index scan) can return a TID
pointing into a segno that did not exist when the descriptor was initialized →
`lastSequence[segno] == InvalidAORowNum` → spurious XX000.

None of those tuples can be visible to the fetch's snapshot: a segno missing
from the cached list means its first-ever use began after the descriptor was
initialized (initial pg_aoseg/pg_aocsseg entries are frozen on insert, so this
is the only way to miss). Erroring out is wrong; the TID should simply be
treated as not found.

## Fix

In `aocs_fetch()` and `appendonly_fetch()`, fold the
`lastSequence[segno] == InvalidAORowNum` case into the existing
"rowNum beyond lastSequence → return not found" fast path instead of raising
the error. This restores the pre-61323b178e semantics (`ReadLastSequence()`
returned 0 for a segno without a gp_fastsequence entry, silently skipping such
TIDs) while keeping that commit's optimization intact.

## Test

New isolation2 test `uao/index_fetch_while_vacuum` (row + column variants)
reproduces the race deterministically without fault injection:

1. session 1 opens a cursor over a nestloop join with a bitmap index scan
   inner side and pulls one row (`MOVE 1`) — pinning the fetch descriptor and
   its cached segfile list;
2. session 2 deletes ~1/3 of the AO table and runs `VACUUM` — compaction moves
   the surviving tuples into a brand-new segfile (the reader's open snapshot
   keeps the old one in `AWAITING_DROP`);
3. session 1 drains the cursor (`MOVE ALL`) — the rescanning inner index scans
   now return TIDs into the new segfile.

Without the fix both variants fail deterministically (row: appendonlyam.c,
column: aocsam.c); with the fix the cursor returns the exact pre-DELETE row
count.

## Verification matrix

| Check | Before fix | After fix |
|---|---|---|
| Stress repro (3 concurrent sessions: index-fetch UPDATE loop + DELETE/INSERT/VACUUM churn + snapshot holder) | error in **1 s**, 1st reader iteration | clean for **300 s** / ~203 VACUUM cycles, insert segno advanced to 29 |
| Deterministic cursor repro (ao_column) | XX000 every run | no error; row count exact (snapshot-correct, deleted rows still visible to old snapshot) |
| New isolation2 test, ao_row + ao_column | both FAIL (appendonlyam.c / aocsam.c) | both pass |
| `uao/limit_indexscan_inits_row/_column` (test added by 61323b178e — guards its optimization) | — | pass |
| Related suites: `uao/` cursor/compaction/vacuum tests, `uao_crash_compaction_*`, brin | — | pass |
| **Full isolation2 schedule** (demo cluster, 3 primaries + 3 mirrors) | — | **All 303 tests passed** |
