### PR TITLE
feat: wire-up coordinator-only native CTAS path

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -325,7 +325,6 @@ cdbllize_get_final_locus(PlannerInfo *root, PathTarget *target)
 
 		if (intoPolicy != NULL)
 		{
-			Assert(intoPolicy->ptype != POLICYTYPE_ENTRY);
 			Assert(intoPolicy->nattrs >= 0);
 			Assert(intoPolicy->nattrs <= MaxPolicyAttributeNumber);
 
@@ -340,6 +339,17 @@ cdbllize_get_final_locus(PlannerInfo *root, PathTarget *target)
 
 				CdbPathLocus_MakeReplicated(&locus, intoPolicy->numsegments);
 				return locus;
+			}
+			else if (intoPolicy->ptype == POLICYTYPE_ENTRY)
+			{
+				/*
+				 * CTAS into a DISTRIBUTED COORDINATOR ONLY table: the result
+				 * needs to be brought back to the QD.
+				 */
+				CdbPathLocus entryLocus;
+
+				CdbPathLocus_MakeEntry(&entryLocus);
+				return entryLocus;
 			}
 		}
 	}
@@ -409,8 +419,7 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path,
 		if (query->intoPolicy != NULL)
 		{
 			targetPolicy = query->intoPolicy;
-
-			Assert(query->intoPolicy->ptype != POLICYTYPE_ENTRY);
+            
 			Assert(query->intoPolicy->nattrs >= 0);
 			Assert(query->intoPolicy->nattrs <= MaxPolicyAttributeNumber);
 		}
@@ -498,7 +507,13 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path,
 								 " Make sure column(s) chosen are the optimal data distribution key to minimize skew.")));
 			}
 		}
-		Assert(targetPolicy->ptype != POLICYTYPE_ENTRY);
+		/*
+		 * An ENTRY policy can only originate from an explicit intoPolicy
+		 * (DISTRIBUTED COORDINATOR ONLY); the deduction branches above never
+		 * produce one.
+		 */
+		Assert(targetPolicy->ptype != POLICYTYPE_ENTRY ||
+			   query->intoPolicy == targetPolicy);
 
 		query->intoPolicy = targetPolicy;
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -171,7 +171,13 @@ create_ctas_internal(List *attrList, IntoClause *into, QueryDesc *queryDesc, boo
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		queryDesc->ddesc->intoCreateStmt = create;
+		/*
+		 * ddesc is NULL when the CTAS plan runs entirely on the coordinator
+		 * and dispatches no gang (e.g. a POLICYTYPE_ENTRY target fed by a
+		 * VALUES or constant source), so guard the store.
+		 */
+		if (queryDesc->ddesc)
+			queryDesc->ddesc->intoCreateStmt = create;
 	}
 
 	/*
@@ -650,9 +656,15 @@ intorel_initplan(struct QueryDesc *queryDesc, int eflags)
 	 * case, dispatch the creation of the table immediately. Normally, the table
 	 * is created in the initialization of the plan in QEs, but with NO DATA, we
 	 * don't need to dispatch the plan during ExecutorStart().
+	 *
+	 * Also dispatch immediately for a coordinator-only (POLICYTYPE_ENTRY)
+	 * target: its top slice runs on the QD only, so no QE ever executes
+	 * intorel_initplan and the relation would otherwise exist solely on the QD.
 	 */
 	intoRelationAddr = create_ctas_internal(attrList, into, queryDesc,
-											into->skipData ? true : false);
+											into->skipData ||
+											(queryDesc->plannedstmt->intoPolicy &&
+											 queryDesc->plannedstmt->intoPolicy->ptype == POLICYTYPE_ENTRY));
 
 	/*
 	 * Finally we can open the target table

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -240,7 +240,8 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	Assert(queryDesc->plannedstmt->intoPolicy == NULL ||
 		GpPolicyIsPartitioned(queryDesc->plannedstmt->intoPolicy) ||
-		GpPolicyIsReplicated(queryDesc->plannedstmt->intoPolicy));
+		GpPolicyIsReplicated(queryDesc->plannedstmt->intoPolicy) ||
+		GpPolicyIsEntry(queryDesc->plannedstmt->intoPolicy));
 
 	/* GPDB hook for collecting query info */
 	if (query_info_collect_hook)
@@ -1651,7 +1652,8 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 
 	Assert(plannedstmt->intoPolicy == NULL ||
 		GpPolicyIsPartitioned(plannedstmt->intoPolicy) ||
-		GpPolicyIsReplicated(plannedstmt->intoPolicy));
+		GpPolicyIsReplicated(plannedstmt->intoPolicy) ||
+		GpPolicyIsEntry(plannedstmt->intoPolicy));
 
 	if (DEBUG1 >= log_min_messages)
 	{

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1077,6 +1077,17 @@ CTranslatorQueryToDXL::TranslateCTASToDXL()
 			nullptr);
 	}
 
+	// ORCA cannot build a coordinator-only (DISTRIBUTED COORDINATOR ONLY) CTAS target;
+	// fall back to the Postgres planner, which materializes the ENTRY policy correctly
+	// (see cdbllize_adjust_top_path). Without this, a release build silently produces a
+	// hash-distributed table instead.
+	if (IMDRelation::EreldistrCoordinatorOnly == rel_distr_policy)
+	{
+		GPOS_RAISE(
+			gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+			GPOS_WSZ_LIT("CREATE TABLE AS ... DISTRIBUTED COORDINATOR ONLY"));
+	}
+
 	GPOS_ASSERT(IMDRelation::EreldistrCoordinatorOnly != rel_distr_policy);
 	m_context->m_has_distributed_tables = true;
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3080,10 +3080,16 @@ transformCreateTableAsStmt(ParseState *pstate, CreateTableAsStmt *stmt)
 	DistributedBy *distributedBy = (DistributedBy *)stmt->into->distributedBy;
 	if (distributedBy && (Gp_role == GP_ROLE_DISPATCH || IsBinaryUpgrade))
 	{
-		if (distributedBy->ptype == POLICYTYPE_ENTRY)
+		/*
+		 * CTAS into a DISTRIBUTED COORDINATOR ONLY table is supported.
+		 * Materialized views remain fenced: the REFRESH path does not
+		 * handle an ENTRY policy yet.
+		 */
+		if (distributedBy->ptype == POLICYTYPE_ENTRY &&
+			stmt->relkind != OBJECT_TABLE)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("CTAS DISTRIBUTED COORDINATOR ONLY is not supported yet")));
+					 errmsg("CREATE MATERIALIZED VIEW DISTRIBUTED COORDINATOR ONLY is not supported yet")));
 
 		setQryDistributionPolicy(pstate, stmt->into, (Query *) stmt->query);
 	}

--- a/src/test/regress/expected/coordinator_only.out
+++ b/src/test/regress/expected/coordinator_only.out
@@ -322,18 +322,95 @@ DISTRIBUTED BY (c1);
  c2     | integer |           |          |         | plain   |              | 
 Distributed by: (c1)
 
--- CTAS from a regular distributed table to coordinator-only, should fail
+-- CTAS from a regular distributed table to coordinator-only
 CREATE TABLE ctas_from_distributed AS
 SELECT * FROM distributed_table_aux
 WHERE c2 > 25
 DISTRIBUTED COORDINATOR ONLY;
-ERROR:  CTAS DISTRIBUTED COORDINATOR ONLY is not supported yet
--- CTAS from a coordinator-only table to coordinator-only, should fail
+\d+ ctas_from_distributed
+                           Table "public.ctas_from_distributed"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ c1     | integer |           |          |         | plain   |              | 
+ c2     | integer |           |          |         | plain   |              | 
+Distributed by: DISTRIBUTED COORDINATOR ONLY
+
+-- Verify the distribution policy in catalog
+SELECT policytype, numsegments, distkey, distclass
+FROM gp_distribution_policy
+WHERE localoid = 'ctas_from_distributed'::regclass;
+ policytype | numsegments | distkey | distclass 
+------------+-------------+---------+-----------
+ e          |          -1 |         | 
+(1 row)
+
+-- The relation must exist on every segment with the coordinator's OID,
+-- otherwise any distributed plan referencing it fails on the segments
+SELECT DISTINCT oid = 'ctas_from_distributed'::regclass::oid AS oid_matches
+FROM gp_dist_random('pg_class')
+WHERE relname = 'ctas_from_distributed';
+ oid_matches 
+-------------
+ t
+(1 row)
+
+-- Row count must match the equivalent plain SELECT
+SELECT count(*) FROM ctas_from_distributed;
+ count 
+-------
+    13
+(1 row)
+
+SELECT count(*) FROM distributed_table_aux WHERE c2 > 25;
+ count 
+-------
+    13
+(1 row)
+
+-- And the new table must be usable in a distributed join
+SELECT count(*)
+FROM ctas_from_distributed c JOIN distributed_table_aux d USING (c1);
+ count 
+-------
+    13
+(1 row)
+
+-- CTAS from a coordinator-only table to coordinator-only
 CREATE TABLE ctas_from_coordinator_only_to_only AS
 SELECT * FROM coordinator_only_heap
 WHERE c1 > 25
 DISTRIBUTED COORDINATOR ONLY;
-ERROR:  CTAS DISTRIBUTED COORDINATOR ONLY is not supported yet
+SELECT count(*) FROM ctas_from_coordinator_only_to_only;
+ count 
+-------
+   775
+(1 row)
+
+SELECT count(*) FROM coordinator_only_heap WHERE c1 > 25;
+ count 
+-------
+   775
+(1 row)
+
+-- CTAS WITH NO DATA to coordinator-only: table is created everywhere and
+-- empty, and can be populated with a regular INSERT ... SELECT afterwards
+CREATE TABLE ctas_coordinator_only_nodata AS
+SELECT * FROM distributed_table_aux
+WITH NO DATA
+DISTRIBUTED COORDINATOR ONLY;
+SELECT count(*) FROM ctas_coordinator_only_nodata;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO ctas_coordinator_only_nodata SELECT * FROM distributed_table_aux;
+SELECT count(*) FROM ctas_coordinator_only_nodata;
+ count 
+-------
+    20
+(1 row)
+
 -- CTAS from coordinator-only table (should create hash-distributed table by default)
 CREATE TABLE ctas_from_coordinator_only_no_distribution AS
 SELECT * FROM coordinator_only_heap
@@ -432,7 +509,7 @@ WHERE c2 IN (SELECT c1 FROM coordinator_only_heap WHERE c1 < 500);
 CREATE MATERIALIZED VIEW mv_coordinator_only_explicit AS
 SELECT i FROM generate_series(1, 20) i
 DISTRIBUTED COORDINATOR ONLY;
-ERROR:  CTAS DISTRIBUTED COORDINATOR ONLY is not supported yet
+ERROR:  CREATE MATERIALIZED VIEW DISTRIBUTED COORDINATOR ONLY is not supported yet
 -- Matview from coordinator-only table (should infer hash distribution)
 CREATE MATERIALIZED VIEW mv_from_coordinator_only AS
 SELECT c1, c2 FROM coordinator_only_heap WHERE c1 BETWEEN 100 AND 200;
@@ -556,14 +633,16 @@ ERROR:  PARTITION BY clause cannot be used with DISTRIBUTED REPLICATED or COORDI
 SELECT gp_segment_id, count(*)
 FROM gp_dist_random('pg_class')
 WHERE relname IN ('coordinator_only_heap', 'coordinator_only_ao', 'coordinator_only_aoco',
-                  'like_coordinator_only', 'coordinator_only_constraints')
+                  'like_coordinator_only', 'coordinator_only_constraints',
+                  'ctas_from_distributed', 'ctas_from_coordinator_only_to_only',
+                  'ctas_coordinator_only_nodata')
 GROUP BY gp_segment_id
 ORDER BY gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
-             0 |     5
-             1 |     5
-             2 |     5
+             0 |     8
+             1 |     8
+             2 |     8
 (3 rows)
 
 -- Left two coordinator-only tables for following pg_upgrade and gpcheckcat tests
@@ -572,6 +651,9 @@ DROP TABLE IF EXISTS coordinator_only_ao CASCADE;
 --  DROP TABLE IF EXISTS coordinator_only_aoco CASCADE;
 DROP TABLE IF EXISTS like_coordinator_only CASCADE;
 DROP TABLE IF EXISTS coordinator_only_constraints CASCADE;
+DROP TABLE IF EXISTS ctas_from_distributed CASCADE;
+DROP TABLE IF EXISTS ctas_from_coordinator_only_to_only CASCADE;
+DROP TABLE IF EXISTS ctas_coordinator_only_nodata CASCADE;
 DROP FUNCTION IF EXISTS get_coordinator_only_data() CASCADE;
 DROP FUNCTION IF EXISTS get_coordinator_only_data_on_coordinator() CASCADE;
 -- Extra cleanup for auxiliary and optional objects
@@ -581,7 +663,9 @@ DROP TABLE IF EXISTS distributed_table_aux_r CASCADE;
 SELECT gp_segment_id, count(*)
 FROM gp_dist_random('pg_class')
 WHERE relname IN ('coordinator_only_heap', 'coordinator_only_ao', 'coordinator_only_aoco',
-                  'like_coordinator_only', 'coordinator_only_constraints')
+                  'like_coordinator_only', 'coordinator_only_constraints',
+                  'ctas_from_distributed', 'ctas_from_coordinator_only_to_only',
+                  'ctas_coordinator_only_nodata')
 GROUP BY gp_segment_id
 ORDER BY gp_segment_id;
  gp_segment_id | count 

--- a/src/test/regress/sql/coordinator_only.sql
+++ b/src/test/regress/sql/coordinator_only.sql
@@ -174,17 +174,51 @@ WHERE c2 > 25
 DISTRIBUTED BY (c1);
 \d+ ctas_from_distributed_to_distributed
 
--- CTAS from a regular distributed table to coordinator-only, should fail
+-- CTAS from a regular distributed table to coordinator-only
 CREATE TABLE ctas_from_distributed AS
 SELECT * FROM distributed_table_aux
 WHERE c2 > 25
 DISTRIBUTED COORDINATOR ONLY;
+\d+ ctas_from_distributed
 
--- CTAS from a coordinator-only table to coordinator-only, should fail
+-- Verify the distribution policy in catalog
+SELECT policytype, numsegments, distkey, distclass
+FROM gp_distribution_policy
+WHERE localoid = 'ctas_from_distributed'::regclass;
+
+-- The relation must exist on every segment with the coordinator's OID,
+-- otherwise any distributed plan referencing it fails on the segments
+SELECT DISTINCT oid = 'ctas_from_distributed'::regclass::oid AS oid_matches
+FROM gp_dist_random('pg_class')
+WHERE relname = 'ctas_from_distributed';
+
+-- Row count must match the equivalent plain SELECT
+SELECT count(*) FROM ctas_from_distributed;
+SELECT count(*) FROM distributed_table_aux WHERE c2 > 25;
+
+-- And the new table must be usable in a distributed join
+SELECT count(*)
+FROM ctas_from_distributed c JOIN distributed_table_aux d USING (c1);
+
+-- CTAS from a coordinator-only table to coordinator-only
 CREATE TABLE ctas_from_coordinator_only_to_only AS
 SELECT * FROM coordinator_only_heap
 WHERE c1 > 25
 DISTRIBUTED COORDINATOR ONLY;
+
+SELECT count(*) FROM ctas_from_coordinator_only_to_only;
+SELECT count(*) FROM coordinator_only_heap WHERE c1 > 25;
+
+-- CTAS WITH NO DATA to coordinator-only: table is created everywhere and
+-- empty, and can be populated with a regular INSERT ... SELECT afterwards
+CREATE TABLE ctas_coordinator_only_nodata AS
+SELECT * FROM distributed_table_aux
+WITH NO DATA
+DISTRIBUTED COORDINATOR ONLY;
+
+SELECT count(*) FROM ctas_coordinator_only_nodata;
+INSERT INTO ctas_coordinator_only_nodata SELECT * FROM distributed_table_aux;
+SELECT count(*) FROM ctas_coordinator_only_nodata;
 
 -- CTAS from coordinator-only table (should create hash-distributed table by default)
 CREATE TABLE ctas_from_coordinator_only_no_distribution AS
@@ -340,7 +374,9 @@ PARTITION BY RANGE (c2)
 SELECT gp_segment_id, count(*)
 FROM gp_dist_random('pg_class')
 WHERE relname IN ('coordinator_only_heap', 'coordinator_only_ao', 'coordinator_only_aoco',
-                  'like_coordinator_only', 'coordinator_only_constraints')
+                  'like_coordinator_only', 'coordinator_only_constraints',
+                  'ctas_from_distributed', 'ctas_from_coordinator_only_to_only',
+                  'ctas_coordinator_only_nodata')
 GROUP BY gp_segment_id
 ORDER BY gp_segment_id;
 
@@ -350,6 +386,9 @@ DROP TABLE IF EXISTS coordinator_only_ao CASCADE;
 --  DROP TABLE IF EXISTS coordinator_only_aoco CASCADE;
 DROP TABLE IF EXISTS like_coordinator_only CASCADE;
 DROP TABLE IF EXISTS coordinator_only_constraints CASCADE;
+DROP TABLE IF EXISTS ctas_from_distributed CASCADE;
+DROP TABLE IF EXISTS ctas_from_coordinator_only_to_only CASCADE;
+DROP TABLE IF EXISTS ctas_coordinator_only_nodata CASCADE;
 DROP FUNCTION IF EXISTS get_coordinator_only_data() CASCADE;
 DROP FUNCTION IF EXISTS get_coordinator_only_data_on_coordinator() CASCADE;
 
@@ -361,6 +400,8 @@ DROP TABLE IF EXISTS distributed_table_aux_r CASCADE;
 SELECT gp_segment_id, count(*)
 FROM gp_dist_random('pg_class')
 WHERE relname IN ('coordinator_only_heap', 'coordinator_only_ao', 'coordinator_only_aoco',
-                  'like_coordinator_only', 'coordinator_only_constraints')
+                  'like_coordinator_only', 'coordinator_only_constraints',
+                  'ctas_from_distributed', 'ctas_from_coordinator_only_to_only',
+                  'ctas_coordinator_only_nodata')
 GROUP BY gp_segment_id
 ORDER BY gp_segment_id;


### PR DESCRIPTION
This allows using `DISTRIBUTED COORDINATOR ONLY` in a CTAS statement.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
