### PR TITLE
Fix gp_workfile_entries inflating metrics via gang pid fan-out

### DIFF
--- a/gpcontrib/gp_internal_tools/gp_workfile_mgr.c
+++ b/gpcontrib/gp_internal_tools/gp_workfile_mgr.c
@@ -30,6 +30,7 @@
 PG_MODULE_MAGIC;
 
 Datum gp_workfile_mgr_cache_entries(PG_FUNCTION_ARGS);
+Datum gp_workfile_mgr_cache_entries_v2(PG_FUNCTION_ARGS);
 Datum gp_workfile_mgr_used_diskspace(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(gp_workfile_mgr_cache_entries);
@@ -43,6 +44,18 @@ Datum
 gp_workfile_mgr_cache_entries(PG_FUNCTION_ARGS)
 {
 	return gp_workfile_mgr_cache_entries_internal(fcinfo);
+}
+
+PG_FUNCTION_INFO_V1(gp_workfile_mgr_cache_entries_v2);
+
+/*
+ * Same as gp_workfile_mgr_cache_entries, but the result also includes the
+ * pid of the process that created each workfile set.
+ */
+Datum
+gp_workfile_mgr_cache_entries_v2(PG_FUNCTION_ARGS)
+{
+	return gp_workfile_mgr_cache_entries_v2_internal(fcinfo);
 }
 
 PG_FUNCTION_INFO_V1(gp_workfile_mgr_used_diskspace);

--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -2,7 +2,7 @@ EXTENSION = gp_toolkit
 DATA = gp_toolkit--1.1--1.2.sql gp_toolkit--1.0--1.1.sql gp_toolkit--1.0.sql \
 		gp_toolkit--1.2--1.3.sql gp_toolkit--1.3.sql gp_toolkit--1.3--1.4.sql \
 		gp_toolkit--1.4--1.5.sql gp_toolkit--1.5--1.6.sql gp_toolkit--1.6--1.7.sql \
-		gp_toolkit--1.7--1.8.sql
+		gp_toolkit--1.7--1.8.sql gp_toolkit--1.8--1.9.sql
 MODULE_big = gp_toolkit
 ifeq ($(shell uname -s), Linux)
 OBJS = resgroup.o gp_partition_maint.o gxid_func.o

--- a/gpcontrib/gp_toolkit/gp_toolkit--1.8--1.9.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.8--1.9.sql
@@ -1,0 +1,149 @@
+/* gpcontrib/gp_toolkit/gp_toolkit--1.8--1.9.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_toolkit UPDATE TO '1.9'" to load this file. \quit
+
+--
+-- Fix gp_toolkit.gp_workfile_entries inflating workfile metrics: the view
+-- used to join the workfile entries to gp_stat_activity on (sess_id, segid)
+-- only, so a single spilling workfile set was repeated for every process of
+-- the session's gang on that segment, inflating SUM(size)/SUM(numfiles) in
+-- the downstream gp_workfile_usage_per_* views.
+--
+-- The workfile manager now records the pid of the process that created each
+-- workfile set, exposed via the new *_v2 UDFs, and the view joins on it.
+-- We have to drop the view and its dependents first, and then recreate them.
+--
+
+--------------------------------------------------------------------------------
+-- @function:
+--        gp_toolkit.__gp_workfile_entries_f_v2
+--
+-- @in:
+--
+-- @out:
+--        int - segment id
+--        text - path to workfile set,
+--        bigint - size in bytes,
+--        text - type of the spilling operation,
+--        int - containing slice,
+--        int - sessionid,
+--        int - command_cnt,
+--        int - number of files,
+--        int - pid of the process that created the workfile set
+--
+-- @doc:
+--        UDF to retrieve workfile sets currently present on disk on one segment
+--
+--------------------------------------------------------------------------------
+
+CREATE FUNCTION gp_toolkit.__gp_workfile_entries_f_v2_on_coordinator()
+RETURNS SETOF record
+AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries_v2'
+LANGUAGE C VOLATILE EXECUTE ON COORDINATOR;
+
+GRANT EXECUTE ON FUNCTION gp_toolkit.__gp_workfile_entries_f_v2_on_coordinator() TO public;
+
+CREATE FUNCTION gp_toolkit.__gp_workfile_entries_f_v2_on_segments()
+RETURNS SETOF record
+AS '$libdir/gp_workfile_mgr', 'gp_workfile_mgr_cache_entries_v2'
+LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS;
+
+GRANT EXECUTE ON FUNCTION gp_toolkit.__gp_workfile_entries_f_v2_on_segments() TO public;
+
+ALTER EXTENSION gp_toolkit DROP VIEW gp_toolkit.gp_workfile_entries;
+ALTER EXTENSION gp_toolkit DROP VIEW gp_toolkit.gp_workfile_usage_per_segment;
+ALTER EXTENSION gp_toolkit DROP VIEW gp_toolkit.gp_workfile_usage_per_query;
+DROP VIEW gp_toolkit.gp_workfile_entries CASCADE;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.gp_workfile_entries
+--
+-- @doc:
+--        List of all the workfile sets currently present on disk
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_workfile_entries AS
+WITH all_entries AS (
+    SELECT C.*
+        FROM gp_toolkit.__gp_workfile_entries_f_v2_on_coordinator() AS C (
+           segid int,
+           prefix text,
+           size bigint,
+           optype text,
+           slice int,
+           sessionid int,
+           commandid int,
+           numfiles int,
+           pid int
+        )
+    UNION ALL
+    SELECT C.*
+        FROM gp_toolkit.__gp_workfile_entries_f_v2_on_segments() AS C (
+            segid int,
+            prefix text,
+            size bigint,
+            optype text,
+            slice int,
+            sessionid int,
+            commandid int,
+            numfiles int,
+            pid int
+        ))
+SELECT S.datname,
+       C.pid,
+       C.sessionid as sess_id,
+       C.commandid as command_cnt,
+       S.usename,
+       S.query,
+       C.segid,
+       C.slice,
+       C.optype,
+       C.size,
+       C.numfiles,
+       C.prefix
+FROM all_entries C LEFT OUTER JOIN gp_stat_activity S
+ON C.sessionid = S.sess_id and C.segid = S.gp_segment_id and C.pid = S.pid;
+
+GRANT SELECT ON gp_toolkit.gp_workfile_entries TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.gp_workfile_usage_per_segment
+--
+-- @doc:
+--        Amount of disk space used for workfiles at each segment
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_workfile_usage_per_segment AS
+SELECT gpseg.content AS segid, COALESCE(SUM(wfe.size),0) AS size,
+       SUM(wfe.numfiles) AS numfiles
+FROM (
+         SELECT content
+         FROM gp_segment_configuration
+         WHERE role = 'p') gpseg
+         LEFT JOIN gp_toolkit.gp_workfile_entries wfe
+                   ON (gpseg.content = wfe.segid)
+GROUP BY gpseg.content;
+
+GRANT SELECT ON gp_toolkit.gp_workfile_usage_per_segment TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_toolkit.gp_workfile_usage_per_query
+--
+-- @doc:
+--        Amount of disk space used for workfiles by each query
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_toolkit.gp_workfile_usage_per_query AS
+SELECT datname, pid, sess_id, command_cnt, usename, query, segid,
+       SUM(size) AS size, SUM(numfiles) AS numfiles
+FROM gp_toolkit.gp_workfile_entries
+GROUP BY datname, pid, sess_id, command_cnt, usename, query, segid;
+
+GRANT SELECT ON gp_toolkit.gp_workfile_usage_per_query TO public;

--- a/gpcontrib/gp_toolkit/gp_toolkit.control
+++ b/gpcontrib/gp_toolkit/gp_toolkit.control
@@ -1,5 +1,5 @@
 # gp_toolkit extension
 
 comment = 'various GPDB administrative views/functions'
-default_version = '1.8'
+default_version = '1.9'
 schema = gp_toolkit

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -79,6 +79,7 @@
 #include "common/hashfn.h"
 #include "funcapi.h"
 #include "lib/ilist.h"
+#include "miscadmin.h"
 #include "storage/buffile.h"
 #include "storage/fd.h"
 #include "storage/ipc.h"
@@ -632,6 +633,7 @@ workfile_mgr_create_set_internal(const char *operator_name, const char *prefix)
 	work_set->session_id = gp_session_id;
 	work_set->command_count = gp_command_count;
 	work_set->slice_id = currentSliceId;
+	work_set->pid = MyProcPid;
 	work_set->perquery = perquery;
 	work_set->num_files = 0;
 	work_set->total_bytes = 0;
@@ -846,13 +848,23 @@ typedef struct
 } get_entries_cxt;
 
 /*
- * Function returning all workfile cache entries for one segment
+ * Guts of the workfile cache entries functions.
+ *
+ * The original version of the function returns NUM_CACHE_ENTRIES_ELEM
+ * columns. The v2 version appends a 'pid' column, so that callers can tell
+ * which process in the session's gang created a workfile set. Keep both
+ * output formats, since older versions of the gp_toolkit views specify the
+ * original format in their column definition lists.
  */
-Datum
-gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
+#define NUM_CACHE_ENTRIES_ELEM		8
+#define NUM_CACHE_ENTRIES_ELEM_V2	(NUM_CACHE_ENTRIES_ELEM + 1)
+
+static Datum
+workfile_mgr_cache_entries_guts(FunctionCallInfo fcinfo, bool include_pid)
 {
 	FuncCallContext *funcctx;
 	get_entries_cxt *cxt;
+	int			natts = include_pid ? NUM_CACHE_ENTRIES_ELEM_V2 : NUM_CACHE_ENTRIES_ELEM;
 
 	if (SRF_IS_FIRSTCALL())
 	{
@@ -869,8 +881,7 @@ gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
 		 * The number and type of attributes have to match the definition of the
 		 * view gp_workfile_mgr_cache_entries
 		 */
-#define NUM_CACHE_ENTRIES_ELEM 8
-		TupleDesc tupdesc = CreateTemplateTupleDesc(NUM_CACHE_ENTRIES_ELEM);
+		TupleDesc tupdesc = CreateTemplateTupleDesc(natts);
 
 		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "prefix", TEXTOID, -1, 0);
@@ -880,6 +891,8 @@ gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
 		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "sessionid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "commandid", INT4OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "numfiles", INT4OID, -1, 0);
+		if (include_pid)
+			TupleDescInitEntry(tupdesc, (AttrNumber) 9, "pid", INT4OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 
@@ -900,8 +913,8 @@ gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
 	while (cxt->index < cxt->num_entries)
 	{
 		WorkFileSetSharedEntry *work_set = &cxt->copied_entries[cxt->index];
-		Datum		values[NUM_CACHE_ENTRIES_ELEM];
-		bool		nulls[NUM_CACHE_ENTRIES_ELEM];
+		Datum		values[NUM_CACHE_ENTRIES_ELEM_V2];
+		bool		nulls[NUM_CACHE_ENTRIES_ELEM_V2];
 		HeapTuple tuple;
 		Datum		result;
 
@@ -915,6 +928,8 @@ gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
 		values[5] = UInt32GetDatum(work_set->session_id);
 		values[6] = UInt32GetDatum(work_set->command_count);
 		values[7] = UInt32GetDatum(work_set->num_files);
+		if (include_pid)
+			values[8] = Int32GetDatum(work_set->pid);
 
 		cxt->index++;
 
@@ -925,6 +940,25 @@ gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
 	}
 
 	SRF_RETURN_DONE(funcctx);
+}
+
+/*
+ * Function returning all workfile cache entries for one segment
+ */
+Datum
+gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS)
+{
+	return workfile_mgr_cache_entries_guts(fcinfo, false);
+}
+
+/*
+ * Same as gp_workfile_mgr_cache_entries_internal, but also returns the pid
+ * of the process that created each workfile set.
+ */
+Datum
+gp_workfile_mgr_cache_entries_v2_internal(PG_FUNCTION_ARGS)
+{
+	return workfile_mgr_cache_entries_guts(fcinfo, true);
 }
 
 /*

--- a/src/include/utils/workfile_mgr.h
+++ b/src/include/utils/workfile_mgr.h
@@ -91,13 +91,17 @@ typedef struct workfile_set
 	/* Average work file size */
 	uint64		avg_file_size;
 
+	/* PID of the process that created the workfile set */
+	int32		pid;
+
 	/*
 	 * GP_ABI_BUMP_FIXME
 	 *
 	 * Not used, just for ABI compatibility, remove this when we decide to bump
-	 * the ABI version.
+	 * the ABI version. (This is the remainder of a former 8-byte reserved
+	 * field, the first half of which is now used for 'pid' above.)
 	 */
-	uint64		abi_reserved;
+	int32		abi_reserved;
 
 	/* Total memory usage by compression buffer */
 	uint64		compression_buf_total;
@@ -120,6 +124,7 @@ extern workfile_set *workfile_mgr_create_set(const char *operator_name, const ch
 extern void workfile_mgr_close_set(workfile_set *work_set);
 
 extern Datum gp_workfile_mgr_cache_entries_internal(PG_FUNCTION_ARGS);
+extern Datum gp_workfile_mgr_cache_entries_v2_internal(PG_FUNCTION_ARGS);
 extern workfile_set *workfile_mgr_cache_entries_get_copy(int* num_actives);
 extern uint64 WorkfileSegspace_GetSize(void);
 

--- a/src/test/isolation2/input/workfile_mgr_test.source
+++ b/src/test/isolation2/input/workfile_mgr_test.source
@@ -125,3 +125,36 @@ language plpgsql volatile execute on all segments;
 -- "inter_xact_workset" entries show up in the output of
 -- gp_workfile_mgr_cache_entries().
 4: select * from report_workfile_entries();
+
+-- Test that gp_toolkit.gp_workfile_entries reports each workfile set exactly
+-- once, attributed to the pid of the process that created it.  The view used
+-- to join the workfile entries to gp_stat_activity on (sess_id, segid) only,
+-- fanning out each entry to every backend of the session on that segment and
+-- thereby inflating the workfile metrics.
+
+-- The test database may have been created with an older gp_toolkit; make
+-- sure we test the current version of the views.
+-- start_ignore
+6: alter extension gp_toolkit update;
+-- end_ignore
+5: set gp_vmem_idle_resource_timeout = 0;
+5: create table workfile_entries_fanout_t(a int, b int) distributed by (a);
+5: insert into workfile_entries_fanout_t select i, i from generate_series(1, 10) i;
+-- Run a multi-slice query, so that the session keeps more than one backend
+-- per segment around.
+5: select count(*) from workfile_entries_fanout_t t1 join workfile_entries_fanout_t t2 on t1.b = t2.b;
+-- Create an inter-transaction workset on all segments; it lives until the
+-- session exits.
+5: select gp_workfile_mgr_create_workset('fanout_check_workset', true, false, false);
+-- Sanity check: the session holds more than one backend per segment, i.e.
+-- the conditions for the old fan-out are present.
+6: select count(*) > 3 as more_than_one_backend_per_seg from gp_stat_activity where sess_id in (select sess_id from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%') and gp_segment_id >= 0;
+-- The view must report exactly one entry per segment, with the pid matching
+-- a backend of the session on that segment (so the left join to
+-- gp_stat_activity found the creating backend and usename is not null).
+6: select count(*) from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%';
+6: select count(*) from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%' and usename is not null;
+6: drop table workfile_entries_fanout_t;
+5q:
+-- Wait until the workset of the exited session is cleaned up.
+6: select * from report_workfile_entries();

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -346,3 +346,69 @@ ROLLBACK
  1     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        
  2     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        
 (3 rows)
+
+-- Test that gp_toolkit.gp_workfile_entries reports each workfile set exactly
+-- once, attributed to the pid of the process that created it.  The view used
+-- to join the workfile entries to gp_stat_activity on (sess_id, segid) only,
+-- fanning out each entry to every backend of the session on that segment and
+-- thereby inflating the workfile metrics.
+
+-- The test database may have been created with an older gp_toolkit; make
+-- sure we test the current version of the views.
+-- start_ignore
+6: alter extension gp_toolkit update;
+ALTER EXTENSION
+-- end_ignore
+5: set gp_vmem_idle_resource_timeout = 0;
+SET
+5: create table workfile_entries_fanout_t(a int, b int) distributed by (a);
+CREATE TABLE
+5: insert into workfile_entries_fanout_t select i, i from generate_series(1, 10) i;
+INSERT 0 10
+-- Run a multi-slice query, so that the session keeps more than one backend
+-- per segment around.
+5: select count(*) from workfile_entries_fanout_t t1 join workfile_entries_fanout_t t2 on t1.b = t2.b;
+ count 
+-------
+ 10    
+(1 row)
+-- Create an inter-transaction workset on all segments; it lives until the
+-- session exits.
+5: select gp_workfile_mgr_create_workset('fanout_check_workset', true, false, false);
+ gp_workfile_mgr_create_workset 
+--------------------------------
+                                
+                                
+                                
+(3 rows)
+-- Sanity check: the session holds more than one backend per segment, i.e.
+-- the conditions for the old fan-out are present.
+6: select count(*) > 3 as more_than_one_backend_per_seg from gp_stat_activity where sess_id in (select sess_id from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%') and gp_segment_id >= 0;
+ more_than_one_backend_per_seg 
+-------------------------------
+ t                             
+(1 row)
+-- The view must report exactly one entry per segment, with the pid matching
+-- a backend of the session on that segment (so the left join to
+-- gp_stat_activity found the creating backend and usename is not null).
+6: select count(*) from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%';
+ count 
+-------
+ 3     
+(1 row)
+6: select count(*) from gp_toolkit.gp_workfile_entries where prefix like 'fanout_check_workset%' and usename is not null;
+ count 
+-------
+ 3     
+(1 row)
+6: drop table workfile_entries_fanout_t;
+DROP TABLE
+5q: ... <quitting>
+-- Wait until the workset of the exited session is cleaned up.
+6: select * from report_workfile_entries();
+ segid | prefix              | size | operation         | slice | numfiles 
+-------+---------------------+------+-------------------+-------+----------
+ 0     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        
+ 1     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        
+ 2     | long_live_workset_1 | 0    | long_live_workset | 1     | 0        
+(3 rows)


### PR DESCRIPTION
Fixes https://github.com/warehouse-pg/warehouse-pg/issues/122 (internal ticket: PTT-746)

## Problem

`gp_toolkit.gp_workfile_entries` joins the workfile entries to `gp_stat_activity` on `(sess_id, segid)` only. Every backend of the session's gang on a segment matches that condition, so a single spilling workfile set is reported once per backend of the gang, inflating `SUM(size)` and `SUM(numfiles)` in the downstream views `gp_workfile_usage_per_query` and `gp_workfile_usage_per_segment`.

For example, while a 3-slice query is spilling, the view reports each workfile set 3+ times per segment with identical size/numfiles but different pids (see issue #122 for a full reproduction).

## Fix

Record the pid of the process that creates a `workfile_set` and join on it:

- `workfile_mgr.h`: store the creating process's pid in the reserved ABI field of `workfile_set` (split the 8-byte `abi_reserved` into `int32 pid` + `int32 abi_reserved`), so the struct layout is unchanged.
- `workfile_mgr.c`: set `work_set->pid = MyProcPid` on creation, and add `gp_workfile_mgr_cache_entries_v2_internal()` which returns the same columns as before plus a trailing `pid` column. Both variants share one implementation.
- `gp_workfile_mgr` module: export the new `gp_workfile_mgr_cache_entries_v2` symbol.
- `gp_toolkit` 1.9 (new `gp_toolkit--1.8--1.9.sql`, `default_version` bumped): add `__gp_workfile_entries_f_v2_on_coordinator/segments()` and recreate `gp_workfile_entries` to join with `C.pid = S.pid` as well. The `pid` column now comes from the workfile entry itself, so it identifies the actual spilling process and stays populated even when the left join finds no activity row.

The old 8-column C function is kept unchanged, so views from older extension versions (which spell out the 8-column record in their column definition lists) keep working with new binaries until `ALTER EXTENSION gp_toolkit UPDATE` is run.

## Before / after

While one hash-join query is spilling (session with 4 backends per segment, 2 workfile sets per segment):

Old view (1.8): 24 rows — each workfile set duplicated once per gang process:

```
   pid   | sess_id | slice | segid |  optype  |   size   | numfiles
---------+---------+-------+-------+----------+----------+----------
 1114150 |      10 |     1 |     0 | HashJoin | 14221312 |      127
 1114157 |      10 |     1 |     0 | HashJoin | 14221312 |      127
 1114162 |      10 |     1 |     0 | HashJoin | 14221312 |      127
 1114169 |      10 |     1 |     0 | HashJoin | 14221312 |      127
 ...
(24 rows)
```

New view (1.9): 6 rows — one row per workfile set, attributed to the pid of the spilling process:

```
   pid   | sess_id | slice | segid |  optype  |   size   | numfiles
---------+---------+-------+-------+----------+----------+----------
 1114157 |      10 |     1 |     0 | HashJoin | 20283392 |      254
 1114157 |      10 |     1 |     0 | HashJoin | 14221312 |      127
 ...
(6 rows)
```

`gp_workfile_usage_per_segment` correspondingly reports 381 files per segment instead of 4x that.

## Testing

- Added a regression test to `isolation2/workfile_mgr_test`: create extra gangs in a session with a multi-slice query (and assert more than one backend per segment exists, i.e. the fan-out precondition holds), create an inter-transaction workset on all segments, then assert the view reports exactly one entry per segment with a pid that matches a live backend of the session.
- Verified `ALTER EXTENSION gp_toolkit UPDATE TO '1.9'` on a cluster initialized at 1.8.
- `gpcontrib/gp_toolkit` regress suite passes (the `gp_toolkit_resqueue` failure is pre-existing and unrelated; it fails identically on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
