### PR TITLE
fix: dispatch ALTER COLLATION ... REFRESH VERSION to segments

### DIFF
--- a/src/backend/commands/collationcmds.c
+++ b/src/backend/commands/collationcmds.c
@@ -398,6 +398,20 @@ AlterCollation(AlterCollationStmt *stmt)
 	heap_freetuple(tup);
 	table_close(rel, NoLock);
 
+	/*
+	 * Refresh the version recorded in every segment's pg_collation too;
+	 * each node derives the actual version from its own collation
+	 * provider, and collation version mismatch checks run wherever the
+	 * collation is used.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		CdbDispatchUtilityStatement((Node *) stmt,
+									DF_CANCEL_ON_ERROR|
+									DF_WITH_SNAPSHOT|
+									DF_NEED_TWO_PHASE,
+									NIL,
+									NULL);
+
 	return address;
 }
 

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1376,6 +1376,10 @@ _outNode(StringInfo str, void *obj)
 				_outAlterObjectDependsStmt(str, obj);
 				break;
 
+			case T_AlterCollationStmt:
+				_outAlterCollationStmt(str, obj);
+				break;
+
 			case T_DefineStmt:
 				_outDefineStmt(str,obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3778,6 +3778,14 @@ _outSegfileMapNode(StringInfo str, const SegfileMapNode *node)
 
 
 static void
+_outAlterCollationStmt(StringInfo str, const AlterCollationStmt *node)
+{
+	WRITE_NODE_TYPE("ALTERCOLLATIONSTMT");
+
+	WRITE_NODE_FIELD(collname);
+}
+
+static void
 _outDefineStmt(StringInfo str, const DefineStmt *node)
 {
 	WRITE_NODE_TYPE("DEFINESTMT");
@@ -6133,6 +6141,10 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_AlterFunctionStmt:
 				_outAlterFunctionStmt(str, obj);
+				break;
+
+			case T_AlterCollationStmt:
+				_outAlterCollationStmt(str, obj);
 				break;
 
 			case T_DefineStmt:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2165,6 +2165,10 @@ readNodeBinary(void)
 				return_value = _readAlterFunctionStmt();
 				break;
 
+			case T_AlterCollationStmt:
+				return_value = _readAlterCollationStmt();
+				break;
+
 			case T_DefineStmt:
 				return_value = _readDefineStmt();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3867,6 +3867,16 @@ _readAlterFunctionStmt(void)
 	READ_DONE();
 }
 
+static AlterCollationStmt *
+_readAlterCollationStmt(void)
+{
+	READ_LOCALS(AlterCollationStmt);
+
+	READ_NODE_FIELD(collname);
+
+	READ_DONE();
+}
+
 static DefineStmt *
 _readDefineStmt(void)
 {
@@ -4742,6 +4752,8 @@ parseNodeString(void)
 		return_value = _readAConst();
 	else if (MATCHX("AEXPR"))
 		return_value = _readAExpr();
+	else if (MATCHX("ALTERCOLLATIONSTMT"))
+		return_value = _readAlterCollationStmt();
 	else if (MATCHX("ALTERDOMAINSTMT"))
 		return_value = _readAlterDomainStmt();
 	else if (MATCHX("ALTERFUNCTIONSTMT"))

--- a/src/test/regress/expected/gp_collation_refresh.out
+++ b/src/test/regress/expected/gp_collation_refresh.out
@@ -1,0 +1,49 @@
+--
+-- Verify that ALTER COLLATION ... REFRESH VERSION updates pg_collation on
+-- the coordinator and on every segment.  The collation version mismatch
+-- check runs on whichever node actually uses the collation, so a refresh
+-- must reach all of them.
+--
+-- Only ICU collations carry a version, so skip on builds without ICU (no
+-- ICU collations imported by initdb) or databases where ICU collations
+-- cannot be created.
+SELECT getdatabaseencoding() <> 'UTF8'
+       OR NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en-x-icu')
+       AS skip_test \gset
+\if :skip_test
+\quit
+\endif
+-- Suppress messages that embed the environment's ICU version string.
+SET client_min_messages = error;
+-- CREATE COLLATION is dispatched, so the stale version lands on all nodes.
+CREATE COLLATION coll_refresh_c (provider = icu, locale = 'en-US', version = '0.0');
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes,
+       count(DISTINCT collversion) = 1 AS consistent,
+       min(collversion) = '0.0'        AS stale
+FROM (SELECT collversion FROM pg_collation WHERE collname = 'coll_refresh_c'
+      UNION ALL
+      SELECT collversion FROM gp_dist_random('pg_collation')
+      WHERE collname = 'coll_refresh_c') q;
+ all_nodes | consistent | stale 
+-----------+------------+-------
+ t         | t          | t
+(1 row)
+
+ALTER COLLATION coll_refresh_c REFRESH VERSION;
+-- Every node must have re-derived its actual ICU version.
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes,
+       count(DISTINCT collversion) = 1 AS consistent,
+       bool_and(collversion <> '0.0')  AS refreshed
+FROM (SELECT collversion FROM pg_collation WHERE collname = 'coll_refresh_c'
+      UNION ALL
+      SELECT collversion FROM gp_dist_random('pg_collation')
+      WHERE collname = 'coll_refresh_c') q;
+ all_nodes | consistent | refreshed 
+-----------+------------+-----------
+ t         | t          | t
+(1 row)
+
+DROP COLLATION coll_refresh_c;
+RESET client_min_messages;

--- a/src/test/regress/expected/gp_collation_refresh_1.out
+++ b/src/test/regress/expected/gp_collation_refresh_1.out
@@ -1,0 +1,14 @@
+--
+-- Verify that ALTER COLLATION ... REFRESH VERSION updates pg_collation on
+-- the coordinator and on every segment.  The collation version mismatch
+-- check runs on whichever node actually uses the collation, so a refresh
+-- must reach all of them.
+--
+-- Only ICU collations carry a version, so skip on builds without ICU (no
+-- ICU collations imported by initdb) or databases where ICU collations
+-- cannot be created.
+SELECT getdatabaseencoding() <> 'UTF8'
+       OR NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en-x-icu')
+       AS skip_test \gset
+\if :skip_test
+\quit

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -364,4 +364,7 @@ test: quicklz_fallback
 # run pg_hba raleted testing
 test: hba_conf
 
+# ALTER COLLATION ... REFRESH VERSION must update every node's pg_collation
+test: gp_collation_refresh
+
 # end of tests

--- a/src/test/regress/sql/gp_collation_refresh.sql
+++ b/src/test/regress/sql/gp_collation_refresh.sql
@@ -1,0 +1,45 @@
+--
+-- Verify that ALTER COLLATION ... REFRESH VERSION updates pg_collation on
+-- the coordinator and on every segment.  The collation version mismatch
+-- check runs on whichever node actually uses the collation, so a refresh
+-- must reach all of them.
+--
+-- Only ICU collations carry a version, so skip on builds without ICU (no
+-- ICU collations imported by initdb) or databases where ICU collations
+-- cannot be created.
+SELECT getdatabaseencoding() <> 'UTF8'
+       OR NOT EXISTS (SELECT 1 FROM pg_collation WHERE collname = 'en-x-icu')
+       AS skip_test \gset
+\if :skip_test
+\quit
+\endif
+
+-- Suppress messages that embed the environment's ICU version string.
+SET client_min_messages = error;
+
+-- CREATE COLLATION is dispatched, so the stale version lands on all nodes.
+CREATE COLLATION coll_refresh_c (provider = icu, locale = 'en-US', version = '0.0');
+
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes,
+       count(DISTINCT collversion) = 1 AS consistent,
+       min(collversion) = '0.0'        AS stale
+FROM (SELECT collversion FROM pg_collation WHERE collname = 'coll_refresh_c'
+      UNION ALL
+      SELECT collversion FROM gp_dist_random('pg_collation')
+      WHERE collname = 'coll_refresh_c') q;
+
+ALTER COLLATION coll_refresh_c REFRESH VERSION;
+
+-- Every node must have re-derived its actual ICU version.
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes,
+       count(DISTINCT collversion) = 1 AS consistent,
+       bool_and(collversion <> '0.0')  AS refreshed
+FROM (SELECT collversion FROM pg_collation WHERE collname = 'coll_refresh_c'
+      UNION ALL
+      SELECT collversion FROM gp_dist_random('pg_collation')
+      WHERE collname = 'coll_refresh_c') q;
+
+DROP COLLATION coll_refresh_c;
+RESET client_min_messages;


### PR DESCRIPTION
## Problem

`ALTER COLLATION ... REFRESH VERSION` updates `pg_collation.collversion` on the coordinator only. The collation version mismatch check runs on whichever node actually uses the collation, so after a collation provider (ICU) upgrade:

1. every node starts warning `collation ... has version mismatch`;
2. the administrator reindexes and runs `ALTER COLLATION ... REFRESH VERSION`;
3. the warning disappears on the coordinator, **but the segments keep the stale version and keep warning forever** — there is no supported way to clear them cluster-wide.

Reproduction on an ICU build (`153.14` is the ICU 67.1 collator version):

```
-- plant collversion '0.0' on every node, then on the coordinator:
ALTER COLLATION c REFRESH VERSION;
NOTICE:  changing version from 0.0 to 153.14

-- probe pg_collation UNION ALL gp_dist_random('pg_collation'):
-1|153.14   0|0.0   1|0.0   2|0.0     <- catalogs silently diverged
```

## Fix

* `AlterCollation()` now dispatches the statement (same three-flag convention as `DefineCollation()` in the same file). Each node re-derives the version from its **own** collation provider, which is the correct semantics when provider versions differ across hosts.
* `AlterCollationStmt` had never been dispatched before, so it had no serialization support at all — dispatching died with `could not serialize unrecognized node type: 721 (outfast.c)`. Added the missing `_out`/`_read` functions and switch cases in outfuncs/outfast/readfuncs/readfast (the struct carries a single `List *collname`).

## Test

New `gp_collation_refresh` regress test (scheduled in `greenplum_schedule`):

* seeds a consistent stale version on **all** nodes through the already-dispatched `CREATE COLLATION ... (provider = icu, version = '0.0')` — no utility-mode catalog surgery needed;
* asserts cross-node consistency via boolean probes over `pg_collation UNION ALL gp_dist_random('pg_collation')` (no environment-specific ICU version strings in the expected output; node count taken from `gp_segment_configuration`, not hard-coded);
* skips cleanly on non-ICU builds / non-UTF8 databases via a `\if :skip_test \quit` guard plus an alternate expected file (`gp_collation_refresh_1.out`, captured from a real skip-path run).

## Verification

* Unpatched build: repro shows the divergence above; the new test **fails** with `consistent/refreshed = f|f` — it bites the actual bug.
* Patched build: all nodes converge (`153.14` everywhere, per-segment NOTICEs visible); test passes on both the ICU path and the skip path.
* `installcheck-small`: 194/194 pass.