### PR TITLE
Expand materialized views at any depth in gp_dump_query_oids

### DIFF
--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -65,6 +65,7 @@ typedef struct fireRIRonSubLink_context
 {
 	List	   *activeRIRs;
 	bool		hasRowSecurity;
+	bool		expandMatViews;
 } fireRIRonSubLink_context;
 
 static bool acquireLocksOnSubLinks(Node *node,
@@ -1929,6 +1930,7 @@ ApplyRetrieveRule(Query *parsetree,
 	 * OLD rangetable entries by the action below (in a recursive call of this
 	 * routine).
 	 */
+	rule_action->expandMatViews = parsetree->expandMatViews;
 	rule_action = fireRIRrules(rule_action, activeRIRs);
 
 	/*
@@ -2057,6 +2059,7 @@ fireRIRonSubLink(Node *node, fireRIRonSubLink_context *context)
 		SubLink    *sub = (SubLink *) node;
 
 		/* Do what we came for */
+		((Query *) sub->subselect)->expandMatViews = context->expandMatViews;
 		sub->subselect = (Node *) fireRIRrules((Query *) sub->subselect,
 											   context->activeRIRs);
 
@@ -2116,6 +2119,7 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 		 */
 		if (rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_TABLEFUNCTION)
 		{
+			rte->subquery->expandMatViews = parsetree->expandMatViews;
 			rte->subquery = fireRIRrules(rte->subquery, activeRIRs);
 
 			/*
@@ -2145,7 +2149,10 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 		 *
 		 * In the minirepro utility in GPDB, we use the expandMatViews flag
 		 * to treat materialized views as regular views when dumping the
-		 * DDL in order to dump dependent objects
+		 * DDL in order to dump dependent objects.  The flag is propagated
+		 * to every child Query recursed into during rewrite (view rule
+		 * actions, subquery RTEs, CTEs and sublinks), so materialized views
+		 * are expanded at any nesting depth, like regular views.
 		 */
 		if (rte->relkind == RELKIND_MATVIEW && !parsetree->expandMatViews)
 			continue;
@@ -2239,6 +2246,7 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 	{
 		CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
 
+		((Query *) cte->ctequery)->expandMatViews = parsetree->expandMatViews;
 		cte->ctequery = (Node *)
 			fireRIRrules((Query *) cte->ctequery, activeRIRs);
 
@@ -2259,6 +2267,7 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 
 		context.activeRIRs = activeRIRs;
 		context.hasRowSecurity = false;
+		context.expandMatViews = parsetree->expandMatViews;
 
 		query_tree_walker(parsetree, fireRIRonSubLink, (void *) &context,
 						  QTW_IGNORE_RC_SUBQUERIES);
@@ -2341,6 +2350,7 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 				 */
 				fire_context.activeRIRs = activeRIRs;
 				fire_context.hasRowSecurity = false;
+				fire_context.expandMatViews = parsetree->expandMatViews;
 
 				expression_tree_walker((Node *) securityQuals,
 									   fireRIRonSubLink, (void *) &fire_context);
@@ -4276,6 +4286,7 @@ QueryRewrite(Query *parsetree)
 	{
 		Query	   *query = (Query *) lfirst(l);
 
+		query->expandMatViews = parsetree->expandMatViews;
 		query = fireRIRrules(query, NIL);
 
 		query->queryId = input_query_id;

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -7,6 +7,16 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create materialized view base_mv as select a from base;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create view base_v as select a from base;
+create materialized view base_mv2 as select a from base_mv;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create view base_v_over_mv as select a from base_mv;
+create table rule_tgt(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table rule_log(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create rule tgt_log_rule as on insert to rule_tgt do also insert into rule_log select a from base_mv;
 CREATE SEQUENCE minirepro_test_b;
 CREATE TABLE minirepro_test(a serial, b int default nextval('minirepro_test_b'));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -19,6 +29,10 @@ declare
   base_oid oid;
   base_mv_oid oid;
   base_v_oid oid;
+  base_mv2_oid oid;
+  base_v_over_mv_oid oid;
+  rule_tgt_oid oid;
+  rule_log_oid oid;
   minirepro_test_oid oid;
   minirepro_test_b_oid oid;
   minirepro_test_a_seq_oid oid;
@@ -28,6 +42,10 @@ begin
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
     base_v_oid = 'base_v'::regclass::oid;
+    base_mv2_oid = 'base_mv2'::regclass::oid;
+    base_v_over_mv_oid = 'base_v_over_mv'::regclass::oid;
+    rule_tgt_oid = 'rule_tgt'::regclass::oid;
+    rule_log_oid = 'rule_log'::regclass::oid;
     minirepro_test_oid = 'minirepro_test'::regclass::oid;
     minirepro_test_b_oid = 'minirepro_test_b'::regclass::oid;
     minirepro_test_a_seq_oid = 'minirepro_test_a_seq'::regclass::oid;
@@ -37,6 +55,10 @@ begin
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
     t := replace(t, base_v_oid::text, '<base_v>');
+    t := replace(t, base_mv2_oid::text, '<base_mv2>');
+    t := replace(t, base_v_over_mv_oid::text, '<base_v_over_mv>');
+    t := replace(t, rule_tgt_oid::text, '<rule_tgt>');
+    t := replace(t, rule_log_oid::text, '<rule_log>');
     t := replace(t, minirepro_test_oid::text, '<minirepro_test>');
     t := replace(t, minirepro_test_b_oid::text, '<minirepro_test_b>');
     t := replace(t, minirepro_test_a_seq_oid::text, '<minirepro_test_a_seq>');
@@ -193,6 +215,56 @@ SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'
  {"relids": "<base_v>,<base_table>", "funcids": ""}
 (1 row)
 
+-- materialized views must be expanded at any nesting depth, so that objects
+-- referenced transitively (here the base table) are always collected
+-- materialized view on top of another materialized view
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv2'));
+                        sanitize_output                         
+----------------------------------------------------------------
+ {"relids": "<base_mv2>,<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_mv2'));
+                        sanitize_output                         
+----------------------------------------------------------------
+ {"relids": "<base_mv2>,<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+-- materialized view inside a subquery
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM (SELECT * FROM base_mv) x'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+-- materialized view inside a sublink
+SELECT sanitize_output(gp_dump_query_oids('SELECT 1 WHERE EXISTS (SELECT 1 FROM base_mv)'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+-- materialized view behind a regular view
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_v_over_mv'));
+                           sanitize_output                            
+----------------------------------------------------------------------
+ {"relids": "<base_v_over_mv>,<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+-- materialized view inside a CTE
+SELECT sanitize_output(gp_dump_query_oids('WITH c AS (SELECT * FROM base_mv) SELECT * FROM c'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+-- materialized view inside a DO ALSO rule action fired by a DML statement
+SELECT sanitize_output(gp_dump_query_oids('INSERT INTO rule_tgt VALUES (1)'));
+                              sanitize_output                              
+---------------------------------------------------------------------------
+ {"relids": "<rule_tgt>,<rule_log>,<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
 -- gp_dump_query_oids should output relids of referenced sequences
 SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM minirepro_test'));
                                      sanitize_output                                     
@@ -207,6 +279,10 @@ DROP TABLE cctable;
 DROP TABLE ctable;
 DROP TABLE ptable;
 DROP TABLE minirepro_partition_test;
+DROP TABLE rule_tgt;
+DROP TABLE rule_log;
+DROP VIEW base_v_over_mv;
+DROP MATERIALIZED VIEW base_mv2;
 DROP MATERIALIZED VIEW base_mv;
 DROP VIEW base_v;
 DROP TABLE base;

--- a/src/test/regress/sql/gp_dump_query_oids.sql
+++ b/src/test/regress/sql/gp_dump_query_oids.sql
@@ -4,6 +4,11 @@ CREATE FUNCTION dumptestfunc2(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUA
 create table base(a int);
 create materialized view base_mv as select a from base;
 create view base_v as select a from base;
+create materialized view base_mv2 as select a from base_mv;
+create view base_v_over_mv as select a from base_mv;
+create table rule_tgt(a int);
+create table rule_log(a int);
+create rule tgt_log_rule as on insert to rule_tgt do also insert into rule_log select a from base_mv;
 CREATE SEQUENCE minirepro_test_b;
 CREATE TABLE minirepro_test(a serial, b int default nextval('minirepro_test_b'));
 
@@ -15,6 +20,10 @@ declare
   base_oid oid;
   base_mv_oid oid;
   base_v_oid oid;
+  base_mv2_oid oid;
+  base_v_over_mv_oid oid;
+  rule_tgt_oid oid;
+  rule_log_oid oid;
   minirepro_test_oid oid;
   minirepro_test_b_oid oid;
   minirepro_test_a_seq_oid oid;
@@ -24,6 +33,10 @@ begin
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
     base_v_oid = 'base_v'::regclass::oid;
+    base_mv2_oid = 'base_mv2'::regclass::oid;
+    base_v_over_mv_oid = 'base_v_over_mv'::regclass::oid;
+    rule_tgt_oid = 'rule_tgt'::regclass::oid;
+    rule_log_oid = 'rule_log'::regclass::oid;
     minirepro_test_oid = 'minirepro_test'::regclass::oid;
     minirepro_test_b_oid = 'minirepro_test_b'::regclass::oid;
     minirepro_test_a_seq_oid = 'minirepro_test_a_seq'::regclass::oid;
@@ -33,6 +46,10 @@ begin
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
     t := replace(t, base_v_oid::text, '<base_v>');
+    t := replace(t, base_mv2_oid::text, '<base_mv2>');
+    t := replace(t, base_v_over_mv_oid::text, '<base_v_over_mv>');
+    t := replace(t, rule_tgt_oid::text, '<rule_tgt>');
+    t := replace(t, rule_log_oid::text, '<rule_log>');
     t := replace(t, minirepro_test_oid::text, '<minirepro_test>');
     t := replace(t, minirepro_test_b_oid::text, '<minirepro_test_b>');
     t := replace(t, minirepro_test_a_seq_oid::text, '<minirepro_test_a_seq>');
@@ -105,6 +122,21 @@ SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_v'));
 -- gp_dump_query_oids should output relids of view/materialized view and used/accessed objects when query contains explain analyze command
 SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_mv'));
 SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'));
+-- materialized views must be expanded at any nesting depth, so that objects
+-- referenced transitively (here the base table) are always collected
+-- materialized view on top of another materialized view
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv2'));
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_mv2'));
+-- materialized view inside a subquery
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM (SELECT * FROM base_mv) x'));
+-- materialized view inside a sublink
+SELECT sanitize_output(gp_dump_query_oids('SELECT 1 WHERE EXISTS (SELECT 1 FROM base_mv)'));
+-- materialized view behind a regular view
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_v_over_mv'));
+-- materialized view inside a CTE
+SELECT sanitize_output(gp_dump_query_oids('WITH c AS (SELECT * FROM base_mv) SELECT * FROM c'));
+-- materialized view inside a DO ALSO rule action fired by a DML statement
+SELECT sanitize_output(gp_dump_query_oids('INSERT INTO rule_tgt VALUES (1)'));
 -- gp_dump_query_oids should output relids of referenced sequences
 SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM minirepro_test'));
 
@@ -115,6 +147,10 @@ DROP TABLE cctable;
 DROP TABLE ctable;
 DROP TABLE ptable;
 DROP TABLE minirepro_partition_test;
+DROP TABLE rule_tgt;
+DROP TABLE rule_log;
+DROP VIEW base_v_over_mv;
+DROP MATERIALIZED VIEW base_mv2;
 DROP MATERIALIZED VIEW base_mv;
 DROP VIEW base_v;
 DROP TABLE base;


### PR DESCRIPTION
## Problem

`minirepro` doesn't collect the DDL of tables used by a nested materialized view: with `mv2 -> mv1 -> t_test`, the output contains `mv2` and `mv1` but not `t_test` (PTT-1345).

## Root cause

minirepro enumerates dependent objects via `gp_dump_query_oids()`. Commit eedd5ff94e ("Fix dependency bug with minirepro and materialized views (#14223)") introduced `Query.expandMatViews` so matviews are expanded like regular views during rewrite — but it sets the flag **only on the top-level Query**. Every child Query reached during rewrite (a view/matview rule action, a subquery RTE, a CTE, a sublink, or a product query of a non-SELECT rule) is a fresh node with the flag unset, so a matview more than one Query level deep stays unexpanded and its dependencies are missed. All of these shapes lose the base table:

- matview on top of another matview (the reported case)
- matview inside a subquery / sublink / CTE
- matview behind a regular view
- matview referenced in a `DO ALSO` rule action fired by DML

## Fix

Propagate `expandMatViews` into every child Query recursed into during rewrite — the same idiom `fireRIRrules` already uses for `hasRowSecurity` at the same sites — plus onto the product queries in `QueryRewrite`. Matviews are then expanded at any nesting depth (regular views already recurse unconditionally), so `gp_dump_query_oids` returns the full transitive closure of referenced relations. Sequences and partition/inheritance children were already collected per-relid downstream, so they follow automatically.

The flag is only ever set by `gp_dump_query_oids()`; for every other statement the new assignments copy `false` into nodes that were already `false`, so normal query rewrite is unchanged. No node serialization (`out/read/copy/equalfuncs`) is touched, so the stored-rule (`pg_rewrite.ev_action`) format is unaffected — safe for stable-branch backport (`Query.expandMatViews` already exists in 7.2/7.3/7.4).

## Testing

- `gp_dump_query_oids` regress case extended with all 7 shapes above; passes.
- Full local `make installcheck` (parallel + greenplum schedules, 637 tests): only 2 failures, both local-environment artifacts (Docker DNS wildcard in `external_table`, FTS mirror-recovery timing in `fts_recovery_in_progress`), unrelated to this change.
- End-to-end: ran the `minirepro` utility with the reported scenario; the output file now contains `CREATE TABLE public.t_test`.