### PR TITLE
Fix ORCA folding NULL scalar-subquery count() results to 0

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStar.mdp
@@ -277,10 +277,10 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="120">
+    <dxl:Plan Id="0" SpaceSize="100">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000778" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000773" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="19" Alias="?column?">
@@ -291,29 +291,50 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.000748" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000743" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="19" Alias="?column?">
-              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:Result>
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000746" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000740" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ProjElem ColId="18" Alias="count">
                 <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000740" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.921975.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:Materialize Eager="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000703" Rows="3.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="count">
@@ -321,31 +342,9 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
+              <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.921975.1.1" TableName="foo">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000703" Rows="3.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000695" Rows="3.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="count">
@@ -353,29 +352,30 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                <dxl:SortingColumnList/>
+                <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000695" Rows="3.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000265" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="count">
                       <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:Limit>
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000265" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000257" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
                         <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000257" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000227" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="count">
@@ -383,98 +383,98 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000227" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="9"/>
+                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="18" Alias="count">
-                            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="9" Alias="c">
+                            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000227" Rows="1.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="12"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="9"/>
-                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="18" Alias="count">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
-                                <dxl:ValuesList ParamType="aggargs">
-                                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                                </dxl:ValuesList>
-                                <dxl:ValuesList ParamType="aggdirectargs"/>
-                                <dxl:ValuesList ParamType="aggorder"/>
-                                <dxl:ValuesList ParamType="aggdistinct"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="9" Alias="c">
                               <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:SortingColumnList/>
+                          <dxl:HashExprList>
+                            <dxl:HashExpr>
+                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                          </dxl:HashExprList>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="9" Alias="c">
                                 <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashExprList>
-                              <dxl:HashExpr>
-                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                            </dxl:HashExprList>
-                            <dxl:Result>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
                               </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="9"/>
+                              </dxl:GroupingColumns>
                               <dxl:ProjList>
+                                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                    <dxl:ValuesList ParamType="aggargs"/>
+                                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                                    <dxl:ValuesList ParamType="aggorder"/>
+                                    <dxl:ValuesList ParamType="aggdistinct"/>
+                                  </dxl:AggFunc>
+                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="c">
                                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                  <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
-                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
-                                <dxl:GroupingColumns>
-                                  <dxl:GroupingColumn ColId="9"/>
-                                </dxl:GroupingColumns>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
-                                      <dxl:ValuesList ParamType="aggargs"/>
-                                      <dxl:ValuesList ParamType="aggdirectargs"/>
-                                      <dxl:ValuesList ParamType="aggorder"/>
-                                      <dxl:ValuesList ParamType="aggdistinct"/>
-                                    </dxl:AggFunc>
-                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="c">
                                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="9" Alias="c">
@@ -482,48 +482,36 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="9" Alias="c">
-                                        <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="6.922002.1.1" TableName="bar">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:RandomMotion>
-                              </dxl:Aggregate>
-                            </dxl:Result>
-                          </dxl:RedistributeMotion>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:GatherMotion>
-                    <dxl:LimitCount>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                    </dxl:LimitCount>
-                    <dxl:LimitOffset>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:LimitOffset>
-                  </dxl:Limit>
-                </dxl:BroadcastMotion>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-          </dxl:Result>
+                                  <dxl:TableDescriptor Mdid="6.922002.1.1" TableName="bar">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:RandomMotion>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                        </dxl:RedistributeMotion>
+                      </dxl:Aggregate>
+                    </dxl:Result>
+                  </dxl:GatherMotion>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
+              </dxl:BroadcastMotion>
+            </dxl:Materialize>
+          </dxl:NestedLoopJoin>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -370,10 +370,10 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10800">
+    <dxl:Plan Id="0" SpaceSize="200">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.001073" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="30170.084331" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="29" Alias="?column?">
@@ -384,301 +384,292 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.001043" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="30170.084301" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="29" Alias="?column?">
-              <dxl:Coalesce TypeMdid="0.20.1.0">
-                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
-                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-              </dxl:Coalesce>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.001040" Rows="2.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="Left">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.001035" Rows="2.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="28" Alias="count">
-                  <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000440" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="e">
-                    <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="28" Alias="count">
-                    <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+              <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000284" Rows="3.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="5172.002531" Rows="3.000000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:ProjList/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="28" Alias="count">
+                      <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:Limit>
+                  <dxl:JoinFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:JoinFilter>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000230" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="28" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                          <dxl:ValuesList ParamType="aggargs"/>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000313" Rows="3.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000247" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="e">
+                            <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000243" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="e">
+                              <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="19" Alias="e">
+                                <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
+                              <dxl:Columns>
+                                <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:Aggregate>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000285" Rows="3.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:Filter/>
+                    <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000229" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000284" Rows="3.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
-                      <dxl:Result>
+                      <dxl:Limit>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000230" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000229" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="9"/>
-                          </dxl:GroupingColumns>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="18" Alias="count">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
-                                <dxl:ValuesList ParamType="aggargs">
-                                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
-                                </dxl:ValuesList>
-                                <dxl:ValuesList ParamType="aggdirectargs"/>
-                                <dxl:ValuesList ParamType="aggorder"/>
-                                <dxl:ValuesList ParamType="aggdistinct"/>
-                              </dxl:AggFunc>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="9" Alias="c">
-                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
+                          <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:SortingColumnList/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="9" Alias="c">
-                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                                <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
+                            <dxl:ProjList/>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashExprList>
-                              <dxl:HashExpr>
-                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                            </dxl:HashExprList>
-                            <dxl:Result>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000225" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="9"/>
+                              </dxl:GroupingColumns>
                               <dxl:ProjList>
+                                <dxl:ProjElem ColId="18" Alias="count">
+                                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                                    <dxl:ValuesList ParamType="aggargs">
+                                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                                    </dxl:ValuesList>
+                                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                                    <dxl:ValuesList ParamType="aggorder"/>
+                                    <dxl:ValuesList ParamType="aggdistinct"/>
+                                  </dxl:AggFunc>
+                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="c">
                                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
-                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000105" Rows="1.000000" Width="12"/>
                                 </dxl:Properties>
-                                <dxl:GroupingColumns>
-                                  <dxl:GroupingColumn ColId="9"/>
-                                </dxl:GroupingColumns>
                                 <dxl:ProjList>
-                                  <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                                    <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
-                                      <dxl:ValuesList ParamType="aggargs"/>
-                                      <dxl:ValuesList ParamType="aggdirectargs"/>
-                                      <dxl:ValuesList ParamType="aggorder"/>
-                                      <dxl:ValuesList ParamType="aggdistinct"/>
-                                    </dxl:AggFunc>
-                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="c">
                                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                                  </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:SortingColumnList/>
+                                <dxl:HashExprList>
+                                  <dxl:HashExpr>
+                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                </dxl:HashExprList>
+                                <dxl:Result>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="9" Alias="c">
                                       <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                                    </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
+                                  <dxl:OneTimeFilter/>
+                                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="12"/>
                                     </dxl:Properties>
+                                    <dxl:GroupingColumns>
+                                      <dxl:GroupingColumn ColId="9"/>
+                                    </dxl:GroupingColumns>
                                     <dxl:ProjList>
+                                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
+                                          <dxl:ValuesList ParamType="aggargs"/>
+                                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                                          <dxl:ValuesList ParamType="aggorder"/>
+                                          <dxl:ValuesList ParamType="aggdistinct"/>
+                                        </dxl:AggFunc>
+                                      </dxl:ProjElem>
                                       <dxl:ProjElem ColId="9" Alias="c">
                                         <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:RandomMotion>
-                              </dxl:Aggregate>
-                            </dxl:Result>
-                          </dxl:RedistributeMotion>
-                        </dxl:Aggregate>
-                      </dxl:Result>
-                    </dxl:GatherMotion>
-                    <dxl:LimitCount>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                    </dxl:LimitCount>
-                    <dxl:LimitOffset>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:LimitOffset>
-                  </dxl:Limit>
-                </dxl:BroadcastMotion>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000084" Rows="1.000000" Width="12"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="19"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="28" Alias="count">
-                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                        <dxl:ValuesList ParamType="aggargs"/>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct"/>
-                      </dxl:AggFunc>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="e">
-                      <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="e">
-                        <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="e">
-                          <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16450.1.1" TableName="jazz">
-                        <dxl:Columns>
-                          <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:Sort>
-                </dxl:Aggregate>
-              </dxl:NestedLoopJoin>
-            </dxl:HashJoin>
-          </dxl:Result>
+                                    <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="9" Alias="c">
+                                          <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="9" Alias="c">
+                                            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="6.16423.1.1" TableName="bar">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:RandomMotion>
+                                  </dxl:Aggregate>
+                                </dxl:Result>
+                              </dxl:RedistributeMotion>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                        </dxl:GatherMotion>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="30170.084298" Rows="1000.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.16396.1.1" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -268,10 +268,16 @@ public:
 	// check if given expression has a count(*)/count(Any) agg
 	static BOOL FHasCountAgg(CExpression *pexpr, CColRef **ppcrCount);
 
-	// check if given expression has count matching the given column, returns the Logical GroupBy Agg above
+	// check if the given column is a count aggregate output reachable from
+	// the given expression, returning the Logical GroupBy Agg producing it;
+	// with fThroughRowPreservingOpsOnly, only traverse operators that cannot
+	// eliminate the aggregate's output row (so a NULL count can only mean
+	// outer-join null-extension over empty aggregation input, which callers
+	// may fold to 0)
 	static BOOL FHasCountAggMatchingColumn(const CExpression *pexpr,
 										   const CColRef *colref,
-										   const CLogicalGbAgg **ppgbAgg);
+										   const CLogicalGbAgg **ppgbAgg,
+										   BOOL fThroughRowPreservingOpsOnly);
 
 	// generate a GbAgg with count(*) and sum(col) over the given expression
 	static CExpression *PexprCountStarAndSum(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CSubqueryHandler.h
@@ -74,6 +74,13 @@ private:
 		//  does subquery project a count expression
 		BOOL m_fProjectCount{false};
 
+		// the subquery returns a count aggregate that sits behind a
+		// row-eliminating operator (filter/limit/join above the aggregate);
+		// outer-join decorrelation cannot represent both count-over-empty
+		// -input = 0 and eliminated-row = NULL, so correlated execution is
+		// required
+		BOOL m_fCountAggBehindRowFilter{false};
+
 		// subquery is used in a value context
 		BOOL m_fValueSubquery{false};
 

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -2050,7 +2050,8 @@ FCountAggMatchingColumn(CExpression *pexprPrjElem, const CColRef *colref)
 BOOL
 CUtils::FHasCountAggMatchingColumn(const CExpression *pexpr,
 								   const CColRef *colref,
-								   const CLogicalGbAgg **ppgbAgg)
+								   const CLogicalGbAgg **ppgbAgg,
+								   BOOL fThroughRowPreservingOpsOnly)
 {
 	COperator *pop = pexpr->Pop();
 	// base case, we have a logical agg operator
@@ -2070,18 +2071,33 @@ CUtils::FHasCountAggMatchingColumn(const CExpression *pexpr,
 				return true;
 			}
 		}
+		return false;
 	}
-	// recurse
-	else
+
+	// With fThroughRowPreservingOpsOnly, recurse only through operators that
+	// neither eliminate nor null-extend the aggregate's output row.  Callers
+	// use such a match to substitute COALESCE(count, 0) for the count column,
+	// which is only valid when a NULL count can arise solely from outer-join
+	// null-extension over an empty aggregation input.  A row-eliminating
+	// operator (e.g. a Select derived from a HAVING clause, a Limit, or a
+	// join) between the count aggregate and the subquery output produces
+	// genuine "no row" NULL semantics that must not be folded to 0.
+	if (fThroughRowPreservingOpsOnly &&
+		COperator::EopLogicalProject != pop->Eopid() &&
+		COperator::EopLogicalSequenceProject != pop->Eopid())
 	{
-		const ULONG arity = pexpr->Arity();
-		for (ULONG ul = 0; ul < arity; ul++)
+		return false;
+	}
+
+	// recurse
+	const ULONG arity = pexpr->Arity();
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		const CExpression *pexprChild = (*pexpr)[ul];
+		if (FHasCountAggMatchingColumn(pexprChild, colref, ppgbAgg,
+									   fThroughRowPreservingOpsOnly))
 		{
-			const CExpression *pexprChild = (*pexpr)[ul];
-			if (FHasCountAggMatchingColumn(pexprChild, colref, ppgbAgg))
-			{
-				return true;
-			}
+			return true;
 		}
 	}
 	return false;

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -324,7 +324,8 @@ CSubqueryHandler::SSubqueryDesc::SetCorrelatedExecution()
 		m_returns_set ||  // subquery produces > 1 rows, we need correlated execution to check for cardinality at runtime
 		m_fHasVolatileFunctions ||	// volatile functions cannot be decorrelated
 		(m_fHasCountAgg &&
-		 m_fHasSkipLevelCorrelations);	// count() with skip-level correlations cannot be decorrelated due to their NULL semantics
+		 m_fHasSkipLevelCorrelations) ||  // count() with skip-level correlations cannot be decorrelated due to their NULL semantics
+		m_fCountAggBehindRowFilter;	 // count() behind a row-eliminating operator cannot be decorrelated due to their NULL semantics
 }
 
 
@@ -373,6 +374,25 @@ CSubqueryHandler::Psd(CMemoryPool *mp, CExpression *pexprSubquery,
 	{
 		psd->m_fProjectCount =
 			FProjectCountSubquery(pexprSubquery, psd->m_pcrCountAgg);
+	}
+
+	if (psd->m_fHasCountAgg && psd->m_fHasOuterRefs)
+	{
+		// If the subquery output is a count aggregate that a row-eliminating
+		// operator (filter/limit/join) can hide, outer-apply decorrelation
+		// cannot distinguish "aggregate row eliminated" (NULL) from
+		// "aggregate over empty input" (0): a single COALESCE at the
+		// subquery output is wrong for one of the two.  Require correlated
+		// execution for such subqueries.
+		const CLogicalGbAgg *pgbAggAnywhere = nullptr;
+		const CLogicalGbAgg *pgbAggRowPreserving = nullptr;
+		psd->m_fCountAggBehindRowFilter =
+			CUtils::FHasCountAggMatchingColumn(
+				pexprInner, pcrSubquery, &pgbAggAnywhere,
+				false /*fThroughRowPreservingOpsOnly*/) &&
+			!CUtils::FHasCountAggMatchingColumn(
+				pexprInner, pcrSubquery, &pgbAggRowPreserving,
+				true /*fThroughRowPreservingOpsOnly*/);
 	}
 
 	// set flag for using subquery in a value context
@@ -735,7 +755,8 @@ CSubqueryHandler::FCreateOuterApplyForScalarSubquery(
 
 	const CLogicalGbAgg *pgbAgg = nullptr;
 	BOOL fHasCountAggMatchingColumn = CUtils::FHasCountAggMatchingColumn(
-		(*pexprSubquery)[0], colref, &pgbAgg);
+		(*pexprSubquery)[0], colref, &pgbAgg,
+		true /*fThroughRowPreservingOpsOnly*/);
 
 	if (!fHasCountAggMatchingColumn)
 	{

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5644,7 +5644,15 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NULL != havingQual)
 	{
 		queryNew->havingQual = flatten_join_alias_vars(queryNew, havingQual);
-		pfree(havingQual);
+		/*
+		 * flatten_join_alias_vars returns the input node itself, not a copy,
+		 * when the node is a Var that does not reference a JOIN output (see
+		 * flatten_join_alias_vars_mutator), e.g. a HAVING clause that is a
+		 * bare outer-reference boolean column.  Freeing the old qual would
+		 * then leave queryNew->havingQual pointing to freed memory.
+		 */
+		if (queryNew->havingQual != havingQual)
+			pfree(havingQual);
 	}
 
 	List *scatterClause = queryNew->scatterClause;
@@ -5658,7 +5666,9 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NULL != limitOffset)
 	{
 		queryNew->limitOffset = flatten_join_alias_vars(queryNew, limitOffset);
-		pfree(limitOffset);
+		/* see the havingQual case above */
+		if (queryNew->limitOffset != limitOffset)
+			pfree(limitOffset);
 	}
 
 	List *windowClause = queryNew->windowClause;
@@ -5685,7 +5695,9 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NULL != limitCount)
 	{
 		queryNew->limitCount = flatten_join_alias_vars(queryNew, limitCount);
-		pfree(limitCount);
+		/* see the havingQual case above */
+		if (queryNew->limitCount != limitCount)
+			pfree(limitCount);
 	}
 
     return queryNew;

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -613,3 +613,61 @@ select * from t1_15793 cross join t2_15793 where not ((t1_15793.c0)+(t1_15793.c0
 
 drop table t1_15793;
 drop table t2_15793;
+--
+-- Test NULL vs 0 semantics of scalar subqueries over count() aggregates.
+--
+-- A scalar subquery yields NULL when a row-eliminating operator (a
+-- correlated filter above the aggregate, or a join) eliminates the
+-- aggregate's output row; it yields 0 only when the count aggregate itself
+-- runs over empty input. ORCA used to wrap such subquery outputs in
+-- COALESCE(count, 0) whenever it could find a count() aggregate anywhere
+-- below, resurrecting eliminated rows as 0.
+--
+-- correlated filter above the aggregate: eliminated row must be NULL
+select v.c, (select cnt from (select count(*) cnt from generate_series(1,4)) s
+             where v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+ c | cnt 
+---+-----
+ f |    
+ t |   4
+(2 rows)
+
+-- same, phrased through HAVING over an empty grouping set
+select v.c, (select count(*) from generate_series(1,4) group by () having v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+ c | cnt 
+---+-----
+ f |    
+ t |   4
+(2 rows)
+
+-- control: correlated filter below the aggregate still yields count = 0
+select v.x, (select count(*) from generate_series(1,4) g where g < v.x) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |   0
+ 3 |   2
+(2 rows)
+
+-- join above the aggregate, join input non-empty: count over empty input is 0
+select v.x, (select cnt from (select 1 z from generate_series(1,1) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |   0
+ 3 |   2
+(2 rows)
+
+-- join above the aggregate, join input empty: subquery must be NULL
+select v.x, (select cnt from (select 1 z from generate_series(1,0) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |    
+ 3 |    
+(2 rows)
+

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -608,3 +608,61 @@ select * from t1_15793 cross join t2_15793 where not ((t1_15793.c0)+(t1_15793.c0
 
 drop table t1_15793;
 drop table t2_15793;
+--
+-- Test NULL vs 0 semantics of scalar subqueries over count() aggregates.
+--
+-- A scalar subquery yields NULL when a row-eliminating operator (a
+-- correlated filter above the aggregate, or a join) eliminates the
+-- aggregate's output row; it yields 0 only when the count aggregate itself
+-- runs over empty input. ORCA used to wrap such subquery outputs in
+-- COALESCE(count, 0) whenever it could find a count() aggregate anywhere
+-- below, resurrecting eliminated rows as 0.
+--
+-- correlated filter above the aggregate: eliminated row must be NULL
+select v.c, (select cnt from (select count(*) cnt from generate_series(1,4)) s
+             where v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+ c | cnt 
+---+-----
+ f |    
+ t |   4
+(2 rows)
+
+-- same, phrased through HAVING over an empty grouping set
+select v.c, (select count(*) from generate_series(1,4) group by () having v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+ c | cnt 
+---+-----
+ f |    
+ t |   4
+(2 rows)
+
+-- control: correlated filter below the aggregate still yields count = 0
+select v.x, (select count(*) from generate_series(1,4) g where g < v.x) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |   0
+ 3 |   2
+(2 rows)
+
+-- join above the aggregate, join input non-empty: count over empty input is 0
+select v.x, (select cnt from (select 1 z from generate_series(1,1) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |   0
+ 3 |   2
+(2 rows)
+
+-- join above the aggregate, join input empty: subquery must be NULL
+select v.x, (select cnt from (select 1 z from generate_series(1,0) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;
+ x | cnt 
+---+-----
+ 0 |    
+ 3 |    
+(2 rows)
+

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -1002,8 +1002,6 @@ explain (costs off)
 
 select v.c, (select count(*) from gstest2 group by () having v.c)
   from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
  c | count 
 ---+-------
  f |      
@@ -1013,23 +1011,21 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 explain (costs off)
   select v.c, (select count(*) from gstest2 group by () having v.c)
     from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Sort
-   Sort Key: "*VALUES*".column1
-   ->  Values Scan on "*VALUES*"
-         SubPlan 1
-           ->  Aggregate
-                 Group Key: ()
-                 Filter: "*VALUES*".column1
-                 ->  Result
-                       One-Time Filter: "*VALUES*".column1
-                       ->  Materialize
-                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Result
+   ->  Sort
+         Sort Key: "Values".column1
+         ->  Values Scan on "Values"
+   SubPlan 1
+     ->  Result
+           One-Time Filter: "Values".column1
+           ->  Finalize Aggregate
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                             ->  Partial Aggregate
                                    ->  Seq Scan on gstest2
- Optimizer: Postgres query optimizer
+ Optimizer: GPORCA
 (13 rows)
 
 -- HAVING with GROUPING queries

--- a/src/test/regress/expected/orca_groupingsets_fallbacks.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks.out
@@ -78,7 +78,8 @@ select d from gstest2 group by grouping sets ((a,b), (a));
  1
 (4 rows)
 
--- Orca falls back due to HAVING clause with outer references
+-- Orca used to fall back here due to the HAVING clause with outer references,
+-- a spurious fallback caused by a use-after-free in query normalization
 select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
  c | count 
 ---+-------

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -86,10 +86,9 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
  1
 (4 rows)
 
--- Orca falls back due to HAVING clause with outer references
+-- Orca used to fall back here due to the HAVING clause with outer references,
+-- a spurious fallback caused by a use-after-free in query normalization
 select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
  c | count 
 ---+-------
  f |      

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -891,24 +891,23 @@ select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t
 
 -- subquery contains a HAVING clause
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), '0'::bigint))
-         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-               Hash Cond: (t0.t = t1.t)
-               ->  Seq Scan on csq_pullup t0  (cost=0.00..431.00 rows=1 width=17)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                     ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                           Filter: ((count()) < 10)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
-                                 Group Key: t1.t
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: t1.t
-                                       ->  Seq Scan on csq_pullup t1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(15 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6465.25 rows=1 width=17)
+   ->  Result  (cost=0.00..6465.25 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup t0  (cost=0.00..6465.24 rows=334 width=36)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                 Filter: ((count()) < 10)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             Filter: (t0.t = t1.t)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Seq Scan on csq_pullup t1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: GPORCA
+(14 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
   t  | n | i |  v  

--- a/src/test/regress/sql/bfv_subquery.sql
+++ b/src/test/regress/sql/bfv_subquery.sql
@@ -368,3 +368,31 @@ select * from t1_15793 cross join t2_15793 where not ((t1_15793.c0)+(t1_15793.c0
 
 drop table t1_15793;
 drop table t2_15793;
+--
+-- Test NULL vs 0 semantics of scalar subqueries over count() aggregates.
+--
+-- A scalar subquery yields NULL when a row-eliminating operator (a
+-- correlated filter above the aggregate, or a join) eliminates the
+-- aggregate's output row; it yields 0 only when the count aggregate itself
+-- runs over empty input. ORCA used to wrap such subquery outputs in
+-- COALESCE(count, 0) whenever it could find a count() aggregate anywhere
+-- below, resurrecting eliminated rows as 0.
+--
+-- correlated filter above the aggregate: eliminated row must be NULL
+select v.c, (select cnt from (select count(*) cnt from generate_series(1,4)) s
+             where v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+-- same, phrased through HAVING over an empty grouping set
+select v.c, (select count(*) from generate_series(1,4) group by () having v.c) as cnt
+from (values (false),(true)) v(c) order by 1;
+-- control: correlated filter below the aggregate still yields count = 0
+select v.x, (select count(*) from generate_series(1,4) g where g < v.x) as cnt
+from (values (0),(3)) v(x) order by 1;
+-- join above the aggregate, join input non-empty: count over empty input is 0
+select v.x, (select cnt from (select 1 z from generate_series(1,1) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;
+-- join above the aggregate, join input empty: subquery must be NULL
+select v.x, (select cnt from (select 1 z from generate_series(1,0) limit 1) t,
+             (select count(*) cnt from generate_series(1,4) g where g < v.x) y) as cnt
+from (values (0),(3)) v(x) order by 1;

--- a/src/test/regress/sql/orca_groupingsets_fallbacks.sql
+++ b/src/test/regress/sql/orca_groupingsets_fallbacks.sql
@@ -34,7 +34,8 @@ insert into gstest2 values (1, 1, 1, 1, 1);
 insert into gstest2 values (2, 2, 2, 2, 1);
 select d from gstest2 group by grouping sets ((a,b), (a));
 
--- Orca falls back due to HAVING clause with outer references
+-- Orca used to fall back here due to the HAVING clause with outer references,
+-- a spurious fallback caused by a use-after-free in query normalization
 select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
 
 -- Orca falls back due to grouping function with multiple arguments


### PR DESCRIPTION
A scalar subquery returns NULL when a row-eliminating operator (a correlated filter above the aggregate, or a join) eliminates the aggregate's output row; it returns 0 only when the count() aggregate itself ran over empty input.

CSubqueryHandler wrapped the subquery output in COALESCE(count, 0) whenever CUtils::FHasCountAggMatchingColumn() could find a matching count() aggregate anywhere below the subquery root -- the recursion walked through filters, limits and joins, so an eliminated aggregate row was resurrected as 0:

    select v.c, (select cnt
                 from (select count(*) cnt from generate_series(1,4)) s
                 where v.c)
    from (values (false),(true)) v(c);

returned (f,0) instead of (f,NULL) with optimizer=on.

Fix by restricting the coalesce decision to count aggregates reachable through row-preserving operators only, and by requiring correlated execution when the count output sits behind a row-eliminating operator: a single COALESCE at the subquery output cannot represent both "aggregate row eliminated" (NULL) and "aggregate over empty input" (0) in the decorrelated form. Regenerate the two affected minidumps and add regression coverage to bfv_subquery.