### PR TITLE
Guard against unexpected dimensions of oidvector/int2vector.

### DIFF
--- a/src/backend/access/hash/hashfunc.c
+++ b/src/backend/access/hash/hashfunc.c
@@ -234,6 +234,7 @@ hashoidvector(PG_FUNCTION_ARGS)
 {
 	oidvector  *key = (oidvector *) PG_GETARG_POINTER(0);
 
+	check_valid_oidvector(key);
 	return hash_any((unsigned char *) key->values, key->dim1 * sizeof(Oid));
 }
 
@@ -242,6 +243,7 @@ hashoidvectorextended(PG_FUNCTION_ARGS)
 {
 	oidvector  *key = (oidvector *) PG_GETARG_POINTER(0);
 
+	check_valid_oidvector(key);
 	return hash_any_extended((unsigned char *) key->values,
 							 key->dim1 * sizeof(Oid),
 							 PG_GETARG_INT64(1));

--- a/src/backend/access/nbtree/nbtcompare.c
+++ b/src/backend/access/nbtree/nbtcompare.c
@@ -307,6 +307,9 @@ btoidvectorcmp(PG_FUNCTION_ARGS)
 	oidvector  *b = (oidvector *) PG_GETARG_POINTER(1);
 	int			i;
 
+	check_valid_oidvector(a);
+	check_valid_oidvector(b);
+
 	/* We arbitrarily choose to sort first by vector length */
 	if (a->dim1 != b->dim1)
 		PG_RETURN_INT32(a->dim1 - b->dim1);

--- a/src/backend/utils/adt/format_type.c
+++ b/src/backend/utils/adt/format_type.c
@@ -431,10 +431,14 @@ oidvectortypes(PG_FUNCTION_ARGS)
 {
 	oidvector  *oidArray = (oidvector *) PG_GETARG_POINTER(0);
 	char	   *result;
-	int			numargs = oidArray->dim1;
+	int			numargs;
 	int			num;
 	size_t		total;
 	size_t		left;
+
+	/* validate input before fetching dim1 */
+	check_valid_oidvector(oidArray);
+	numargs = oidArray->dim1;
 
 	total = 20 * numargs + 1;
 	result = palloc(total);

--- a/src/backend/utils/adt/int.c
+++ b/src/backend/utils/adt/int.c
@@ -135,6 +135,30 @@ buildint2vector(const int16 *int2s, int n)
 }
 
 /*
+ * validate that an array object meets the restrictions of int2vector
+ *
+ * We need this because there are pathways by which a general int2[] array can
+ * be cast to int2vector, allowing the type's restrictions to be violated.
+ * All code that receives an int2vector as a SQL parameter should check this.
+ */
+static void
+check_valid_int2vector(const int2vector *int2Array)
+{
+	/*
+	 * We insist on ndim == 1 and dataoffset == 0 (that is, no nulls) because
+	 * otherwise the array's layout will not be what calling code expects.  We
+	 * needn't be picky about the index lower bound though.  Checking elemtype
+	 * is just paranoia.
+	 */
+	if (int2Array->ndim != 1 ||
+		int2Array->dataoffset != 0 ||
+		int2Array->elemtype != INT2OID)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("array is not a valid int2vector")));
+}
+
+/*
  *		int2vectorin			- converts "num num ..." to internal form
  */
 Datum
@@ -181,9 +205,13 @@ int2vectorout(PG_FUNCTION_ARGS)
 {
 	int2vector *int2Array = (int2vector *) PG_GETARG_POINTER(0);
 	int			num,
-				nnums = int2Array->dim1;
+				nnums;
 	char	   *rp;
 	char	   *result;
+
+	/* validate input before fetching dim1 */
+	check_valid_int2vector(int2Array);
+	nnums = int2Array->dim1;
 
 	/* assumes sign, 5 digits, ' ' */
 	rp = result = (char *) palloc(nnums * 7 + 1);
@@ -253,6 +281,7 @@ int2vectorrecv(PG_FUNCTION_ARGS)
 Datum
 int2vectorsend(PG_FUNCTION_ARGS)
 {
+	/* We don't do check_valid_int2vector, since array_send won't care */
 	return array_send(fcinfo);
 }
 

--- a/src/backend/utils/adt/oid.c
+++ b/src/backend/utils/adt/oid.c
@@ -188,6 +188,30 @@ buildoidvector(const Oid *oids, int n)
 }
 
 /*
+ * validate that an array object meets the restrictions of oidvector
+ *
+ * We need this because there are pathways by which a general oid[] array can
+ * be cast to oidvector, allowing the type's restrictions to be violated.
+ * All code that receives an oidvector as a SQL parameter should check this.
+ */
+void
+check_valid_oidvector(const oidvector *oidArray)
+{
+	/*
+	 * We insist on ndim == 1 and dataoffset == 0 (that is, no nulls) because
+	 * otherwise the array's layout will not be what calling code expects.  We
+	 * needn't be picky about the index lower bound though.  Checking elemtype
+	 * is just paranoia.
+	 */
+	if (oidArray->ndim != 1 ||
+		oidArray->dataoffset != 0 ||
+		oidArray->elemtype != OIDOID)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("array is not a valid oidvector")));
+}
+
+/*
  *		oidvectorin			- converts "num num ..." to internal form
  */
 Datum
@@ -232,9 +256,13 @@ oidvectorout(PG_FUNCTION_ARGS)
 {
 	oidvector  *oidArray = (oidvector *) PG_GETARG_POINTER(0);
 	int			num,
-				nnums = oidArray->dim1;
+				nnums;
 	char	   *rp;
 	char	   *result;
+
+	/* validate input before fetching dim1 */
+	check_valid_oidvector(oidArray);
+	nnums = oidArray->dim1;
 
 	/* assumes sign, 10 digits, ' ' */
 	rp = result = (char *) palloc(nnums * 12 + 1);
@@ -304,6 +332,7 @@ oidvectorrecv(PG_FUNCTION_ARGS)
 Datum
 oidvectorsend(PG_FUNCTION_ARGS)
 {
+	/* We don't do check_valid_oidvector, since array_send won't care */
 	return array_send(fcinfo);
 }
 

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -63,6 +63,7 @@ extern int64 get_size_from_segDBs(const char *cmd);
 
 /* oid.c */
 extern oidvector *buildoidvector(const Oid *oids, int n);
+extern void check_valid_oidvector(const oidvector *oidArray);
 extern Oid	oidparse(Node *node);
 
 /* pseudotypes.c */

--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -1530,6 +1530,11 @@ select '[0:1]={1.1,2.2}'::float8[];
 (1 row)
 
 -- all of the above should be accepted
+-- some day we might allow these cases, but for now they're errors:
+select array[]::oidvector;
+ERROR:  array is not a valid oidvector
+select array[]::int2vector;
+ERROR:  array is not a valid int2vector
 -- tests for array aggregates
 CREATE TEMP TABLE arraggtest ( f1 INT[], f2 TEXT[][], f3 FLOAT[]) DISTRIBUTED RANDOMLY;
 INSERT INTO arraggtest (f1, f2, f3) VALUES

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -473,6 +473,10 @@ select array[]::text[];
 select '[0:1]={1.1,2.2}'::float8[];
 -- all of the above should be accepted
 
+-- some day we might allow these cases, but for now they're errors:
+select array[]::oidvector;
+select array[]::int2vector;
+
 -- tests for array aggregates
 CREATE TEMP TABLE arraggtest ( f1 INT[], f2 TEXT[][], f3 FLOAT[]) DISTRIBUTED RANDOMLY;
 


### PR DESCRIPTION
These data types are represented like full-fledged arrays, but functions that deal specifically with these types assume that the array is 1-dimensional and contains no nulls.  However, there are cast pathways that allow general oid[] or int2[] arrays to be cast to these types, allowing these expectations to be violated.  This can be exploited to cause server memory disclosure or SIGSEGV. Fix by installing explicit checks in functions that accept these types.

Reported-by: Altan Birler <altan.birler@tum.de>
Author: Tom Lane <tgl@sss.pgh.pa.us>
Reviewed-by: Noah Misch <noah@leadboat.com>
Security: CVE-2026-2003
Backpatch-through: 14
(cherry picked from commit b39d3813992d4d1fd50e68a9c5be9ba4306de96c)