### PR TITLE
Bake PGDG postgresql18-server into the rocky8/rocky9 build images

### DIFF
--- a/dockerfiles/Dockerfile.el8
+++ b/dockerfiles/Dockerfile.el8
@@ -83,6 +83,13 @@ RUN dnf install -y \
     zlib-devel \
     && dnf clean all
 
+# Vanilla PostgreSQL 18 server, baked at image build.
+# It serves as the postgres_fdw gp2pg remote; PGDG installs to /usr/pgsql-18.
+RUN dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm" \
+    && dnf -qy module disable postgresql \
+    && dnf install -y postgresql18-server \
+    && dnf clean all
+
 # add gpadmin user for building the database
 RUN groupadd gpadmin \
     && useradd -m -d /home/gpadmin -s /bin/bash -c "WarehousePG Database" -g gpadmin gpadmin \

--- a/dockerfiles/Dockerfile.el9
+++ b/dockerfiles/Dockerfile.el9
@@ -83,6 +83,13 @@ RUN dnf install -y \
     zlib-devel \
     && dnf clean all
 
+# Vanilla PostgreSQL 18 server, baked at image build.
+# It serves as the postgres_fdw gp2pg remote; PGDG installs to /usr/pgsql-18.
+RUN dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm" \
+    && dnf -qy module disable postgresql \
+    && dnf install -y postgresql18-server \
+    && dnf clean all
+
 # add gpadmin user for building the database
 RUN groupadd gpadmin \
     && useradd -m -d /home/gpadmin -s /bin/bash -c "WarehousePG Database" -g gpadmin gpadmin \


### PR DESCRIPTION
## Summary

This repo's build-docker-image workflow is the canonical source of `ghcr.io/warehouse-pg/whpg-rocky{8,9}-build`. That repo's ic-contrib leg now runs postgres_fdw's `gp2pg_postgres_fdw` suite against a vanilla PostgreSQL 18 sidecar; its `just sidecar-pg-up` recipe discovers `/usr/pgsql-18/bin`.

Bake PGDG `postgresql18-server` into both images so the sidecar has binaries with no job-time network dependency. PGDG carries PG18 for EL8/EL9 on both x86_64 and aarch64 (repo URL uses `$(uname -m)`). Images without PG18 are still safe: the gp2pg tests self-skip when no PG18 binaries are found.