### PR TITLE
Veto direct dispatch for Strewn-locus Append/MergeAppend children

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1271,9 +1271,23 @@ create_append_plan(PlannerInfo *root, AppendPath *best_path, int flags)
 		 * this child's rows on every segment the sibling's target
 		 * excludes.  Veto direct dispatch here, from the Path's own
 		 * locus, before that ambiguity has a chance to arise downstream.
+		 *
+		 * Exception: set_append_path_locus() also tags a pinned General/
+		 * SegmentGeneral child (the "One-Time Filter:
+		 * gp_execution_segment() = N" trick, see the direct_dispath_
+		 * contentIds comment above) as Strewn -- that child is NOT an
+		 * unconstrained "runs everywhere" leaf, it is already confined to
+		 * one specific, known segment, and create_plan_recurse() (via
+		 * create_gating_plan()'s tail above) already merged that exact
+		 * content id into this slice's direct-dispatch info. Blanket-
+		 * vetoing here would clobber that correct, already-computed
+		 * narrowing, so skip the veto whenever the Path recorded a
+		 * specific pin.
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
-			CdbPathLocus_IsStrewn(subpath->locus))
+			CdbPathLocus_IsStrewn(subpath->locus) &&
+			!(IsA(subpath, ProjectionPath) &&
+			  ((ProjectionPath *) subpath)->direct_dispath_contentIds != NIL))
 		{
 			DirectDispatchInfo dispatchInfo;
 
@@ -1490,10 +1504,14 @@ create_merge_append_plan(PlannerInfo *root, MergeAppendPath *best_path,
 		 * MergeAppend arises here exactly like an Append does -- from a
 		 * UNION ALL whose branches happen to already be sorted (or
 		 * trivially sorted, as a single-row Result is) -- so it needs the
-		 * same veto.
+		 * same veto, with the same exception for an already-pinned
+		 * General/SegmentGeneral child (see the comment in
+		 * create_append_plan()).
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
-			CdbPathLocus_IsStrewn(subpath->locus))
+			CdbPathLocus_IsStrewn(subpath->locus) &&
+			!(IsA(subpath, ProjectionPath) &&
+			  ((ProjectionPath *) subpath)->direct_dispath_contentIds != NIL))
 		{
 			DirectDispatchInfo dispatchInfo;
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1255,6 +1255,36 @@ create_append_plan(PlannerInfo *root, AppendPath *best_path, int flags)
 		subplan = create_plan_recurse(root, subpath, CP_EXACT_TLIST);
 
 		/*
+		 * A Strewn-locus child (e.g. gp_dist_random(...), which
+		 * CdbPathLocus_MakeStrewn()'s callers use precisely because there
+		 * is no known function tying rows to segments) must run on every
+		 * segment; there is no qual-based narrowing that could make it
+		 * safe to skip any of them.  But once such a child's plan is
+		 * built, its shape can collapse to a bare Result or a plain
+		 * SubqueryScan (e.g. a FROM-less view's contents get
+		 * constant-folded away), and
+		 * DirectDispatchUpdateContentIdsFromPlan()'s per-node-type walker
+		 * has no way to tell that collapsed shape apart from a harmless
+		 * one -- it silently contributes "no change" for both.  That
+		 * silence lets a sibling's correctly-computed narrow target win
+		 * the whole Append's direct-dispatch decision, silently dropping
+		 * this child's rows on every segment the sibling's target
+		 * excludes.  Veto direct dispatch here, from the Path's own
+		 * locus, before that ambiguity has a chance to arise downstream.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
+			CdbPathLocus_IsStrewn(subpath->locus))
+		{
+			DirectDispatchInfo dispatchInfo;
+
+			dispatchInfo.isDirectDispatch = false;
+			dispatchInfo.contentIds = NIL;
+			dispatchInfo.haveProcessedAnyCalculations = true;
+
+			MergeDirectDispatchCalculationInfo(&root->curSlice->directDispatch, &dispatchInfo);
+		}
+
+		/*
 		 * For ordered Appends, we must insert a Sort node if subplan isn't
 		 * sufficiently ordered.
 		 */
@@ -1450,6 +1480,29 @@ create_merge_append_plan(PlannerInfo *root, MergeAppendPath *best_path,
 		/* Build the child plan */
 		/* Must insist that all children return the same tlist */
 		subplan = create_plan_recurse(root, subpath, CP_EXACT_TLIST);
+
+		/*
+		 * Same reasoning as the identical check in create_append_plan() --
+		 * a Strewn-locus child must run on every segment and can collapse
+		 * to a plan shape DirectDispatchUpdateContentIdsFromPlan() can't
+		 * distinguish from a harmless one, letting a sibling's narrower
+		 * target win the whole MergeAppend's direct-dispatch decision.  A
+		 * MergeAppend arises here exactly like an Append does -- from a
+		 * UNION ALL whose branches happen to already be sorted (or
+		 * trivially sorted, as a single-row Result is) -- so it needs the
+		 * same veto.
+		 */
+		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
+			CdbPathLocus_IsStrewn(subpath->locus))
+		{
+			DirectDispatchInfo dispatchInfo;
+
+			dispatchInfo.isDirectDispatch = false;
+			dispatchInfo.contentIds = NIL;
+			dispatchInfo.haveProcessedAnyCalculations = true;
+
+			MergeDirectDispatchCalculationInfo(&root->curSlice->directDispatch, &dispatchInfo);
+		}
 
 		/* Compute sort column info, and adjust subplan's tlist as needed */
 		subplan = prepare_sort_from_pathkeys(subplan, pathkeys,

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -1691,6 +1691,92 @@ explain select * from t_14887 where a = 'a'::text;
  Optimizer: Postgres query optimizer
 (9 rows)
 
+-- A UNION ALL arm that gp_dist_random() forces to run on every segment
+-- (planned as a silent SubqueryScan/Result -- a "Strewn" data source) must
+-- not have its own dispatch requirement discarded just because a sibling
+-- arm narrows the slice to one segment.  The narrowing arm's content-id set
+-- used to win the merge and the Strewn arm's rows were silently dropped on
+-- the other segments.
+create table t_913(a int) distributed by (a);
+insert into t_913 values (100);
+create view v_913_fromless as select 1 as x;
+explain (costs off)
+select a from t_913 where a = 100
+union all
+select x from gp_dist_random('v_913_fromless');
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on t_913
+               Filter: (a = 100)
+         ->  Result
+ Optimizer: Postgres-based planner
+(6 rows)
+
+select * from (
+  select a from t_913 where a = 100
+  union all
+  select x from gp_dist_random('v_913_fromless')
+) s order by 1;
+  a  
+-----
+   1
+   1
+   1
+ 100
+(4 rows)
+
+drop view v_913_fromless;
+drop table t_913;
+-- The MergeAppend variant of the same bug: a UNION ALL whose branches are
+-- each independently sortable (an inner ORDER BY, plus a trivially-sorted
+-- single-row Strewn arm) makes the planner choose a MergeAppend instead of
+-- a plain Append, and create_merge_append_plan() needs the identical
+-- Strewn-locus veto create_append_plan() has: otherwise the narrowing
+-- sibling's target still wins the whole slice's direct dispatch and the
+-- Strewn arm's rows are silently dropped on the excluded segments.
+create table t_913b(a int, b int) distributed by (a);
+insert into t_913b select 100, i from generate_series(1,1000) i;
+create view v_913b_fromless as select 1 as x;
+explain (costs off)
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Limit
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: t_913b.b
+         ->  Limit
+               ->  Merge Append
+                     Sort Key: t_913b.b
+                     ->  Sort
+                           Sort Key: t_913b.b
+                           ->  Seq Scan on t_913b
+                                 Filter: (a = 100)
+                     ->  Sort
+                           Sort Key: (1)
+                           ->  Result
+ Optimizer: Postgres-based planner
+(14 rows)
+
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+ b 
+---
+ 1
+ 1
+ 1
+ 1
+ 2
+(5 rows)
+
+drop view v_913b_fromless;
+drop table t_913b;
 begin;
 drop table if exists direct_test;
 drop table if exists direct_test_two_column;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -1715,6 +1715,92 @@ explain select * from t_14887 where a = 'a'::text;
  Optimizer: Postgres query optimizer
 (9 rows)
 
+-- A UNION ALL arm that gp_dist_random() forces to run on every segment
+-- (planned as a silent SubqueryScan/Result -- a "Strewn" data source) must
+-- not have its own dispatch requirement discarded just because a sibling
+-- arm narrows the slice to one segment.  The narrowing arm's content-id set
+-- used to win the merge and the Strewn arm's rows were silently dropped on
+-- the other segments.
+create table t_913(a int) distributed by (a);
+insert into t_913 values (100);
+create view v_913_fromless as select 1 as x;
+explain (costs off)
+select a from t_913 where a = 100
+union all
+select x from gp_dist_random('v_913_fromless');
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on t_913
+               Filter: (a = 100)
+         ->  Result
+ Optimizer: Postgres-based planner
+(6 rows)
+
+select * from (
+  select a from t_913 where a = 100
+  union all
+  select x from gp_dist_random('v_913_fromless')
+) s order by 1;
+  a  
+-----
+   1
+   1
+   1
+ 100
+(4 rows)
+
+drop view v_913_fromless;
+drop table t_913;
+-- The MergeAppend variant of the same bug: a UNION ALL whose branches are
+-- each independently sortable (an inner ORDER BY, plus a trivially-sorted
+-- single-row Strewn arm) makes the planner choose a MergeAppend instead of
+-- a plain Append, and create_merge_append_plan() needs the identical
+-- Strewn-locus veto create_append_plan() has: otherwise the narrowing
+-- sibling's target still wins the whole slice's direct dispatch and the
+-- Strewn arm's rows are silently dropped on the excluded segments.
+create table t_913b(a int, b int) distributed by (a);
+insert into t_913b select 100, i from generate_series(1,1000) i;
+create view v_913b_fromless as select 1 as x;
+explain (costs off)
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Limit
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: t_913b.b
+         ->  Limit
+               ->  Merge Append
+                     Sort Key: t_913b.b
+                     ->  Sort
+                           Sort Key: t_913b.b
+                           ->  Seq Scan on t_913b
+                                 Filter: (a = 100)
+                     ->  Sort
+                           Sort Key: (1)
+                           ->  Result
+ Optimizer: Postgres-based planner
+(14 rows)
+
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+ b 
+---
+ 1
+ 1
+ 1
+ 1
+ 2
+(5 rows)
+
+drop view v_913b_fromless;
+drop table t_913b;
 begin;
 drop table if exists direct_test;
 drop table if exists direct_test_two_column;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -638,6 +638,55 @@ create table t1_14887 partition of t_14887 for values with (modulus 3,remainder 
 create table t2_14887 partition of t_14887 for values with (modulus 3,remainder 2);
 explain select * from t_14887 where a = 'a'::text;
 
+-- A UNION ALL arm that gp_dist_random() forces to run on every segment
+-- (planned as a silent SubqueryScan/Result -- a "Strewn" data source) must
+-- not have its own dispatch requirement discarded just because a sibling
+-- arm narrows the slice to one segment.  The narrowing arm's content-id set
+-- used to win the merge and the Strewn arm's rows were silently dropped on
+-- the other segments.
+create table t_913(a int) distributed by (a);
+insert into t_913 values (100);
+create view v_913_fromless as select 1 as x;
+
+explain (costs off)
+select a from t_913 where a = 100
+union all
+select x from gp_dist_random('v_913_fromless');
+
+select * from (
+  select a from t_913 where a = 100
+  union all
+  select x from gp_dist_random('v_913_fromless')
+) s order by 1;
+
+drop view v_913_fromless;
+drop table t_913;
+
+-- The MergeAppend variant of the same bug: a UNION ALL whose branches are
+-- each independently sortable (an inner ORDER BY, plus a trivially-sorted
+-- single-row Strewn arm) makes the planner choose a MergeAppend instead of
+-- a plain Append, and create_merge_append_plan() needs the identical
+-- Strewn-locus veto create_append_plan() has: otherwise the narrowing
+-- sibling's target still wins the whole slice's direct dispatch and the
+-- Strewn arm's rows are silently dropped on the excluded segments.
+create table t_913b(a int, b int) distributed by (a);
+insert into t_913b select 100, i from generate_series(1,1000) i;
+create view v_913b_fromless as select 1 as x;
+
+explain (costs off)
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+
+(select b from t_913b where a = 100 order by b)
+union all
+select x from gp_dist_random('v_913b_fromless')
+order by 1 limit 5;
+
+drop view v_913b_fromless;
+drop table t_913b;
+
 begin;
 drop table if exists direct_test;
 drop table if exists direct_test_two_column;


### PR DESCRIPTION
## Summary

Closes #199

`DirectDispatchUpdateContentIdsFromPlan()`'s per-plan-node-type switch treats `T_Result` and `T_SubqueryScan` as "no change" (silence, meaning "no constraint"). That's only sound for pass-through nodes. A `gp_dist_random(...)` argument gets `CdbPathLocus_MakeStrewn()` applied to its path specifically because there is no known function tying its rows to segments — it must run on every segment, with no qual-based narrowing possible. But once such a child's plan is built, its shape can collapse to a bare `Result` or a plain `SubqueryScan` (e.g. a FROM-less view's contents get constant-folded away), and the walker has no way to tell that collapsed shape apart from a harmless one — both silently contribute "no change". That silence lets a sibling's correctly-computed narrow target win the whole Append's (or MergeAppend's) direct-dispatch decision outright, silently dropping the Strewn child's rows on every segment the sibling's target excludes.

The same collapse happens through a MergeAppend when both UNION ALL branches are independently sortable (an inner ORDER BY on one side; a single-row Result is trivially sorted on the other), since `create_merge_append_plan()` had none of the veto either.

## Fix

Check each child's own Path locus directly, in `create_append_plan()` and `create_merge_append_plan()`, before the child plan is even built: a Strewn locus is an unambiguous, Path-level signal that this child cannot be narrowed under any circumstances, so veto direct dispatch for the whole slice right there.

## Testing

Added regression coverage to `direct_dispatch` (both variants), including the `_optimizer` answer file (GPORCA falls back to the Postgres planner for this construct, so the output is identical). Verified live on a 3-segment demo cluster: both repros return the correct row counts; a plain two-relation point-lookup UNION ALL with no Strewn child still narrows to a single segment, unaffected. Ran the full `greenplum_schedule` — the only failures observed were pre-existing environment issues (a fault-injector left armed by an earlier fault-injection test, cascading into unrelated later tests), unrelated to this change; `direct_dispatch` itself passes cleanly.