### PR TITLE
Fix SPLIT PARTITION losing user-supplied partition names

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1227,10 +1227,33 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		 * against the partition key of parentRel, so it better have one.
 		 */
 		if (parent->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
+		{
+			/*
+			 * A common mistake is trying to attach a new partition to an
+			 * existing partition (e.g. the DEFAULT leaf) instead of to the
+			 * partitioned root. Detect that case and point the user at the
+			 * right relation.
+			 */
+			if (parent->rd_rel->relispartition)
+			{
+				Oid rootId = get_top_level_partition_root(parentId);
+
+				if (OidIsValid(rootId))
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+							 errmsg("\"%s\" is not partitioned",
+									RelationGetRelationName(parent)),
+							 errdetail("\"%s\" is itself a partition, not a partitioned table.",
+									   RelationGetRelationName(parent)),
+							 errhint("Attach the new partition to its partitioned ancestor \"%s\" instead.",
+									 get_rel_name(rootId))));
+			}
+
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 					 errmsg("\"%s\" is not partitioned",
 							RelationGetRelationName(parent))));
+		}
 
 		classic_range_workflow = stmt->origin == ORIGIN_GP_CLASSIC_CREATE_GEN &&
 			stmt->partbound->strategy == PARTITION_STRATEGY_RANGE;


### PR DESCRIPTION
## Summary

`ALTER TABLE ... SPLIT PARTITION` / `SPLIT DEFAULT PARTITION` silently discards the partition name the user supplies for the new (non-default) partition, replacing it with the legacy auto-generated `<root>_<level>_prt_<name>` pattern.

Example:
```sql
ALTER TABLE test_partition_with_default
  SPLIT DEFAULT PARTITION START ('2026-03-01') END ('2026-04-01')
  INTO (PARTITION m202603, default partition);
Before this fix, the new partition ends up named test_partition_with_default_1_prt_m202603 instead of m202603.
```
## Root cause

AtExecGPSplitPartition() (tablecmds_gp.c) builds CREATE TABLE statements for the new partitions via makePartitionCreateStmt(), passing a shared partname_comp struct. makePartitionCreateStmt() only keeps a partition's literal name if partcomp->tablename is set; otherwise it falls back to ChoosePartitionName(), which synthesizes the legacy <root>_<level>_prt_<name> naming scheme — a scheme meant for partitions generated by ... PARTITION BY ... EVERY, not for names a user explicitly typed in a SPLIT command.

partcomp.tablename was only ever set for the DEFAULT partition (to preserve its original name across the split) — never for the explicitly user-named partition — so that partition always fell through to ChoosePartitionName().