### PR TITLE
Fix planner crash on LATERAL over UNION ALL: keep child parameterization in Append's General-child wrapper

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1911,13 +1911,24 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 												  NULL,		/* outer_relids */
 												  NULL);	/* nullable_relids */
 
+				/*
+				 * Keep the subpath's parameterization (need_param = true).
+				 * When the appendrel has LATERAL references, every child is
+				 * parameterized by the lateral rels (see build_simple_rel),
+				 * and create_append_path requires all children to share the
+				 * same parameterization; dropping param_info here tripped
+				 * that Assert for e.g.
+				 *   ... LEFT JOIN LATERAL (SELECT outer.col FROM t UNION ALL
+				 *       (VALUES (1))) ON true
+				 * where this projection wraps the General-locus VALUES arm.
+				 */
 				subpath = (Path *) create_projection_path_with_quals(
 					root,
 					subpath->parent,
 					subpath,
 					subpath->pathtarget,
 					list_make1(restrict_info),
-					false);
+					true);
 
 				/*
 				 * We use the skill of Result plannode with one time filter

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -120,3 +120,20 @@ from gp_dist_random('gp_distribution_policy') where localoid = 't2_17271'::regcl
 drop table t_17271;
 drop table t1_17271;
 drop table t2_17271;
+-- Append over a General-locus child (the VALUES arm) mixed with a distributed
+-- child, where the appendrel carries LATERAL parameterization: the projection
+-- path that restricts the General child to a single segment used to drop the
+-- child's param_info, tripping create_append_path's assertion that all Append
+-- children share the same parameterization (a crash on assert-enabled builds).
+-- The planner still cannot devise a plan for this query shape (outer Var in
+-- the LATERAL's target list over a distributed table), so the query must fail
+-- with the ordinary "could not devise a query plan" error rather than crash.
+create table t1_lateral_unionall (a int, b int) distributed by (a);
+create table t2_lateral_unionall (a int, b int) distributed by (a);
+select * from t1_lateral_unionall t1
+left join lateral
+  (select t1.b from t2_lateral_unionall t2 union all (values(1))) s
+on true limit 1;
+ERROR:  could not devise a query plan for the given query (pathnode.c:275)
+drop table t1_lateral_unionall;
+drop table t2_lateral_unionall;

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -77,3 +77,20 @@ from gp_dist_random('gp_distribution_policy') where localoid = 't2_17271'::regcl
 drop table t_17271;
 drop table t1_17271;
 drop table t2_17271;
+
+-- Append over a General-locus child (the VALUES arm) mixed with a distributed
+-- child, where the appendrel carries LATERAL parameterization: the projection
+-- path that restricts the General child to a single segment used to drop the
+-- child's param_info, tripping create_append_path's assertion that all Append
+-- children share the same parameterization (a crash on assert-enabled builds).
+-- The planner still cannot devise a plan for this query shape (outer Var in
+-- the LATERAL's target list over a distributed table), so the query must fail
+-- with the ordinary "could not devise a query plan" error rather than crash.
+create table t1_lateral_unionall (a int, b int) distributed by (a);
+create table t2_lateral_unionall (a int, b int) distributed by (a);
+select * from t1_lateral_unionall t1
+left join lateral
+  (select t1.b from t2_lateral_unionall t2 union all (values(1))) s
+on true limit 1;
+drop table t1_lateral_unionall;
+drop table t2_lateral_unionall;


### PR DESCRIPTION
Fixes #195

## What

Planning a `LEFT JOIN LATERAL` whose body is a `UNION ALL` mixing a distributed-table arm with a `VALUES` arm, with an outer-query column in the target list, crashes assert-enabled builds (backend abort + postmaster reset):

```sql
select * from t1
left join lateral
  (select t1.b from t2 union all (values(1))) s
on true limit 1;
```

```
FailedAssertion("!(bms_equal(((subpath)->param_info ? (subpath)->param_info->ppi_req_outer
                 : (Relids) ((void *)0)), required_outer))", pathnode.c:1428)

#0  ExceptionalCondition (...) at assert.c:37
#1  create_append_path (root=..., rel=..., subpaths=..., required_outer={t1}, ...) at pathnode.c:1428
#2  add_paths_to_append_rel (...) at allpaths.c:1936
#3  set_append_rel_pathlist (...) at allpaths.c:1536
#4  set_rel_pathlist (...) at allpaths.c:697
#5  set_base_rel_pathlists / make_one_rel / query_planner / grouping_planner ...
```

At the failing frame the table arm is a `T_SeqScan` (Hashed) with `param_info = {t1}`, while the VALUES arm is the one-time-filter `T_Result` wrapper (Strewn) with `param_info = NULL` — the invariant violation.

## Root cause

The appendrel children all inherit the lateral parameterization `{t1}` (`build_simple_rel` copies the parent's `lateral_relids`). Inside `create_append_path`, `set_append_path_locus()` wraps the General-locus VALUES arm in the `gp_execution_segment()` one-time-filter projection (introduced by 75c4769a00 "Improve Append plan when General children exist.") with `need_param = false`, which silently drops the child's `param_info` and breaks `create_append_path`'s all-children-share-one-parameterization invariant.

## Fix

Pass `need_param = true` at that call site so the wrapper keeps the subpath's `param_info`. For non-lateral children `param_info` is NULL either way, so existing plans are unchanged.

After the fix the query fails with the planner's ordinary `could not devise a query plan` error instead of crashing — same as the sibling shapes today (e.g. `... left join lateral (select t1.b from t2) s on true`). Actually planning an outer Var in a LATERAL target list over a distributed table is a separate planner gap, out of scope here (see #195).

## Tests

New `misc_jiras` case with the repro query, verified to reproduce the FailedAssertion on the unfixed binary and to pass on the fixed one, under both the Postgres planner and ORCA (which falls back), on a 3-segment gpdemo cluster. The snapshotted error's `(file:line)` suffix is normalized by the existing `init_file` rule.

Also verified on the fixed build: mixed General+Hashed `UNION ALL` still produces the one-time-filter plan and returns correct rows; qual-correlated LATERAL shapes (with and without setop) plan and execute unchanged.
