### PR TITLE
test: fix atomic_test expectations and make >4GiB workfile unit tests sparse

### DIFF
--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -65,6 +65,10 @@ language plpgsql volatile execute on all segments;
 1: DROP TABLESPACE IF EXISTS work_file_test_ts;
 1: CREATE TABLESPACE work_file_test_ts LOCATION '@testtablespace@/workfile_mgr';
 
+-- WHPG: 't' is the meaningful expectation here.  The harness's two
+-- sub_fetch sub-tests used to compute their expected value with '+'
+-- instead of '-', so atomic_test always failed and the 'f' rows had
+-- been snapshotted as expected output since the test was added (2020).
 1: select gp_workfile_mgr_test('atomic_test', 0);
 1: select gp_workfile_mgr_test('buffile_size_test', 0);
 1: select gp_workfile_mgr_test('buffile_large_file_test', 0);

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -71,13 +71,17 @@ DROP TABLESPACE
 1: CREATE TABLESPACE work_file_test_ts LOCATION '@testtablespace@/workfile_mgr';
 CREATE TABLESPACE
 
+-- WHPG: 't' is the meaningful expectation here.  The harness's two
+-- sub_fetch sub-tests used to compute their expected value with '+'
+-- instead of '-', so atomic_test always failed and the 'f' rows had
+-- been snapshotted as expected output since the test was added (2020).
 1: select gp_workfile_mgr_test('atomic_test', 0);
  gp_workfile_mgr_test 
 ----------------------
- f                    
- f                    
- f                    
- f                    
+ t                    
+ t                    
+ t                    
+ t                    
 (4 rows)
 1: select gp_workfile_mgr_test('buffile_size_test', 0);
  gp_workfile_mgr_test 

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -118,6 +118,8 @@ gp_workfile_mgr_test_harness(PG_FUNCTION_ARGS)
 		elog(LOG, "No tests match given name: %s", test_name);
 	}
 
+	pfree(test_name);
+
 	PG_RETURN_BOOL(ran_any_tests && result);
 }
 
@@ -153,6 +155,8 @@ gp_workfile_mgr_create_workset(PG_FUNCTION_ARGS)
 		if (closeFile)
 			BufFileClose(buffile);
 	}
+
+	pfree(worksetName);
 
 	PG_RETURN_VOID();
 }
@@ -335,6 +339,8 @@ buffile_size_test(void)
 	elog(LOG, "Running sub-test: Writing to new buffile and reading size > bufsize");
 	nchars = 1000000;
 	expected_size += nchars;
+	pfree(text->data);
+	pfree(text);
 	text = create_text_stringinfo(nchars);
 	BufFileWrite(testBf, text->data, nchars);
 	test_size = BufFileGetSize(testBf);
@@ -525,6 +531,7 @@ buffile_large_file_test(void)
 
 	pfree(test_string->data);
 	pfree(test_string);
+	pfree(buffer);
 
 	return unit_test_summary();
 }
@@ -625,6 +632,10 @@ logicaltape_test(void)
 	LogicalTapeSetClose(tape_set);
 
 	unit_test_result (strncmp(test_string->data, buffer, test_string->len) == 0);
+
+	pfree(test_string->data);
+	pfree(test_string);
+	pfree(buffer);
 
 	return unit_test_summary();
 }
@@ -751,6 +762,8 @@ workfile_create_and_set_cleanup(void)
 
 	unit_test_result(!work_set->active);
 
+	pfree(ewfiles);
+
 	return unit_test_summary();
 }
 
@@ -853,6 +866,8 @@ workfile_create_and_individual_cleanup(void)
 	/* the workfile_set should be freed since all it's files are closed */
 	unit_test_result(!work_set->active);
 
+	pfree(ewfiles);
+
 	return unit_test_summary();
 }
 
@@ -915,6 +930,8 @@ workfile_create_and_individual_cleanup_with_pinned_workfile_set(void)
 	workfile_mgr_close_set(work_set);
 
 	unit_test_result(!work_set->active);
+
+	pfree(ewfiles);
 
 	return unit_test_summary();
 }

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -449,6 +449,16 @@ atomic_test(void)
 /*
  * Unit test for BufFile support of large files (greater than 4 GB).
  *
+ * What large-spill-file support depends on is the int64 offset arithmetic
+ * (fileno/offset normalization in BufFileSeek, block-number arithmetic in
+ * BufFileSeekBlock) and the rollover of writes into a new 1GiB physical
+ * segment file.  None of that requires storing 4GiB of data: BufFileSeek
+ * refuses to move past the last existing segment file, but within existing
+ * segments it does not check the physical file size, and the underlying
+ * pwrite leaves never-written ranges as filesystem holes.  So grow the
+ * file one segment at a time by writing a record across each 1GiB
+ * boundary, then place a marked record past the 4GiB mark: the file is
+ * logically >4GiB but occupies under 1MB of disk.
  */
 static bool
 buffile_large_file_test(void)
@@ -457,41 +467,53 @@ buffile_large_file_test(void)
 	elog(LOG, "Running test: buffile_large_file_test");
 	char *file_name = "Test_large_buff.dat";
 
+	/* buffile.c's MAX_PHYSICAL_FILESIZE: 1GiB per physical segment file */
+	const int64 seg_size = 0x40000000;
+
 	BufFile *bfile = BufFileCreateTempInSet(file_name,
 											true /* interXact */,
 											NULL /* workfile_set */);
 
 	int nchars = 100000;
-	/* 4.5 GBs */
-	int total_entries = 48319;
-	/* Entry that requires an int64 seek */
-	int test_entry = 45000;
+
+	/* Target record: a BLCKSZ-aligned byte offset just past 4GiB (2^32) */
+	int64 target_block = (INT64CONST(1) << 32) / BLCKSZ + 100;
+	int64 target_offset = target_block * BLCKSZ;
 
 	StringInfo test_string = create_text_stringinfo(nchars);
 
+	/*
+	 * Make the target record distinguishable from the filler records, so
+	 * reading the wrong offset after the seek actually fails the test.
+	 * Filler content is never verified; reuse one buffer for all of it.
+	 */
+	memcpy(test_string->data, "TARGET_ENTRY", 12);
+	StringInfo filler = create_text_stringinfo(nchars);
+
 	elog(LOG, "Running sub-test: Creating file %s", file_name);
 
-	for (int i = 0; i < total_entries; i++)
+	/* Grow to five segment files by writing across each 1GiB boundary. */
+	for (int seg = 0; seg < 4; seg++)
 	{
-		if (test_entry == i)
-		{
-			BufFileWrite(bfile, test_string->data , nchars*sizeof(char));
-		}
-		else
-		{
-			StringInfo text = create_text_stringinfo(nchars);
-
-			BufFileWrite(bfile, text->data , nchars*sizeof(char));
-
-			pfree(text->data);
-			pfree(text);
-		}
+		unit_test_result(BufFileSeek(bfile, seg, seg_size - BLCKSZ, SEEK_SET) == 0);
+		BufFileWrite(bfile, filler->data, nchars * sizeof(char));
 	}
+
+	/* Seeking past the last segment file must still be refused. */
+	unit_test_result(BufFileSeek(bfile, 5, BLCKSZ, SEEK_SET) == EOF);
+
+	/* Write the target record past the 4GiB mark. */
+	unit_test_result(BufFileSeek(bfile, 0, target_offset, SEEK_SET) == 0);
+	BufFileWrite(bfile, test_string->data, nchars * sizeof(char));
+
+	pfree(filler->data);
+	pfree(filler);
 	elog(LOG, "Running sub-test: Reading record %s", file_name);
 
 	char *buffer = palloc(nchars * sizeof(char));
 
-	BufFileSeek(bfile, 0 /* fileno */, (int64) ((int64)test_entry * (int64) nchars), SEEK_SET);
+	/* Read it back through the block-oriented seek API. */
+	unit_test_result(BufFileSeekBlock(bfile, target_block) == 0);
 
 	int nread = BufFileRead(bfile, buffer, nchars*sizeof(char));
 
@@ -518,12 +540,22 @@ logicaltape_test(void)
 
 	int max_tapes = 10;
 	int nchars = 100000;
-	/* 4.5 GBs */
-	int max_entries = 48319;
 
-	/* Target record values */
+	/*
+	 * Enough records for the tape to cross the underlying 1GiB
+	 * physical-segment-file boundary (10737 x 100KB), the tape-level
+	 * scenario worth exercising here.  The >4GiB int64 offset arithmetic
+	 * that large spill files depend on is covered by
+	 * buffile_large_file_test -- including BufFileSeekBlock, which is what
+	 * logical tape block I/O goes through -- so the tape itself does not
+	 * need to be grown past 4GiB (which, with the tape's strictly
+	 * sequential block allocation, would mean actually writing 4.3GB).
+	 */
+	int max_entries = 10800;
+
+	/* Target record values; past the 1GiB segment boundary */
 	int test_tape = 5;
-	int test_entry = 45000;
+	int test_entry = 10750;
 
 	LogicalTapeSet *tape_set = LogicalTapeSetCreate(max_tapes, false, NULL, NULL, -1);
 
@@ -532,6 +564,14 @@ logicaltape_test(void)
 	int offset = 0;
 
 	StringInfo test_string = create_text_stringinfo(nchars);
+
+	/*
+	 * Make the target record distinguishable from the filler records, so
+	 * reading the wrong position after the seek actually fails the test.
+	 * Filler content is never verified; reuse one buffer for all of it.
+	 */
+	memcpy(test_string->data, "TARGET_ENTRY", 12);
+	StringInfo filler = create_text_stringinfo(nchars);
 
 	elog(LOG, "Running sub-test: Creating LogicalTape");
 
@@ -554,27 +594,20 @@ logicaltape_test(void)
 				else
 				{
 					/* Add additional records */
-					StringInfo text = create_text_stringinfo(nchars);
-
-					LogicalTapeWrite(tape_set, work_tape, text->data, (size_t)text->len);
-
-					pfree(text->data);
-					pfree(text);
+					LogicalTapeWrite(tape_set, work_tape, filler->data, (size_t)filler->len);
 				}
 			}
 		}
 		else
 		{
 			/* Add additional records */
-			StringInfo text = create_text_stringinfo(nchars);
-
-			LogicalTapeWrite(tape_set, work_tape, text->data, (size_t)text->len);
-
-			pfree(text->data);
-			pfree(text);
+			LogicalTapeWrite(tape_set, work_tape, filler->data, (size_t)filler->len);
 		}
 
 	}
+
+	pfree(filler->data);
+	pfree(filler);
 
 	/* Set target LogicalTape */
 	work_tape = test_tape;

--- a/src/test/isolation2/workfile_mgr_test.c
+++ b/src/test/isolation2/workfile_mgr_test.c
@@ -415,7 +415,7 @@ atomic_test(void)
 
 		inc = 4;
 		result = 0;
-		expected_result = base + inc;
+		expected_result = base - inc;
 		elog(DEBUG1, "Before: base=%lld, inc=%lld, result=%lld", (long long int) base, (long long int) inc, (long long int) result);
 		result = pg_atomic_sub_fetch_u64((pg_atomic_uint64 *)&base, inc);
 		elog(DEBUG1, "After: base=%lld, inc=%lld, result=%lld", (long long int) base, (long long int) inc, (long long int) result);
@@ -435,7 +435,7 @@ atomic_test(void)
 		elog(LOG, "Running sub-test: pg_atomic_sub_fetch_u64 huge subtraction");
 		inc  = 32738246483234;
 		result = 0;
-		expected_result = base + inc;
+		expected_result = base - inc;
 		elog(DEBUG1, "Before: base=%lld, inc=%lld, result=%lld", (long long int) base, (long long int) inc, (long long int) result);
 		result = pg_atomic_sub_fetch_u64((pg_atomic_uint64 *)&base, inc);
 		elog(DEBUG1, "After: base=%lld, inc=%lld, result=%lld", (long long int) base, (long long int) inc, (long long int) result);


### PR DESCRIPTION
### 1. `atomic_test` never asserted anything

Both `pg_atomic_sub_fetch_u64` sub-tests computed their expected value with `+` instead of `-`, so two of the five assertions failed on every platform, the summary was always `f` — and the `f` rows were snapshotted into the expected output in the same commit that added the test (2020, 5b147fbe05e). Fix the arithmetic and expect `t`.

### 2. The >4GiB unit tests wrote ~19GB of filler to test offset arithmetic

`buffile_large_file_test` and `logicaltape_test` each wrote 4.83GB per backend (48319 x 100KB records), on the coordinator and every segment at once — ~19GB transient disk on a one-disk demo cluster, enough to ENOSPC a host with less headroom, and minutes of pure filler I/O.

What they guard is int64 offset arithmetic and 1GiB segment rollover, not bulk data volume. `BufFileSeek` cannot move past the last existing segment file, but within existing segments it does not check the physical file size, and pwrite leaves never-written ranges as filesystem holes. So the buffile test now grows the file by writing one record across each 1GiB boundary (exercising the real segment-rollover write path four times), then writes a marked record just past the 4GiB mark and reads it back through both `BufFileSeek` and `BufFileSeekBlock`: logically >4GiB, under 1MB on disk. The tape (strictly sequential block allocation, no sparse path) shrinks to just past the underlying 1GiB segment boundary; its block I/O goes through `BufFileSeekBlock`, which the buffile test now covers past 4GiB.

The target records are also prefixed with a distinct marker — previously every record had identical content, so the post-seek read-back could not have detected a seek landing on the wrong record.

### Verification

On a demo cluster, `buffile_large_file_test`, `logicaltape_test` and `atomic_test` all return `t` on the coordinator and all segments (previously `f` for atomic_test, ENOSPC-prone for the large-file pair).
