### PR TITLE
fix: treat fixed-size hash keys as binary, and enforce key semantics in hash_create()

### DIFF
--- a/contrib/dblink/dblink.c
+++ b/contrib/dblink/dblink.c
@@ -2568,7 +2568,7 @@ createConnHash(void)
 	ctl.keysize = NAMEDATALEN;
 	ctl.entrysize = sizeof(remoteConnHashEnt);
 
-	return hash_create("Remote Con hash", NUMCONN, &ctl, HASH_ELEM);
+	return hash_create("Remote Con hash", NUMCONN, &ctl, HASH_ELEM | HASH_STRINGS);
 }
 
 static void

--- a/contrib/tablefunc/tablefunc.c
+++ b/contrib/tablefunc/tablefunc.c
@@ -724,7 +724,7 @@ load_categories_hash(char *cats_sql, MemoryContext per_query_ctx)
 	crosstab_hash = hash_create("crosstab hash",
 								INIT_CATS,
 								&ctl,
-								HASH_ELEM | HASH_CONTEXT);
+								HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 	/* Connect to SPI manager */
 	if ((ret = SPI_connect()) < 0)

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -1378,7 +1378,7 @@ validateColumnStorageEncodingClauses(List *aocoColumnEncoding,
 				memset(&cacheInfo, 0, sizeof(cacheInfo));
 				cacheInfo.keysize = NAMEDATALEN;
 				cacheInfo.entrysize = sizeof(*ce);
-				cacheFlags = HASH_ELEM;
+				cacheFlags = HASH_ELEM | HASH_STRINGS;
 
 				ht = hash_create("column info cache",
 								 list_length(tableElts),

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -355,7 +355,8 @@ gatherRMInDoubtTransactions(int prepared_seconds, bool raiseError)
 				hctl.keysize = TMGIDSIZE;	/* GID */
 				hctl.entrysize = sizeof(InDoubtDtx);
 
-				htab = hash_create("InDoubtDtxHash", 10, &hctl, HASH_ELEM);
+				htab = hash_create("InDoubtDtxHash", 10, &hctl,
+								   HASH_ELEM | HASH_STRINGS);
 
 				if (htab == NULL)
 					ereport(FATAL,

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1485,7 +1485,8 @@ getDnsCachedAddress(char *name, int port, int elevel, bool use_cache)
 			hash_ctl.entrysize = sizeof(SegIpEntry);
 
 			segment_ip_cache_htab = hash_create("segment_dns_cache",
-												256, &hash_ctl, HASH_ELEM);
+												256, &hash_ctl,
+												HASH_ELEM | HASH_STRINGS);
 		}
 		else
 		{
@@ -1707,7 +1708,8 @@ hostPrimaryCountHashTableInit(void)
 	 */
 	info.hcxt = CdbComponentsContext;
 
-	return hash_create("HostSegs", 32, &info, HASH_ELEM | HASH_CONTEXT);
+	return hash_create("HostSegs", 32, &info,
+					   HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 }
 
 /*

--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -458,7 +458,7 @@ InitQueryHashTable(void)
 	prepared_queries = hash_create("Prepared Queries",
 								   32,
 								   &hash_ctl,
-								   HASH_ELEM);
+								   HASH_ELEM | HASH_STRINGS);
 }
 
 /*

--- a/src/backend/nodes/extensible.c
+++ b/src/backend/nodes/extensible.c
@@ -51,7 +51,7 @@ RegisterExtensibleNodeEntry(HTAB **p_htable, const char *htable_label,
 		ctl.keysize = EXTNODENAME_MAX_LEN;
 		ctl.entrysize = sizeof(ExtensibleNodeEntry);
 
-		*p_htable = hash_create(htable_label, 100, &ctl, HASH_ELEM);
+		*p_htable = hash_create(htable_label, 100, &ctl, HASH_ELEM | HASH_STRINGS);
 	}
 
 	if (strlen(extnodename) >= EXTNODENAME_MAX_LEN)

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2156,7 +2156,8 @@ do_autovacuum(void)
 	MemSet(&ctl, 0, sizeof(ctl));
         ctl.keysize = sizeof(int);
         ctl.entrysize = sizeof(int);
-	sessionhash = hash_create("Running session IDs", 8, &ctl, HASH_ELEM);
+	sessionhash = hash_create("Running session IDs", 8, &ctl,
+							  HASH_ELEM | HASH_BLOBS);
 
 	sessionlist = GetRunningProcSessionIds();
 	foreach(lc, sessionlist)

--- a/src/backend/storage/file/reinit.c
+++ b/src/backend/storage/file/reinit.c
@@ -178,7 +178,8 @@ ResetUnloggedRelationsInDbspaceDir(const char *dbspacedirname, int op)
 		memset(&ctl, 0, sizeof(ctl));
 		ctl.keysize = sizeof(unlogged_relation_entry);
 		ctl.entrysize = sizeof(unlogged_relation_entry);
-		hash = hash_create("unlogged hash", 32, &ctl, HASH_ELEM);
+		hash = hash_create("unlogged hash", 32, &ctl,
+						   HASH_ELEM | HASH_STRINGS);
 
 		/* Scan the directory. */
 		dbspace_dir = AllocateDir(dbspacedirname);

--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -319,7 +319,7 @@ InitShmemIndex(void)
 	 */
 	info.keysize = SHMEM_INDEX_KEYSIZE;
 	info.entrysize = sizeof(ShmemIndexEnt);
-	hash_flags = HASH_ELEM;
+	hash_flags = HASH_ELEM | HASH_STRINGS;
 
 	ShmemIndex = ShmemInitHash("ShmemIndex",
 							   SHMEM_INDEX_SIZE, SHMEM_INDEX_SIZE,

--- a/src/backend/utils/adt/jsonfuncs.c
+++ b/src/backend/utils/adt/jsonfuncs.c
@@ -3390,7 +3390,7 @@ get_json_object_as_hash(char *json, int len, const char *funcname)
 	tab = hash_create("json object hashtable",
 					  100,
 					  &ctl,
-					  HASH_ELEM | HASH_CONTEXT);
+					  HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 
 	state = palloc0(sizeof(JHashState));
 	sem = palloc0(sizeof(JsonSemAction));
@@ -3782,7 +3782,7 @@ populate_recordset_object_start(void *state)
 	_state->json_hash = hash_create("json object hashtable",
 									100,
 									&ctl,
-									HASH_ELEM | HASH_CONTEXT);
+									HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 }
 
 static void

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3447,7 +3447,7 @@ set_rtable_names(deparse_namespace *dpns, List *parent_namespaces,
 	names_hash = hash_create("set_rtable_names names",
 							 list_length(dpns->rtable),
 							 &hash_ctl,
-							 HASH_ELEM | HASH_CONTEXT);
+							 HASH_ELEM | HASH_STRINGS | HASH_CONTEXT);
 	/* Preload the hash table with names appearing in parent_namespaces */
 	foreach(lc, parent_namespaces)
 	{

--- a/src/backend/utils/fmgr/dfmgr.c
+++ b/src/backend/utils/fmgr/dfmgr.c
@@ -743,7 +743,7 @@ find_rendezvous_variable(const char *varName)
 		rendezvousHash = hash_create("Rendezvous variable hash",
 									 16,
 									 &ctl,
-									 HASH_ELEM);
+									 HASH_ELEM | HASH_STRINGS);
 	}
 
 	/* Find or create the hashtable entry for this varName */

--- a/src/backend/utils/hash/dynahash.c
+++ b/src/backend/utils/hash/dynahash.c
@@ -30,7 +30,8 @@
  * dynahash.c provides support for these types of lookup keys:
  *
  * 1. Null-terminated C strings (truncated if necessary to fit in keysize),
- * compared as though by strcmp().  This is the default behavior.
+ * compared as though by strcmp().  This is selected by specifying the
+ * HASH_STRINGS flag to hash_create.
  *
  * 2. Arbitrary binary data of size keysize, compared as though by memcmp().
  * (Caller must ensure there are no undefined padding bits in the keys!)
@@ -307,6 +308,12 @@ string_compare(const char *key1, const char *key2, Size keysize)
  *	*info: additional table parameters, as indicated by flags
  *	flags: bitmask indicating which parameters to take from *info
  *
+ * The flags value must include exactly one of HASH_STRINGS, HASH_BLOBS,
+ * or HASH_FUNCTION, to define the key hashing semantics (C strings,
+ * binary blobs, or custom, respectively).  Callers specifying a custom
+ * hash function will likely also want to use HASH_COMPARE, and perhaps
+ * also HASH_KEYCOPY, to control key comparison and copying.
+ *
  * Note: for a shared-memory hashtable, nelem needs to be a pretty good
  * estimate, since we can't expand the table on the fly.  But an unshared
  * hashtable can be expanded on-the-fly, so it's better for nelem to be
@@ -361,9 +368,13 @@ hash_create(const char *tabname, long nelem, HASHCTL *info, int flags)
 	 * Select the appropriate hash function (see comments at head of file).
 	 */
 	if (flags & HASH_FUNCTION)
+	{
+		Assert(!(flags & (HASH_BLOBS | HASH_STRINGS)));
 		hashp->hash = info->hash;
+	}
 	else if (flags & HASH_BLOBS)
 	{
+		Assert(!(flags & HASH_STRINGS));
 		/* We can optimize hashing for common key sizes */
 		Assert(flags & HASH_ELEM);
 		if (info->keysize == sizeof(uint32))
@@ -372,7 +383,21 @@ hash_create(const char *tabname, long nelem, HASHCTL *info, int flags)
 			hashp->hash = tag_hash;
 	}
 	else
-		hashp->hash = string_hash;	/* default hash function */
+	{
+		/*
+		 * string_hash used to be considered the default hash method, and in a
+		 * non-assert build it effectively still is.  But we now consider it
+		 * an assertion error to not say HASH_STRINGS explicitly.  To help
+		 * catch mistaken usage of HASH_STRINGS, we also insist on a
+		 * reasonably long string length: if the keysize is only 4 or 8 bytes,
+		 * it's almost certainly an integer or pointer not a string.
+		 */
+		Assert(flags & HASH_STRINGS);
+		Assert(flags & HASH_ELEM);
+		Assert(info->keysize > 8);
+
+		hashp->hash = string_hash;
+	}
 
 	/*
 	 * If you don't specify a match function, it defaults to string_compare if

--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -126,7 +126,7 @@ EnablePortalManager(void)
 	 * create, initially
 	 */
 	PortalHashTable = hash_create("Portal hash", PORTALS_PER_USER,
-								  &ctl, HASH_ELEM);
+								  &ctl, HASH_ELEM | HASH_STRINGS);
 }
 
 /*

--- a/src/backend/utils/resgroup/cgroup_io_limit.c
+++ b/src/backend/utils/resgroup/cgroup_io_limit.c
@@ -410,7 +410,7 @@ get_iostat(Oid groupid, List *io_limit)
 	ctl.hcxt = CurrentMemoryContext;
 	io_stat_hash =
 		hash_create("hash table for bdi -> io stat", list_length(io_limit), &ctl,
-					HASH_ELEM | HASH_CONTEXT);
+					HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
 	while (pg_get_line_append(f, line))
 	{

--- a/src/include/utils/hsearch.h
+++ b/src/include/utils/hsearch.h
@@ -94,6 +94,7 @@ typedef struct HASHCTL
 #define HASH_SHARED_MEM 0x0800	/* Hashtable is in shared memory */
 #define HASH_ATTACH		0x1000	/* Do not initialize hctl */
 #define HASH_FIXED_SIZE 0x2000	/* Initial size is a hard limit */
+#define HASH_STRINGS	0x4000	/* Select support functions for string keys */
 
 
 /* max_dsize value to indicate expansible directory */
@@ -120,8 +121,9 @@ typedef struct
  * prototypes for functions in dynahash.c
  *
  * Note: It is deprecated for callers of hash_create to explicitly specify
- * string_hash, tag_hash, uint32_hash, or oid_hash.  Just set HASH_BLOBS or
- * not.  Use HASH_FUNCTION only when you want something other than those.
+ * string_hash, tag_hash, uint32_hash, or oid_hash.  Just set HASH_STRINGS
+ * or HASH_BLOBS.  Use HASH_FUNCTION only when you want something other than
+ * one of these.
  */
 extern uint32 tag_hash(const void *key, Size keysize);
 extern HTAB *hash_create(const char *tabname, long nelem,

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -590,7 +590,7 @@ select_perl_context(bool trusted)
 		interp_desc->query_hash = hash_create("PL/Perl queries",
 											  32,
 											  &hash_ctl,
-											  HASH_ELEM);
+											  HASH_ELEM | HASH_STRINGS);
 	}
 
 	/*

--- a/src/test/regress/expected/autovacuum-alive-session.out
+++ b/src/test/regress/expected/autovacuum-alive-session.out
@@ -1,0 +1,145 @@
+-- The autovacuum orphan-temp-namespace sweep must compare session ids as
+-- fixed-size binary keys.  If the alive-session hash table falls back to
+-- string hashing/comparison, the comparison stops at the first zero byte
+-- of the key: an orphaned namespace whose numeric suffix differs from a
+-- live session id only in bytes past that zero byte is mistaken for the
+-- live session's namespace and never cleaned up.
+--
+-- Scenario: take our own session id S and find the first zero byte below
+-- its top byte.  Adding 256^p (p = 1-based position of that zero byte)
+-- flips a byte that string comparison never reaches, so the orphan suffix
+-- S + 256^p reads as the same C string as S.  Under string comparison the
+-- sweep wrongly considers the orphan alive; under binary comparison the
+-- orphan is swept.  Our real temp table must survive either way.
+--
+-- NOTE: this test must run inside an enable_autovacuum schedule window
+-- (it relies on the launcher being up); it manages only naptime itself,
+-- like the other autovacuum-* tests.
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+RESET client_min_messages;
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- The string-alias offset for this session: 256^p where the p'th byte
+-- (1-based, little-endian) of the session id is the first zero byte below
+-- the top byte.  Such a byte exists for every session id below 65536 (CI
+-- clusters) and for larger ids whose low bytes happen to contain a zero;
+-- if none exists, the alias is mathematically inexpressible and we bail
+-- out with an explanation rather than construct a vacuous test.
+CREATE OR REPLACE FUNCTION alias_offset() RETURNS bigint AS $$
+DECLARE sid int; ofs bigint;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  IF sid <= 0 THEN
+    RAISE EXCEPTION 'invalid session id %', sid;
+  END IF;
+  FOR p IN 1..3 LOOP
+    IF (sid / (256^(p-1))::bigint) % 256 = 0 THEN
+      ofs := (256^p)::bigint;
+      IF sid + ofs > 2147483647 THEN
+        RAISE EXCEPTION 'alias suffix for session id % overflows int4', sid;
+      END IF;
+      RETURN ofs;
+    END IF;
+  END LOOP;
+  RAISE EXCEPTION 'session id % has no zero byte below its top byte; the string-alias cannot be constructed -- rerun on a younger cluster', sid;
+END $$ LANGUAGE plpgsql STABLE;
+-- positive control: a live session's real temp table
+CREATE TEMP TABLE alive_probe(a int) DISTRIBUTED BY (a);
+INSERT INTO alive_probe SELECT generate_series(1, 10);
+-- fabricate the orphan: a plain table rewritten into a temp table living
+-- in a namespace whose suffix string-aliases our session id.  The catalog
+-- UPDATEs below run on the coordinator only (catalog DML is not
+-- dispatched); the segments keep the schema under its original name, and
+-- cleanup at the end relies on that.
+CREATE SCHEMA orphan_probe_schema;
+CREATE TABLE orphan_probe_schema.t(a int) DISTRIBUTED BY (a);
+SET allow_system_table_mods = on;
+DO $$
+DECLARE sid int;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  UPDATE pg_namespace SET nspname = 'pg_temp_' || (sid + alias_offset())
+   WHERE nspname = 'orphan_probe_schema';
+  UPDATE pg_class SET relpersistence = 't'
+   WHERE oid = ('pg_temp_' || (sid + alias_offset()) || '.t')::regclass;
+END $$;
+RESET allow_system_table_mods;
+-- wait for autovacuum workers to visit this database a few times
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'skip', '', 'regression', '', 1, -1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- the orphan must get swept (bounded poll; prints the final state)
+DO $$
+DECLARE sid int; gone boolean := false;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  FOR i IN 1..150 LOOP
+    PERFORM 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = 't' AND n.nspname = 'pg_temp_' || (sid + alias_offset());
+    gone := NOT FOUND;
+    EXIT WHEN gone;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  IF gone THEN
+    RAISE NOTICE 'orphan temp table swept';
+  ELSE
+    RAISE NOTICE 'orphan temp table still present';
+  END IF;
+END $$;
+NOTICE:  orphan temp table swept
+-- the live session's temp table must have survived the sweep
+SELECT count(*) FROM alive_probe;
+ count 
+-------
+    10
+(1 row)
+
+-- Cleanup, working in both outcomes.  The surgery above only renamed the
+-- coordinator's copy of the schema; the segments still have
+-- orphan_probe_schema.t.  Rename the coordinator's copy back (and restore
+-- relpersistence if the table survived), then drop the schema everywhere
+-- with ordinary dispatched DDL.
+SET allow_system_table_mods = on;
+DO $$
+DECLARE sid int;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  UPDATE pg_namespace SET nspname = 'orphan_probe_schema'
+   WHERE nspname = 'pg_temp_' || (sid + alias_offset());
+  UPDATE pg_class SET relpersistence = 'p'
+   WHERE relname = 't'
+     AND relnamespace = (SELECT oid FROM pg_namespace
+                          WHERE nspname = 'orphan_probe_schema');
+END $$;
+RESET allow_system_table_mods;
+DROP SCHEMA orphan_probe_schema CASCADE;
+DROP FUNCTION alias_offset();
+ALTER SYSTEM RESET autovacuum_naptime;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -321,6 +321,7 @@ test: autovacuum-segment
 test: autovacuum-template0-segment
 test: autovacuum-catalog
 test: autovacuum-ao-aux
+test: autovacuum-alive-session
 
 # gpexpand introduce the partial tables, check them if they can run correctly
 test: gangsize gang_reuse

--- a/src/test/regress/sql/autovacuum-alive-session.sql
+++ b/src/test/regress/sql/autovacuum-alive-session.sql
@@ -1,0 +1,123 @@
+-- The autovacuum orphan-temp-namespace sweep must compare session ids as
+-- fixed-size binary keys.  If the alive-session hash table falls back to
+-- string hashing/comparison, the comparison stops at the first zero byte
+-- of the key: an orphaned namespace whose numeric suffix differs from a
+-- live session id only in bytes past that zero byte is mistaken for the
+-- live session's namespace and never cleaned up.
+--
+-- Scenario: take our own session id S and find the first zero byte below
+-- its top byte.  Adding 256^p (p = 1-based position of that zero byte)
+-- flips a byte that string comparison never reaches, so the orphan suffix
+-- S + 256^p reads as the same C string as S.  Under string comparison the
+-- sweep wrongly considers the orphan alive; under binary comparison the
+-- orphan is swept.  Our real temp table must survive either way.
+--
+-- NOTE: this test must run inside an enable_autovacuum schedule window
+-- (it relies on the launcher being up); it manages only naptime itself,
+-- like the other autovacuum-* tests.
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+RESET client_min_messages;
+
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+SELECT pg_reload_conf();
+
+-- The string-alias offset for this session: 256^p where the p'th byte
+-- (1-based, little-endian) of the session id is the first zero byte below
+-- the top byte.  Such a byte exists for every session id below 65536 (CI
+-- clusters) and for larger ids whose low bytes happen to contain a zero;
+-- if none exists, the alias is mathematically inexpressible and we bail
+-- out with an explanation rather than construct a vacuous test.
+CREATE OR REPLACE FUNCTION alias_offset() RETURNS bigint AS $$
+DECLARE sid int; ofs bigint;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  IF sid <= 0 THEN
+    RAISE EXCEPTION 'invalid session id %', sid;
+  END IF;
+  FOR p IN 1..3 LOOP
+    IF (sid / (256^(p-1))::bigint) % 256 = 0 THEN
+      ofs := (256^p)::bigint;
+      IF sid + ofs > 2147483647 THEN
+        RAISE EXCEPTION 'alias suffix for session id % overflows int4', sid;
+      END IF;
+      RETURN ofs;
+    END IF;
+  END LOOP;
+  RAISE EXCEPTION 'session id % has no zero byte below its top byte; the string-alias cannot be constructed -- rerun on a younger cluster', sid;
+END $$ LANGUAGE plpgsql STABLE;
+
+-- positive control: a live session's real temp table
+CREATE TEMP TABLE alive_probe(a int) DISTRIBUTED BY (a);
+INSERT INTO alive_probe SELECT generate_series(1, 10);
+
+-- fabricate the orphan: a plain table rewritten into a temp table living
+-- in a namespace whose suffix string-aliases our session id.  The catalog
+-- UPDATEs below run on the coordinator only (catalog DML is not
+-- dispatched); the segments keep the schema under its original name, and
+-- cleanup at the end relies on that.
+CREATE SCHEMA orphan_probe_schema;
+CREATE TABLE orphan_probe_schema.t(a int) DISTRIBUTED BY (a);
+SET allow_system_table_mods = on;
+DO $$
+DECLARE sid int;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  UPDATE pg_namespace SET nspname = 'pg_temp_' || (sid + alias_offset())
+   WHERE nspname = 'orphan_probe_schema';
+  UPDATE pg_class SET relpersistence = 't'
+   WHERE oid = ('pg_temp_' || (sid + alias_offset()) || '.t')::regclass;
+END $$;
+RESET allow_system_table_mods;
+
+-- wait for autovacuum workers to visit this database a few times
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'skip', '', 'regression', '', 1, -1, 0, 1);
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_before_do_autovacuum', 3, 1);
+SELECT gp_inject_fault('auto_vac_worker_before_do_autovacuum', 'reset', 1);
+
+-- the orphan must get swept (bounded poll; prints the final state)
+DO $$
+DECLARE sid int; gone boolean := false;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  FOR i IN 1..150 LOOP
+    PERFORM 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relname = 't' AND n.nspname = 'pg_temp_' || (sid + alias_offset());
+    gone := NOT FOUND;
+    EXIT WHEN gone;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  IF gone THEN
+    RAISE NOTICE 'orphan temp table swept';
+  ELSE
+    RAISE NOTICE 'orphan temp table still present';
+  END IF;
+END $$;
+
+-- the live session's temp table must have survived the sweep
+SELECT count(*) FROM alive_probe;
+
+-- Cleanup, working in both outcomes.  The surgery above only renamed the
+-- coordinator's copy of the schema; the segments still have
+-- orphan_probe_schema.t.  Rename the coordinator's copy back (and restore
+-- relpersistence if the table survived), then drop the schema everywhere
+-- with ordinary dispatched DDL.
+SET allow_system_table_mods = on;
+DO $$
+DECLARE sid int;
+BEGIN
+  SELECT sess_id INTO sid FROM pg_stat_activity WHERE pid = pg_backend_pid();
+  UPDATE pg_namespace SET nspname = 'orphan_probe_schema'
+   WHERE nspname = 'pg_temp_' || (sid + alias_offset());
+  UPDATE pg_class SET relpersistence = 'p'
+   WHERE relname = 't'
+     AND relnamespace = (SELECT oid FROM pg_namespace
+                          WHERE nspname = 'orphan_probe_schema');
+END $$;
+RESET allow_system_table_mods;
+DROP SCHEMA orphan_probe_schema CASCADE;
+
+DROP FUNCTION alias_offset();
+ALTER SYSTEM RESET autovacuum_naptime;
+SELECT pg_reload_conf();

--- a/src/timezone/pgtz.c
+++ b/src/timezone/pgtz.c
@@ -211,7 +211,7 @@ init_timezone_hashtable(void)
 	timezone_cache = hash_create("Timezones",
 								 4,
 								 &hash_ctl,
-								 HASH_ELEM);
+								 HASH_ELEM | HASH_STRINGS);
 	if (!timezone_cache)
 		return false;
 


### PR DESCRIPTION
Three commits: two bug fixes sharing one defect pattern, plus a backport of the upstream hardening that makes the pattern impossible to reintroduce silently.

## The defect pattern

`hash_create()` without `HASH_BLOBS`/`HASH_FUNCTION` silently defaults to **string** hashing and comparison. Callers keying on fixed-size integers then get `strlen()`/`strncmp()` over binary bytes: out-of-bounds reads when no key byte is zero, and truncated comparisons that make different keys alias whenever they agree up to the first zero byte.

## Commit 1 — autovacuum alive-session hash (`do_autovacuum`)

Session ids (4-byte ints) hashed as strings:

* Under AddressSanitizer every autovacuum worker aborts at startup (`stack-buffer-overflow` in `string_hash`), crash-looping the cluster.
* Deterministic aliasing: with a live session id `S < 65536`, an orphaned temp namespace with suffix `S + 2^24` has the identical C-string view (`3D 00 00 00` vs `3D 00 00 01` → both `"\x3D"`) and is never cleaned up.

Fix: `HASH_ELEM | HASH_BLOBS`. New `autovacuum-alive-session` regress test fabricates the aliasing orphan via catalog surgery, waits on the existing `auto_vac_worker_before_do_autovacuum` fault point, and asserts the orphan is swept while the live session's own temp table survives. The test fails without the fix (`swept` → `still present`).

## Commit 2 — resource-group io-limit bdi hash

Same pattern, worse odds: keys are `bdi_t` (`dev_t`), whose first byte is the minor number's low 8 bits. Whole-disk devices typically have minor 0 (`sda` 8:0, `nvme0n1` 259:0, `dm-0` 253:0), so their keys all read as the **empty string** — every such device collapses into a single hash entry, misattributing or losing per-device IO statistics. Found by auditing all 114 `hash_create()` call sites for this pattern.

## Commit 3 — enforce key semantics (PostgreSQL 14 hardening, backported)

`hash_create()` now asserts exactly one of `HASH_STRINGS` / `HASH_BLOBS` / `HASH_FUNCTION`, and that string keys are longer than 8 bytes — so the "integer hashed as a string" mistake fails fast at table creation in assert-enabled builds instead of silently corrupting lookups. All in-tree callers relying on the implicit string default (19 sites) now say `HASH_STRINGS` explicitly. No behavior change in production builds.

The assertion proved itself immediately: it caught one call site the static audit had missed (`InitShmemIndex`, exercised at bootstrap — initdb fails without the flag).

## Verification

* Assert-enabled build: `initdb` clean; full `installcheck-good` (669 tests) runs with **zero assertion failures and zero crashes**; the 8 failing tests are pre-existing environment/build-option diffs (tablespace path length, no-llvm/no-libxml/no-gpfdist build, hba view) unrelated to this branch, and the new `autovacuum-alive-session` test passes within the full schedule.
* Unfixed builds fail the new test with the bug's exact signature; under ASan the unfixed autovacuum worker aborts in `string_hash`.