### PR TITLE
Collect CREATE PROTOCOL and ALTER TYPE ... SET DEFAULT ENCODING for ddl_command_end event triggers

### DIFF
--- a/src/backend/commands/extprotocolcmds.c
+++ b/src/backend/commands/extprotocolcmds.c
@@ -42,9 +42,10 @@
 /*
  *	DefineExtprotocol
  */
-void
+ObjectAddress
 DefineExtProtocol(List *name, List *parameters, bool trusted)
 {
+	ObjectAddress address;
 	char	   *protName;
 	List	   *readfuncName = NIL;
 	List	   *writefuncName = NIL;
@@ -110,6 +111,10 @@ DefineExtProtocol(List *name, List *parameters, bool trusted)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
+
+	ObjectAddressSet(address, ExtprotocolRelationId, protOid);
+
+	return address;
 }
 
 /*

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -3855,9 +3855,10 @@ AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
  *
  * ALTER TYPE <typname> SET DEFAULT ENCODING (...)
  */
-void
+ObjectAddress
 AlterType(AlterTypeStmt *stmt)
 {
+	ObjectAddress address;
 	TypeName   *typname;
 	Oid			typid;
 	Oid			arrtypid;
@@ -3905,6 +3906,10 @@ AlterType(AlterTypeStmt *stmt)
 									DF_NEED_TWO_PHASE,
 									NIL,
 									NULL);
+
+	ObjectAddressSet(address, TypeRelationId, typid);
+
+	return address;
 }
 
 /*

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1653,8 +1653,10 @@ ProcessUtilitySlow(ParseState *pstate,
 							break;
 						case OBJECT_EXTPROTOCOL:
 							Assert(stmt->args == NIL);
-							DefineExtProtocol(stmt->defnames, stmt->definition, stmt->trusted);
-							break;						
+							address = DefineExtProtocol(stmt->defnames,
+														stmt->definition,
+														stmt->trusted);
+							break;
 						default:
 							elog(ERROR, "unrecognized define stmt type: %d",
 								 (int) stmt->kind);
@@ -2071,7 +2073,7 @@ ProcessUtilitySlow(ParseState *pstate,
 				break;
 
 			case T_AlterTypeStmt:
-				AlterType((AlterTypeStmt *) parsetree);
+				address = AlterType((AlterTypeStmt *) parsetree);
 				break;
 
 			case T_DropStmt:

--- a/src/include/commands/extprotocolcmds.h
+++ b/src/include/commands/extprotocolcmds.h
@@ -11,7 +11,7 @@
 
 #include "nodes/pg_list.h"
 
-extern void DefineExtProtocol(List *name, List *parameters, bool trusted);
+extern ObjectAddress DefineExtProtocol(List *name, List *parameters, bool trusted);
 extern void RemoveExtProtocolById(Oid protOid);
 
 #endif   /* EXTPROTOCOLCMDS_H */

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -55,7 +55,7 @@ extern Oid AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 									  bool isImplicitArray,
 									  bool errorOnTableType,
 									  ObjectAddresses *objsMoved);
-extern void AlterType(AlterTypeStmt *stmt);
+extern ObjectAddress AlterType(AlterTypeStmt *stmt);
 extern void AlterAMAddArrayType(Form_pg_class oldRelForm);
 extern void AlterAMRemoveArrayType(Form_pg_class oldRelForm);
 

--- a/src/test/regress/expected/event_trigger_gp.out
+++ b/src/test/regress/expected/event_trigger_gp.out
@@ -46,16 +46,31 @@ create event trigger regress_event_trigger_end on ddl_command_end
    execute procedure test_event_trigger_end();
 CREATE EXTERNAL WEB TABLE endtest_ext (x text) EXECUTE 'echo foo;' FORMAT 'text';
 CREATE TABLE endtest_heap (x text) DISTRIBUTED BY (x);
+-- the other two GPDB-specific commands that reach the tail collect
+CREATE OR REPLACE FUNCTION write_to_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE NO SQL;
+NOTICE:  specifying "NO SQL" acts as no operation.
+CREATE OR REPLACE FUNCTION read_from_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
+NOTICE:  specifying "NO SQL" acts as no operation.
+CREATE PROTOCOL demoprot_end_test (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE DOMAIN endtest_domain AS int;
+ALTER TYPE endtest_domain SET DEFAULT ENCODING (compresstype=zlib);
 drop event trigger regress_event_trigger_end;
 -- both the external and the regular table must be here
 SELECT tag, identity, objtype FROM regress_ddl_history ORDER BY id;
-          tag          |      identity       |    objtype    
------------------------+---------------------+---------------
- CREATE EXTERNAL TABLE | public.endtest_ext  | foreign table
- CREATE TABLE          | public.endtest_heap | table
-(2 rows)
+          tag          |        identity         |      objtype      
+-----------------------+-------------------------+-------------------
+ CREATE EXTERNAL TABLE | public.endtest_ext      | foreign table
+ CREATE TABLE          | public.endtest_heap     | table
+ CREATE FUNCTION       | public.write_to_file()  | function
+ CREATE FUNCTION       | public.read_from_file() | function
+ CREATE PROTOCOL       | demoprot_end_test       | external protocol
+ CREATE DOMAIN         | public.endtest_domain   | type
+ ALTER TYPE            | public.endtest_domain   | type
+(7 rows)
 
 DROP EXTERNAL TABLE endtest_ext;
 DROP TABLE endtest_heap;
+DROP PROTOCOL demoprot_end_test;
+DROP DOMAIN endtest_domain;
 DROP TABLE regress_ddl_history;
 DROP FUNCTION test_event_trigger_end();

--- a/src/test/regress/sql/event_trigger_gp.sql
+++ b/src/test/regress/sql/event_trigger_gp.sql
@@ -49,6 +49,14 @@ create event trigger regress_event_trigger_end on ddl_command_end
 CREATE EXTERNAL WEB TABLE endtest_ext (x text) EXECUTE 'echo foo;' FORMAT 'text';
 CREATE TABLE endtest_heap (x text) DISTRIBUTED BY (x);
 
+-- the other two GPDB-specific commands that reach the tail collect
+CREATE OR REPLACE FUNCTION write_to_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE NO SQL;
+CREATE OR REPLACE FUNCTION read_from_file() RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
+CREATE PROTOCOL demoprot_end_test (readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+CREATE DOMAIN endtest_domain AS int;
+ALTER TYPE endtest_domain SET DEFAULT ENCODING (compresstype=zlib);
+
 drop event trigger regress_event_trigger_end;
 
 -- both the external and the regular table must be here
@@ -56,5 +64,7 @@ SELECT tag, identity, objtype FROM regress_ddl_history ORDER BY id;
 
 DROP EXTERNAL TABLE endtest_ext;
 DROP TABLE endtest_heap;
+DROP PROTOCOL demoprot_end_test;
+DROP DOMAIN endtest_domain;
 DROP TABLE regress_ddl_history;
 DROP FUNCTION test_event_trigger_end();


### PR DESCRIPTION
# Collect CREATE PROTOCOL and ALTER TYPE ... SET DEFAULT ENCODING for ddl_command_end event triggers

Follow-up to #211, which fixed the same defect for `CREATE EXTERNAL TABLE`.
## Problem

Two WHPG-specific cases in `ProcessUtilitySlow()` set neither `address` nor
`commandCollected`, so they fall through to the tail `EventTriggerCollectSimpleCommand()`
with nothing meaningful to collect and never appear in
`pg_event_trigger_ddl_commands()`:

1. **`CREATE PROTOCOL`** — `case T_DefineStmt` / `OBJECT_EXTPROTOCOL`, which calls void
   `DefineExtProtocol()`.
2. **`ALTER TYPE ... SET DEFAULT ENCODING`** — `case T_AlterTypeStmt`. GPDB's `AlterType()`
   returns void where upstream's returns `ObjectAddress`.

Before #211's `address = InvalidObjectAddress` initialization, both were the same
uninitialised-memory undefined behaviour as the reported external table crash — a silent
skip or a bogus-class error depending on the build. After it, they are deterministic silent
omissions from the audit trail. Correct, but still holes.

## Fix

Return the object address from both functions and assign it in the corresponding
`utility.c` case — the same shape as #211. For `AlterType()` this also brings the signature
back in line with upstream.

Neither needs new catalog plumbing: `OCLASS_EXTPROTOCOL` is already handled in
`objectaddress.c` by `getObjectDescription`, `getObjectTypeDescription` and
`getObjectIdentityParts`, and the type case is ordinary `TypeRelationId`.

## Testing

`src/test/regress/sql/event_trigger_gp.sql` extends the `ddl_command_end` case added in
#211 to cover both commands. Expected output generated by `pg_regress` against a patched
cluster:

```
          tag          |        identity         |      objtype      
-----------------------+-------------------------+-------------------
 CREATE EXTERNAL TABLE | public.endtest_ext      | foreign table
 CREATE TABLE          | public.endtest_heap     | table
 CREATE FUNCTION       | public.write_to_file()  | function
 CREATE FUNCTION       | public.read_from_file() | function
 CREATE PROTOCOL       | demoprot_end_test       | external protocol
 CREATE DOMAIN         | public.endtest_domain   | type
 ALTER TYPE            | public.endtest_domain   | type
(7 rows)
```

The `CREATE PROTOCOL` and `ALTER TYPE` rows are the new ones; on an unpatched build both
are absent while the surrounding `CREATE FUNCTION` / `CREATE DOMAIN` rows are present.

## Backports

Folded into the existing 7.4 / 7.3 fix branches alongside #211's commits, so
each version still needs only one PR.