### PR TITLE
Fix gp_get_endpoints() cross-database heap overrun

### DIFF
--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -334,10 +334,15 @@ gp_get_endpoints(PG_FUNCTION_ARGS)
 				const		Endpoint *entry = get_endpointdesc_by_index(i);
 
 				/*
-				 * Only allow current user to get own endpoints. Or let
-				 * superuser get all endpoints.
+				 * Only report endpoints that live in the caller's database, and
+				 * only the current user's (or all, for superuser).  This predicate
+				 * MUST match the counting loop above: without the databaseID check
+				 * this loop writes more EndpointInfo entries than were counted into
+				 * cnt, overrunning the palloc'd all_info->infos buffer whenever a
+				 * coordinator endpoint exists in another database.
 				 */
-				if (!entry->empty && (superuser() || entry->userID == GetUserId()))
+				if (!entry->empty && entry->databaseID == MyDatabaseId &&
+					(superuser() || entry->userID == GetUserId()))
 				{
 					EndpointInfo *info = &all_info->infos[idx];
 

--- a/src/test/isolation2/expected/parallel_retrieve_cursor/cross_db_endpoints.out
+++ b/src/test/isolation2/expected/parallel_retrieve_cursor/cross_db_endpoints.out
@@ -1,0 +1,55 @@
+-- @Description gp_get_endpoints() must report only the endpoints that live in
+-- the caller's database.  The coordinator fill loop sizes its result buffer
+-- from a databaseID-filtered count of endpoints, so it must apply the same
+-- databaseID filter when it populates the buffer.  Without it, a
+-- coordinator-resident PARALLEL RETRIEVE CURSOR endpoint belonging to another
+-- database is written past the end of the buffer -> heap corruption and a
+-- coordinator crash whenever endpoints exist in more than one database.
+--
+CREATE DATABASE pce_db_a;
+CREATE DATABASE
+CREATE DATABASE pce_db_b;
+CREATE DATABASE
+
+1:@db_name pce_db_a: CREATE TABLE t (id int) DISTRIBUTED BY (id);
+CREATE TABLE
+2:@db_name pce_db_b: CREATE TABLE t (id int) DISTRIBUTED BY (id);
+CREATE TABLE
+
+-- A gathered plan (ORDER BY) puts the endpoint on the coordinator
+-- (gp_segment_id = -1).  Keep the declaring transaction open so the endpoint
+-- stays live in the cluster-wide shared endpoint array.
+1:@db_name pce_db_a: BEGIN;
+BEGIN
+1:@db_name pce_db_a: DECLARE ca PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t ORDER BY id;
+DECLARE PARALLEL RETRIEVE CURSOR
+2:@db_name pce_db_b: BEGIN;
+BEGIN
+2:@db_name pce_db_b: DECLARE cb PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t ORDER BY id;
+DECLARE PARALLEL RETRIEVE CURSOR
+
+-- Each database must see exactly its own coordinator endpoint and never the
+-- other database's.  Before the fix, either of these calls overran the result
+-- buffer and crashed the coordinator.
+1:@db_name pce_db_a: SELECT gp_segment_id, cursorname, state FROM gp_get_endpoints() ORDER BY cursorname;
+ gp_segment_id | cursorname | state 
+---------------+------------+-------
+ -1            | ca         | READY 
+(1 row)
+2:@db_name pce_db_b: SELECT gp_segment_id, cursorname, state FROM gp_get_endpoints() ORDER BY cursorname;
+ gp_segment_id | cursorname | state 
+---------------+------------+-------
+ -1            | cb         | READY 
+(1 row)
+
+1:@db_name pce_db_a: ROLLBACK;
+ROLLBACK
+2:@db_name pce_db_b: ROLLBACK;
+ROLLBACK
+1q: ... <quitting>
+2q: ... <quitting>
+
+DROP DATABASE pce_db_a;
+DROP DATABASE
+DROP DATABASE pce_db_b;
+DROP DATABASE

--- a/src/test/isolation2/parallel_retrieve_cursor_schedule
+++ b/src/test/isolation2/parallel_retrieve_cursor_schedule
@@ -14,3 +14,4 @@ test: parallel_retrieve_cursor/security
 test: parallel_retrieve_cursor/privilege
 test: parallel_retrieve_cursor/concurrency
 test: parallel_retrieve_cursor/unset
+test: parallel_retrieve_cursor/cross_db_endpoints

--- a/src/test/isolation2/sql/parallel_retrieve_cursor/cross_db_endpoints.sql
+++ b/src/test/isolation2/sql/parallel_retrieve_cursor/cross_db_endpoints.sql
@@ -1,0 +1,35 @@
+-- @Description gp_get_endpoints() must report only the endpoints that live in
+-- the caller's database.  The coordinator fill loop sizes its result buffer
+-- from a databaseID-filtered count of endpoints, so it must apply the same
+-- databaseID filter when it populates the buffer.  Without it, a
+-- coordinator-resident PARALLEL RETRIEVE CURSOR endpoint belonging to another
+-- database is written past the end of the buffer -> heap corruption and a
+-- coordinator crash whenever endpoints exist in more than one database.
+--
+CREATE DATABASE pce_db_a;
+CREATE DATABASE pce_db_b;
+
+1:@db_name pce_db_a: CREATE TABLE t (id int) DISTRIBUTED BY (id);
+2:@db_name pce_db_b: CREATE TABLE t (id int) DISTRIBUTED BY (id);
+
+-- A gathered plan (ORDER BY) puts the endpoint on the coordinator
+-- (gp_segment_id = -1).  Keep the declaring transaction open so the endpoint
+-- stays live in the cluster-wide shared endpoint array.
+1:@db_name pce_db_a: BEGIN;
+1:@db_name pce_db_a: DECLARE ca PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t ORDER BY id;
+2:@db_name pce_db_b: BEGIN;
+2:@db_name pce_db_b: DECLARE cb PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t ORDER BY id;
+
+-- Each database must see exactly its own coordinator endpoint and never the
+-- other database's.  Before the fix, either of these calls overran the result
+-- buffer and crashed the coordinator.
+1:@db_name pce_db_a: SELECT gp_segment_id, cursorname, state FROM gp_get_endpoints() ORDER BY cursorname;
+2:@db_name pce_db_b: SELECT gp_segment_id, cursorname, state FROM gp_get_endpoints() ORDER BY cursorname;
+
+1:@db_name pce_db_a: ROLLBACK;
+2:@db_name pce_db_b: ROLLBACK;
+1q:
+2q:
+
+DROP DATABASE pce_db_a;
+DROP DATABASE pce_db_b;


### PR DESCRIPTION
### Problem
gp_get_endpoints() counts the coordinator-resident parallel-retrieve-cursor endpoints belonging to the caller's database (databaseID == MyDatabaseId) and palloc's a result buffer for exactly that many EndpointInfo structs.  

The loop that then populates the buffer omitted the databaseID predicate, so when coordinator endpoints exist in another database it matched more entries than were counted and wrote them past the end of the buffer.

The out-of-bounds writes corrupt the heap; on a checked build glibc aborts the coordinator with 'malloc(): invalid next size', crashing the whole cluster. Any gp_get_endpoints() call made while coordinator endpoints span more than one database triggers it, from either database.

### Fix
Add the missing 'entry->databaseID == MyDatabaseId' check so the populate loop matches the counting loop, and add an isolation2 regression test that opens a coordinator endpoint in each of two databases and verifies each database sees only its own endpoint (and no longer crashes).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
