### PR TITLE
chore: rename direct_dispatch_contentIds to pinned_direct_dispatch_contentIds

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1274,8 +1274,8 @@ create_append_plan(PlannerInfo *root, AppendPath *best_path, int flags)
 		 *
 		 * Exception: set_append_path_locus() also tags a pinned General/
 		 * SegmentGeneral child (the "One-Time Filter:
-		 * gp_execution_segment() = N" trick, see the direct_dispatch_
-		 * contentIds comment above) as Strewn -- that child is NOT an
+		 * gp_execution_segment() = N" trick, see the pinned_direct_dispatch_contentIds
+		 * comment above) as Strewn -- that child is NOT an
 		 * unconstrained "runs everywhere" leaf, it is already confined to
 		 * one specific, known segment, and create_plan_recurse() (via
 		 * create_gating_plan()'s tail above) already merged that exact
@@ -1287,7 +1287,7 @@ create_append_plan(PlannerInfo *root, AppendPath *best_path, int flags)
 		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
 			CdbPathLocus_IsStrewn(subpath->locus) &&
 			!(IsA(subpath, ProjectionPath) &&
-			  ((ProjectionPath *) subpath)->direct_dispatch_contentIds != NIL))
+			  ((ProjectionPath *) subpath)->pinned_direct_dispatch_contentIds != NIL))
 		{
 			DirectDispatchInfo dispatchInfo;
 
@@ -1511,7 +1511,7 @@ create_merge_append_plan(PlannerInfo *root, MergeAppendPath *best_path,
 		if (Gp_role == GP_ROLE_DISPATCH && root->config->gp_enable_direct_dispatch &&
 			CdbPathLocus_IsStrewn(subpath->locus) &&
 			!(IsA(subpath, ProjectionPath) &&
-			  ((ProjectionPath *) subpath)->direct_dispatch_contentIds != NIL))
+			  ((ProjectionPath *) subpath)->pinned_direct_dispatch_contentIds != NIL))
 		{
 			DirectDispatchInfo dispatchInfo;
 
@@ -2183,12 +2183,12 @@ create_projection_plan(PlannerInfo *root, ProjectionPath *best_path, int flags)
 	 * https://github.com/greenplum-db/gpdb/issues/9874 for more
 	 * detailed info.
 	 */
-	if (root->config->gp_enable_direct_dispatch && best_path->direct_dispatch_contentIds)
+	if (root->config->gp_enable_direct_dispatch && best_path->pinned_direct_dispatch_contentIds)
 	{
 		DirectDispatchInfo dispatchInfo;
 
 		dispatchInfo.isDirectDispatch = true;
-		dispatchInfo.contentIds = best_path->direct_dispatch_contentIds;
+		dispatchInfo.contentIds = best_path->pinned_direct_dispatch_contentIds;
 		dispatchInfo.haveProcessedAnyCalculations = true;
 
 		MergeDirectDispatchCalculationInfo(&root->curSlice->directDispatch, &dispatchInfo);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1935,7 +1935,7 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 				 * gp_execution_segment() = <segid> here, so we should update
 				 * direct dispatch info when creating plan.
 				 */
-				((ProjectionPath *) subpath)->direct_dispatch_contentIds = list_make1_int(gp_session_id % numsegments);
+				((ProjectionPath *) subpath)->pinned_direct_dispatch_contentIds = list_make1_int(gp_session_id % numsegments);
 
 				CdbPathLocus_MakeStrewn(&(subpath->locus),
 				                        numsegments);

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -1975,10 +1975,16 @@ typedef struct ProjectionPath
 	List	   *cdb_restrict_clauses;
 
 	/*
-	 * CDB: projection with qual gp_execution_segment() = <segid>,
-	 * for such case we should consider update directdispatch info.
+	 * CDB: when this projection pins a General/SegmentGeneral child to a
+	 * single segment via a "gp_execution_segment() = <segid>" One-Time Filter,
+	 * this holds that pinned segid.  It marks the segment that the slice's
+	 * direct-dispatch calculation must not drop: create_projection_plan()
+	 * UNIONs it into the slice's direct-dispatch target set, and
+	 * create_append_plan() / create_mergeappend_plan() read it to skip vetoing
+	 * direct dispatch for such a deliberately-pinned (but Strewn-locus) child.
+	 * NIL when the projection pins nothing.
 	 */
-	List	   *direct_dispatch_contentIds;
+	List	   *pinned_direct_dispatch_contentIds;
 } ProjectionPath;
 
 /*


### PR DESCRIPTION
The field holds the segid of a General/SegmentGeneral child pinned to a single segment by a gp_execution_segment()=N One-Time Filter -- the content id the slice's direct-dispatch calculation **must not** drop. The old name conveyed neither the "pinned" role nor its NIL default. Rename it and expand the declaration comment; behaviour is unchanged.
