### PR TITLE
fix: event trigger external table failed

### DIFF
--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -71,7 +71,7 @@ static List * GenerateExtTableEntryOptions(Oid tbloid,
 * to leave it intact and do another dispatch.
 * ----------------------------------------------------------------
 */
-void
+ObjectAddress
 DefineExternalRelation(CreateExternalStmt *createExtStmt)
 {
 	CreateForeignTableStmt *createForeignTableStmt;
@@ -290,6 +290,12 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	else
 		reloid = RangeVarGetRelid(createExtStmt->relation, NoLock, true);
 
+	/*
+	 * Keep the address in step with the OID we actually work on below, so the
+	 * caller can hand it to ddl_command_end event triggers.
+	 */
+	ObjectAddressSet(objAddr, RelationRelationId, reloid);
+
 	entryOptions = GenerateExtTableEntryOptions(reloid,
 										   iswritable,
 										   issreh,
@@ -328,6 +334,8 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
+
+	return objAddr;
 }
 
 /*

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1156,7 +1156,7 @@ ProcessUtilitySlow(ParseState *pstate,
 	bool		isCompleteQuery = (context != PROCESS_UTILITY_SUBCOMMAND);
 	bool		needCleanup;
 	bool		commandCollected = false;
-	ObjectAddress address;
+	ObjectAddress address = InvalidObjectAddress;
 	ObjectAddress secondaryObject = InvalidObjectAddress;
 
 	List 		*deferredValidationParts = NIL;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1688,7 +1688,13 @@ ProcessUtilitySlow(ParseState *pstate,
 						Node	   *stmt = (Node *) lfirst(l);
 
 						if (IsA(stmt, CreateExternalStmt))
-							DefineExternalRelation((CreateExternalStmt *) stmt);
+						{
+							address = DefineExternalRelation((CreateExternalStmt *) stmt);
+
+							EventTriggerCollectSimpleCommand(address,
+															 secondaryObject,
+															 stmt);
+						}
 						else
 						{
 							PlannedStmt *wrapper;
@@ -1710,6 +1716,9 @@ ProcessUtilitySlow(ParseState *pstate,
 										   NULL);
 						}
 					}
+
+					/* commands are collected in the loop above */
+					commandCollected = true;
 				}
 				break;
 

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -31,7 +31,7 @@
 
 extern const char *synthetic_sql;
 
-extern void	DefineExternalRelation(CreateExternalStmt *stmt);
+extern ObjectAddress DefineExternalRelation(CreateExternalStmt *stmt);
 
 extern ObjectAddress DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 									ObjectAddress *typaddress, const char *queryString, bool dispatch,

--- a/src/test/regress/expected/event_trigger_gp.out
+++ b/src/test/regress/expected/event_trigger_gp.out
@@ -11,8 +11,10 @@ NOTICE:  test_event_trigger: ddl_command_start CREATE EXTERNAL TABLE
 DROP EXTERNAL TABLE echotest;
 NOTICE:  test_event_trigger: ddl_command_start DROP FOREIGN TABLE
 CREATE OR REPLACE FUNCTION write_to_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE NO SQL;
+NOTICE:  specifying "NO SQL" acts as no operation.
 NOTICE:  test_event_trigger: ddl_command_start CREATE FUNCTION
 CREATE OR REPLACE FUNCTION read_from_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
+NOTICE:  specifying "NO SQL" acts as no operation.
 NOTICE:  test_event_trigger: ddl_command_start CREATE FUNCTION
 CREATE PROTOCOL demoprot_event_trig_test (readfunc = 'read_from_file', writefunc = 'write_to_file');
 NOTICE:  test_event_trigger: ddl_command_start CREATE PROTOCOL
@@ -23,3 +25,37 @@ NOTICE:  test_event_trigger: ddl_command_start DROP FOREIGN TABLE
 DROP PROTOCOL demoprot_event_trig_test;
 NOTICE:  test_event_trigger: ddl_command_start DROP PROTOCOL
 drop event trigger regress_event_trigger;
+-- Verify that CREATE EXTERNAL TABLE is collected for ddl_command_end triggers.
+-- ddl_command_start never touches command collection, so the checks above would
+-- pass even if pg_event_trigger_ddl_commands() dropped external tables entirely.
+create table regress_ddl_history (id serial, tag text, identity text, objtype text)
+    DISTRIBUTED BY (id);
+create or replace function test_event_trigger_end() returns event_trigger as $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT object_identity, object_type
+             FROM pg_event_trigger_ddl_commands()
+    LOOP
+        INSERT INTO regress_ddl_history (tag, identity, objtype)
+        VALUES (tg_tag, r.object_identity, r.object_type);
+    END LOOP;
+END
+$$ language plpgsql;
+create event trigger regress_event_trigger_end on ddl_command_end
+   execute procedure test_event_trigger_end();
+CREATE EXTERNAL WEB TABLE endtest_ext (x text) EXECUTE 'echo foo;' FORMAT 'text';
+CREATE TABLE endtest_heap (x text) DISTRIBUTED BY (x);
+drop event trigger regress_event_trigger_end;
+-- both the external and the regular table must be here
+SELECT tag, identity, objtype FROM regress_ddl_history ORDER BY id;
+          tag          |      identity       |    objtype    
+-----------------------+---------------------+---------------
+ CREATE EXTERNAL TABLE | public.endtest_ext  | foreign table
+ CREATE TABLE          | public.endtest_heap | table
+(2 rows)
+
+DROP EXTERNAL TABLE endtest_ext;
+DROP TABLE endtest_heap;
+DROP TABLE regress_ddl_history;
+DROP FUNCTION test_event_trigger_end();

--- a/src/test/regress/sql/event_trigger_gp.sql
+++ b/src/test/regress/sql/event_trigger_gp.sql
@@ -23,3 +23,38 @@ DROP EXTERNAL TABLE demoprot_w CASCADE;
 DROP PROTOCOL demoprot_event_trig_test;
 
 drop event trigger regress_event_trigger;
+
+-- Verify that CREATE EXTERNAL TABLE is collected for ddl_command_end triggers.
+-- ddl_command_start never touches command collection, so the checks above would
+-- pass even if pg_event_trigger_ddl_commands() dropped external tables entirely.
+create table regress_ddl_history (id serial, tag text, identity text, objtype text)
+    DISTRIBUTED BY (id);
+
+create or replace function test_event_trigger_end() returns event_trigger as $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT object_identity, object_type
+             FROM pg_event_trigger_ddl_commands()
+    LOOP
+        INSERT INTO regress_ddl_history (tag, identity, objtype)
+        VALUES (tg_tag, r.object_identity, r.object_type);
+    END LOOP;
+END
+$$ language plpgsql;
+
+create event trigger regress_event_trigger_end on ddl_command_end
+   execute procedure test_event_trigger_end();
+
+CREATE EXTERNAL WEB TABLE endtest_ext (x text) EXECUTE 'echo foo;' FORMAT 'text';
+CREATE TABLE endtest_heap (x text) DISTRIBUTED BY (x);
+
+drop event trigger regress_event_trigger_end;
+
+-- both the external and the regular table must be here
+SELECT tag, identity, objtype FROM regress_ddl_history ORDER BY id;
+
+DROP EXTERNAL TABLE endtest_ext;
+DROP TABLE endtest_heap;
+DROP TABLE regress_ddl_history;
+DROP FUNCTION test_event_trigger_end();


### PR DESCRIPTION
# Fix event triggers on CREATE EXTERNAL TABLE

## Summary

An event trigger on `ddl_command_end` that calls `pg_event_trigger_ddl_commands()` either
fails outright or silently loses rows when a `CREATE EXTERNAL TABLE` is executed:

```
ERROR:  invalid non-zero objectSubId for object class 3304059104 (dependency.c:2773)
CONTEXT:  PL/pgSQL function f_log_ddl() line 7 at FOR over SELECT rows
```

Reported against WHPG 7.3. On 7.4 the same script does not error, but `CREATE EXTERNAL
TABLE` is never recorded. Both symptoms are the same defect — see below.

## Root cause

`ProcessUtilitySlow()` declared `ObjectAddress address;` **uninitialized**. Upstream
PostgreSQL is safe because every command case either assigns `address` or sets
`commandCollected = true`. The WHPG-specific `case T_CreateExternalStmt` does neither —
`DefineExternalRelation()` returned `void` — so `EventTriggerCollectSimpleCommand()` was
handed whatever garbage was in that stack slot, and `pg_event_trigger_ddl_commands()` later
dereferenced it.

Which symptom you get depends only on the leftover bytes:

| garbage `objectId` | behaviour |
|---|---|
| `== 0` | skipped by the `!OidIsValid()` guard in `event_trigger.c`; no error, external table **not logged** |
| `!= 0` | `getObjectClass()` throws `invalid non-zero objectSubId for object class <garbage>` |

Nothing was fixed between 7.3 and 7.4 — the code is identical on both branches. Only the
compiler and stack layout changed. This is undefined behaviour, so any rebuild (new
toolchain, different arch, changed optimisation flags) can turn the silent 7.4 behaviour
back into the 7.3 crash.

### Confirmed by debugger

Breaking at `EventTriggerCollectSimpleCommand` on an unpatched build, while executing
`CREATE EXTERNAL TABLE`, shows the argument is uninitialised (aarch64 passes the 12-byte
`ObjectAddress` in x0/x1):

```
x0 0xaac      -> classId     = 2732       (not a real catalog OID)
x1 0x1711c20  -> objectSubId = 24189984   (nonsense)
                 objectId    = 0          <-- the only reason this build does not throw
x2 0x0 x3 0x0 -> secondaryObject = InvalidObjectAddress (correctly initialised)
```

Forcing `objectId` non-zero — the one thing the 7.3 x86_64 build had naturally — reproduces
the reported error exactly, with the junk `classId`/`objectSubId` left untouched.

## Changes

Two commits, deliberately separable:

1. **`Initialize address in ProcessUtilitySlow()`** — one line,
   `ObjectAddress address = InvalidObjectAddress;`. Removes the undefined behaviour. No
   behaviour change on its own: external tables remain unlogged, exactly as 7.4/7.5 behave
   today. Any command case that forgets to set an address now degrades to "not collected"
   instead of reading garbage.

2. **`Collect CREATE EXTERNAL TABLE for ddl_command_end event triggers`** —
   `DefineExternalRelation()` now returns the new relation's `ObjectAddress`, and the
   `T_CreateExternalStmt` case collects it inside the statement loop and sets
   `commandCollected`, mirroring what `T_CreateStmt` already does. The address is set from
   `reloid` *after* the QD/QE resolution so it always matches the OID the rest of the
   function operates on. `DefineExternalRelation()` has a single caller, so the signature
   change is contained.

**This is a user-visible behaviour change**: event trigger functions that previously never
saw `CREATE EXTERNAL TABLE` will start receiving rows for it. That is the point of the fix
(the customer needs external table DDL in their audit trail), but it is worth calling out
for anyone relying on the current silence. Splitting it into its own commit means it can be
dropped from a patch-release backport if release management prefers.

## Reproduction

```sql
CREATE TABLE ddl_history (
  id serial primary key, ddl_date timestamptz, ddl_tag text, schema_name text,
  object_identity text, command_tag text, object_type text, in_extension boolean);

CREATE OR REPLACE FUNCTION f_log_ddl() RETURNS event_trigger AS $$
DECLARE r RECORD;
BEGIN
  FOR r IN SELECT distinct schema_name, object_identity, command_tag, object_type,
                  in_extension
           FROM pg_event_trigger_ddl_commands()
  LOOP
    INSERT INTO ddl_history (ddl_date, ddl_tag, schema_name, object_identity,
                             command_tag, object_type, in_extension)
    VALUES (statement_timestamp(), tg_tag, r.schema_name, r.object_identity,
            r.command_tag, r.object_type, r.in_extension);
  END LOOP;
END; $$ LANGUAGE plpgsql;

CREATE EVENT TRIGGER event_trg_log_ddl_info ON ddl_command_end
  EXECUTE PROCEDURE f_log_ddl();

CREATE EXTERNAL TABLE ext_demo (a int, b text)
  LOCATION ('gpfdist://localhost:8081/data.txt') FORMAT 'TEXT';

CREATE TABLE control_tbl (a int);   -- control: this one is logged

SELECT ddl_tag, object_identity, command_tag, object_type FROM ddl_history ORDER BY id;
```

Before: only `control_tbl` appears (or the statement errors out, build depending).
After: both `ext_demo` and `control_tbl` appear.

## Testing

- Patched tree configures, builds and links clean; both modified files compile with no new
  warnings under `-Wall -Werror=uninitialized`.
- Manual reproduction of the pre-fix behaviour on a WHPG 7 cluster, including the debugger
  confirmation above.
- <!-- fill in: runtime confirmation that CREATE EXTERNAL TABLE is now collected -->
- <!-- fill in: regression test in src/test/regress/sql/event_trigger_gp.sql -->

`event_trigger_gp.sql` already exercises external tables, but only on `ddl_command_start`,
which never touches `pg_event_trigger_ddl_commands()` — which is why the existing suite did
not catch this.

## Affected versions

| Branch | Affected |
|---|---|
| `main` | yes |
| `WHPG_7_5_STABLE` | yes |
| `WHPG_7_4_STABLE` | yes (silent skip) |
| `WHPG_7_3_STABLE` | yes (reported ERROR) |
| `WHPG_7_2_STABLE` | yes |
| `WHPG_6X_STABLE` | no — PG 9.4-based, has no DDL command collection at all |
| `warehouse-pg-next` (WHPG19) | yes |

## Backports

Backport branches for 7.5, 7.4 and 7.3 are prepared and cherry-pick cleanly with no
conflicts. **I will open those PRs once this one is approved**.