### PR TITLE
Require superuser to install a non-built-in selectivity estimator (CVE-2026-2004)

### DIFF
--- a/contrib/intarray/_int_selfuncs.c
+++ b/contrib/intarray/_int_selfuncs.c
@@ -152,7 +152,10 @@ _int_matchsel(PG_FUNCTION_ARGS)
 	 * query_int.
 	 */
 	if (vardata.vartype != INT4ARRAYOID)
+	{
+		ReleaseVariableStats(vardata);
 		PG_RETURN_FLOAT8(DEFAULT_EQ_SEL);
+	}
 
 	/*
 	 * Can't do anything useful if the something is not a constant, either.

--- a/contrib/intarray/_int_selfuncs.c
+++ b/contrib/intarray/_int_selfuncs.c
@@ -190,7 +190,7 @@ _int_matchsel(PG_FUNCTION_ARGS)
 	if (query->size == 0)
 	{
 		ReleaseVariableStats(vardata);
-		return (Selectivity) 0.0;
+		PG_RETURN_FLOAT8(0.0);
 	}
 
 	/*

--- a/contrib/intarray/_int_selfuncs.c
+++ b/contrib/intarray/_int_selfuncs.c
@@ -19,6 +19,7 @@
 #include "catalog/pg_operator.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_type.h"
+#include "commands/extension.h"
 #include "utils/builtins.h"
 #include "utils/selfuncs.h"
 #include "utils/syscache.h"
@@ -171,7 +172,18 @@ _int_matchsel(PG_FUNCTION_ARGS)
 		PG_RETURN_FLOAT8(0.0);
 	}
 
-	/* The caller made sure the const is a query, so get it now */
+	/*
+	 * Verify that the Const is a query_int, else return a default estimate.
+	 * (This could only fail if someone attached this estimator to the wrong
+	 * operator.)
+	 */
+	if (((Const *) other)->consttype !=
+		get_function_sibling_type(fcinfo->flinfo->fn_oid, "query_int"))
+	{
+		ReleaseVariableStats(vardata);
+		PG_RETURN_FLOAT8(DEFAULT_EQ_SEL);
+	}
+
 	query = DatumGetQueryTypeP(((Const *) other)->constvalue);
 
 	/* Empty query matches nothing */

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -22,11 +22,13 @@
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_type.h"
 #include "commands/extension.h"
 #include "miscadmin.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+#include "utils/syscache.h"
 
 
 static bool isObjectPinned(const ObjectAddress *object, Relation rel);
@@ -746,6 +748,77 @@ getAutoExtensionsOfObject(Oid classId, Oid objectId)
 		if (depform->refclassid == ExtensionRelationId &&
 			depform->deptype == DEPENDENCY_AUTO_EXTENSION)
 			result = lappend_oid(result, depform->refobjid);
+	}
+
+	systable_endscan(scan);
+
+	table_close(depRel, AccessShareLock);
+
+	return result;
+}
+
+/*
+ * Look up a type belonging to an extension.
+ *
+ * Returns the type's OID, or InvalidOid if not found.
+ *
+ * Notice that the type is specified by name only, without a schema.
+ * That's because this will typically be used by relocatable extensions
+ * which can't make a-priori assumptions about which schema their objects
+ * are in.  As long as the extension only defines one type of this name,
+ * the answer is unique anyway.
+ *
+ * We might later add the ability to look up functions, operators, etc.
+ */
+Oid
+getExtensionType(Oid extensionOid, const char *typname)
+{
+	Oid			result = InvalidOid;
+	Relation	depRel;
+	ScanKeyData key[3];
+	SysScanDesc scan;
+	HeapTuple	tup;
+
+	depRel = table_open(DependRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_depend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(ExtensionRelationId));
+	ScanKeyInit(&key[1],
+				Anum_pg_depend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(extensionOid));
+	ScanKeyInit(&key[2],
+				Anum_pg_depend_refobjsubid,
+				BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(0));
+
+	scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+							  NULL, 3, key);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_depend depform = (Form_pg_depend) GETSTRUCT(tup);
+
+		if (depform->classid == TypeRelationId &&
+			depform->deptype == DEPENDENCY_EXTENSION)
+		{
+			Oid			typoid = depform->objid;
+			HeapTuple	typtup;
+
+			typtup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typoid));
+			if (!HeapTupleIsValid(typtup))
+				continue;		/* should we throw an error? */
+			if (strcmp(NameStr(((Form_pg_type) GETSTRUCT(typtup))->typname),
+					   typname) == 0)
+			{
+				result = typoid;
+				ReleaseSysCache(typtup);
+				break;			/* no need to keep searching */
+			}
+			ReleaseSysCache(typtup);
+		}
 	}
 
 	systable_endscan(scan);

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -44,6 +44,7 @@
 #include "catalog/pg_depend.h"
 #include "catalog/pg_extension.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "cdb/cdbgang.h"
 #include "commands/alter.h"
@@ -60,10 +61,12 @@
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
+#include "utils/syscache.h"
 #include "utils/varlena.h"
 
 #include "catalog/oid_dispatch.h"
@@ -111,7 +114,26 @@ typedef struct ExtensionVersionInfo
 	struct ExtensionVersionInfo *previous;	/* current best predecessor */
 } ExtensionVersionInfo;
 
+/*
+ * Cache structure for get_function_sibling_type (and maybe later,
+ * allied lookup functions).
+ */
+typedef struct ExtensionSiblingCache
+{
+	struct ExtensionSiblingCache *next; /* list link */
+	/* lookup key: requesting function's OID and type name */
+	Oid			reqfuncoid;
+	const char *typname;
+	bool		valid;			/* is entry currently valid? */
+	uint32		exthash;		/* cache hash of owning extension's OID */
+	Oid			typeoid;		/* OID associated with typname */
+} ExtensionSiblingCache;
+
+/* Head of linked list of ExtensionSiblingCache structs */
+static ExtensionSiblingCache *ext_sibling_list = NULL;
+
 /* Local functions */
+static void ext_sibling_callback(Datum arg, int cacheid, uint32 hashvalue);
 static List *find_update_path(List *evi_list,
 							  ExtensionVersionInfo *evi_start,
 							  ExtensionVersionInfo *evi_target,
@@ -259,6 +281,114 @@ get_extension_schema(Oid ext_oid)
 	table_close(rel, AccessShareLock);
 
 	return result;
+}
+
+/*
+ * get_function_sibling_type - find a type belonging to same extension as func
+ *
+ * Returns the type's OID, or InvalidOid if not found.
+ *
+ * This is useful in extensions, which won't have fixed object OIDs.
+ * We work from the calling function's own OID, which it can get from its
+ * FunctionCallInfo parameter, and look up the owning extension and thence
+ * a type belonging to the same extension.
+ *
+ * Notice that the type is specified by name only, without a schema.
+ * That's because this will typically be used by relocatable extensions
+ * which can't make a-priori assumptions about which schema their objects
+ * are in.  As long as the extension only defines one type of this name,
+ * the answer is unique anyway.
+ *
+ * We might later add the ability to look up functions, operators, etc.
+ *
+ * This code is simply a frontend for some pg_depend lookups.  Those lookups
+ * are fairly expensive, so we provide a simple cache facility.  We assume
+ * that the passed typname is actually a C constant, or at least permanently
+ * allocated, so that we need not copy that string.
+ */
+Oid
+get_function_sibling_type(Oid funcoid, const char *typname)
+{
+	ExtensionSiblingCache *cache_entry;
+	Oid			extoid;
+	Oid			typeoid;
+
+	/*
+	 * See if we have the answer cached.  Someday there may be enough callers
+	 * to justify a hash table, but for now, a simple linked list is fine.
+	 */
+	for (cache_entry = ext_sibling_list; cache_entry != NULL;
+		 cache_entry = cache_entry->next)
+	{
+		if (funcoid == cache_entry->reqfuncoid &&
+			strcmp(typname, cache_entry->typname) == 0)
+			break;
+	}
+	if (cache_entry && cache_entry->valid)
+		return cache_entry->typeoid;
+
+	/*
+	 * Nope, so do the expensive lookups.  We do not expect failures, so we do
+	 * not cache negative results.
+	 */
+	extoid = getExtensionOfObject(ProcedureRelationId, funcoid);
+	if (!OidIsValid(extoid))
+		return InvalidOid;
+	typeoid = getExtensionType(extoid, typname);
+	if (!OidIsValid(typeoid))
+		return InvalidOid;
+
+	/*
+	 * Build, or revalidate, cache entry.
+	 */
+	if (cache_entry == NULL)
+	{
+		/* Register invalidation hook if this is first entry */
+		if (ext_sibling_list == NULL)
+			CacheRegisterSyscacheCallback(EXTENSIONOID,
+										  ext_sibling_callback,
+										  (Datum) 0);
+
+		/* Momentarily zero the space to ensure valid flag is false */
+		cache_entry = (ExtensionSiblingCache *)
+			MemoryContextAllocZero(CacheMemoryContext,
+								   sizeof(ExtensionSiblingCache));
+		cache_entry->next = ext_sibling_list;
+		ext_sibling_list = cache_entry;
+	}
+
+	cache_entry->reqfuncoid = funcoid;
+	cache_entry->typname = typname;
+	cache_entry->exthash = GetSysCacheHashValue1(EXTENSIONOID,
+												 ObjectIdGetDatum(extoid));
+	cache_entry->typeoid = typeoid;
+	/* Mark it valid only once it's fully populated */
+	cache_entry->valid = true;
+
+	return typeoid;
+}
+
+/*
+ * ext_sibling_callback
+ *		Syscache inval callback function for EXTENSIONOID cache
+ *
+ * It seems sufficient to invalidate ExtensionSiblingCache entries when
+ * the owning extension's pg_extension entry is modified or deleted.
+ * Neither a requesting function's OID, nor the OID of the object it's
+ * looking for, could change without an extension update or drop/recreate.
+ */
+static void
+ext_sibling_callback(Datum arg, int cacheid, uint32 hashvalue)
+{
+	ExtensionSiblingCache *cache_entry;
+
+	for (cache_entry = ext_sibling_list; cache_entry != NULL;
+		 cache_entry = cache_entry->next)
+	{
+		if (hashvalue == 0 ||
+			cache_entry->exthash == hashvalue)
+			cache_entry->valid = false;
+	}
 }
 
 /*

--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -297,7 +297,6 @@ ValidateRestrictionEstimator(List *restrictionName)
 {
 	Oid			typeId[4];
 	Oid			restrictionOid;
-	AclResult	aclresult;
 
 	typeId[0] = INTERNALOID;	/* PlannerInfo */
 	typeId[1] = OIDOID;			/* operator OID */
@@ -313,11 +312,32 @@ ValidateRestrictionEstimator(List *restrictionName)
 				 errmsg("restriction estimator function %s must return type %s",
 						NameListToString(restrictionName), "float8")));
 
-	/* Require EXECUTE rights for the estimator */
-	aclresult = pg_proc_aclcheck(restrictionOid, GetUserId(), ACL_EXECUTE);
-	if (aclresult != ACLCHECK_OK)
-		aclcheck_error(aclresult, OBJECT_FUNCTION,
-					   NameListToString(restrictionName));
+	/*
+	 * If the estimator is not a built-in function, require superuser
+	 * privilege to install it.  This protects against using something that is
+	 * not a restriction estimator or has hard-wired assumptions about what
+	 * data types it is working with.  (Built-in estimators are required to
+	 * defend themselves adequately against unexpected data type choices, but
+	 * it seems impractical to expect that of extensions' estimators.)
+	 *
+	 * If it is built-in, only require EXECUTE rights.
+	 */
+	if (restrictionOid >= FirstGenbkiObjectId)
+	{
+		if (!superuser())
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be superuser to specify a non-built-in restriction estimator function")));
+	}
+	else
+	{
+		AclResult	aclresult;
+
+		aclresult = pg_proc_aclcheck(restrictionOid, GetUserId(), ACL_EXECUTE);
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error(aclresult, OBJECT_FUNCTION,
+						   NameListToString(restrictionName));
+	}
 
 	return restrictionOid;
 }
@@ -333,7 +353,6 @@ ValidateJoinEstimator(List *joinName)
 	Oid			typeId[5];
 	Oid			joinOid;
 	Oid			joinOid2;
-	AclResult	aclresult;
 
 	typeId[0] = INTERNALOID;	/* PlannerInfo */
 	typeId[1] = OIDOID;			/* operator OID */
@@ -371,11 +390,23 @@ ValidateJoinEstimator(List *joinName)
 				 errmsg("join estimator function %s must return type %s",
 						NameListToString(joinName), "float8")));
 
-	/* Require EXECUTE rights for the estimator */
-	aclresult = pg_proc_aclcheck(joinOid, GetUserId(), ACL_EXECUTE);
-	if (aclresult != ACLCHECK_OK)
-		aclcheck_error(aclresult, OBJECT_FUNCTION,
-					   NameListToString(joinName));
+	/* privilege checks are the same as in ValidateRestrictionEstimator */
+	if (joinOid >= FirstGenbkiObjectId)
+	{
+		if (!superuser())
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be superuser to specify a non-built-in join estimator function")));
+	}
+	else
+	{
+		AclResult	aclresult;
+
+		aclresult = pg_proc_aclcheck(joinOid, GetUserId(), ACL_EXECUTE);
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error(aclresult, OBJECT_FUNCTION,
+						   NameListToString(joinName));
+	}
 
 	return joinOid;
 }

--- a/src/backend/tsearch/ts_selfuncs.c
+++ b/src/backend/tsearch/ts_selfuncs.c
@@ -109,12 +109,14 @@ tsmatchsel(PG_FUNCTION_ARGS)
 	 * OK, there's a Var and a Const we're dealing with here.  We need the
 	 * Const to be a TSQuery, else we can't do anything useful.  We have to
 	 * check this because the Var might be the TSQuery not the TSVector.
+	 *
+	 * Also check that the Var really is a TSVector, in case this estimator is
+	 * mistakenly attached to some other operator.
 	 */
-	if (((Const *) other)->consttype == TSQUERYOID)
+	if (((Const *) other)->consttype == TSQUERYOID &&
+		vardata.vartype == TSVECTOROID)
 	{
 		/* tsvector @@ tsquery or the other way around */
-		Assert(vardata.vartype == TSVECTOROID);
-
 		selec = tsquerysel(&vardata, ((Const *) other)->constvalue);
 	}
 	else

--- a/src/backend/utils/adt/network_selfuncs.c
+++ b/src/backend/utils/adt/network_selfuncs.c
@@ -43,9 +43,9 @@
 /* Maximum number of items to consider in join selectivity calculations */
 #define MAX_CONSIDERED_ELEMS 1024
 
-static Selectivity networkjoinsel_inner(Oid operator,
+static Selectivity networkjoinsel_inner(Oid operator, int opr_codenum,
 										VariableStatData *vardata1, VariableStatData *vardata2);
-static Selectivity networkjoinsel_semi(Oid operator,
+static Selectivity networkjoinsel_semi(Oid operator, int opr_codenum,
 									   VariableStatData *vardata1, VariableStatData *vardata2);
 static Selectivity mcv_population(float4 *mcv_numbers, int mcv_nvalues);
 static Selectivity inet_hist_value_sel(Datum *values, int nvalues,
@@ -82,6 +82,7 @@ networksel(PG_FUNCTION_ARGS)
 	Oid			operator = PG_GETARG_OID(1);
 	List	   *args = (List *) PG_GETARG_POINTER(2);
 	int			varRelid = PG_GETARG_INT32(3);
+	int			opr_codenum;
 	VariableStatData vardata;
 	Node	   *other;
 	bool		varonleft;
@@ -94,6 +95,14 @@ networksel(PG_FUNCTION_ARGS)
 	double		sumcommon,
 				nullfrac;
 	FmgrInfo	proc;
+
+	/*
+	 * Before all else, verify that the operator is one of the ones supported
+	 * by this function, which in turn proves that the input datatypes are
+	 * what we expect.  Otherwise, attaching this selectivity function to some
+	 * unexpected operator could cause trouble.
+	 */
+	opr_codenum = inet_opr_codenum(operator);
 
 	/*
 	 * If expression is not (variable op something) or (something op
@@ -150,13 +159,12 @@ networksel(PG_FUNCTION_ARGS)
 						 STATISTIC_KIND_HISTOGRAM, InvalidOid,
 						 ATTSTATSSLOT_VALUES))
 	{
-		int			opr_codenum = inet_opr_codenum(operator);
+		int			h_codenum;
 
 		/* Commute if needed, so we can consider histogram to be on the left */
-		if (!varonleft)
-			opr_codenum = -opr_codenum;
+		h_codenum = varonleft ? opr_codenum : -opr_codenum;
 		non_mcv_selec = inet_hist_value_sel(hslot.values, hslot.nvalues,
-											constvalue, opr_codenum);
+											constvalue, h_codenum);
 
 		free_attstatsslot(&hslot);
 	}
@@ -203,9 +211,18 @@ networkjoinsel(PG_FUNCTION_ARGS)
 #endif
 	SpecialJoinInfo *sjinfo = (SpecialJoinInfo *) PG_GETARG_POINTER(4);
 	double		selec;
+	int			opr_codenum;
 	VariableStatData vardata1;
 	VariableStatData vardata2;
 	bool		join_is_reversed;
+
+	/*
+	 * Before all else, verify that the operator is one of the ones supported
+	 * by this function, which in turn proves that the input datatypes are
+	 * what we expect.  Otherwise, attaching this selectivity function to some
+	 * unexpected operator could cause trouble.
+	 */
+	opr_codenum = inet_opr_codenum(operator);
 
 	get_join_variables(root, args, sjinfo,
 					   &vardata1, &vardata2, &join_is_reversed);
@@ -220,16 +237,19 @@ networkjoinsel(PG_FUNCTION_ARGS)
 			 * Selectivity for left/full join is not exactly the same as inner
 			 * join, but we neglect the difference, as eqjoinsel does.
 			 */
-			selec = networkjoinsel_inner(operator, &vardata1, &vardata2);
+			selec = networkjoinsel_inner(operator, opr_codenum,
+										 &vardata1, &vardata2);
 			break;
 		case JOIN_SEMI:
 		case JOIN_ANTI:
 		case JOIN_LASJ_NOTIN:
 			/* Here, it's important that we pass the outer var on the left. */
 			if (!join_is_reversed)
-				selec = networkjoinsel_semi(operator, &vardata1, &vardata2);
+				selec = networkjoinsel_semi(operator, opr_codenum,
+											&vardata1, &vardata2);
 			else
 				selec = networkjoinsel_semi(get_commutator(operator),
+											-opr_codenum,
 											&vardata2, &vardata1);
 			break;
 		default:
@@ -261,7 +281,7 @@ networkjoinsel(PG_FUNCTION_ARGS)
  * Also, MCV vs histogram selectivity is not neglected as in eqjoinsel_inner().
  */
 static Selectivity
-networkjoinsel_inner(Oid operator,
+networkjoinsel_inner(Oid operator, int opr_codenum,
 					 VariableStatData *vardata1, VariableStatData *vardata2)
 {
 	Form_pg_statistic stats;
@@ -274,7 +294,6 @@ networkjoinsel_inner(Oid operator,
 				mcv2_exists = false,
 				hist1_exists = false,
 				hist2_exists = false;
-	int			opr_codenum;
 	int			mcv1_length = 0,
 				mcv2_length = 0;
 	AttStatsSlot mcv1_slot;
@@ -325,8 +344,6 @@ networkjoinsel_inner(Oid operator,
 		memset(&mcv2_slot, 0, sizeof(mcv2_slot));
 		memset(&hist2_slot, 0, sizeof(hist2_slot));
 	}
-
-	opr_codenum = inet_opr_codenum(operator);
 
 	/*
 	 * Calculate selectivity for MCV vs MCV matches.
@@ -388,7 +405,7 @@ networkjoinsel_inner(Oid operator,
  * histogram selectivity for semi/anti join cases.
  */
 static Selectivity
-networkjoinsel_semi(Oid operator,
+networkjoinsel_semi(Oid operator, int opr_codenum,
 					VariableStatData *vardata1, VariableStatData *vardata2)
 {
 	Form_pg_statistic stats;
@@ -402,7 +419,6 @@ networkjoinsel_semi(Oid operator,
 				mcv2_exists = false,
 				hist1_exists = false,
 				hist2_exists = false;
-	int			opr_codenum;
 	FmgrInfo	proc;
 	int			i,
 				mcv1_length = 0,
@@ -456,7 +472,6 @@ networkjoinsel_semi(Oid operator,
 		memset(&hist2_slot, 0, sizeof(hist2_slot));
 	}
 
-	opr_codenum = inet_opr_codenum(operator);
 	fmgr_info(get_opcode(operator), &proc);
 
 	/* Estimate number of input rows represented by RHS histogram. */
@@ -827,6 +842,9 @@ inet_semi_join_sel(Datum lhs_value,
 
 /*
  * Assign useful code numbers for the subnet inclusion/overlap operators
+ *
+ * This will throw an error if the operator is not one of the ones we
+ * support in networksel() and networkjoinsel().
  *
  * Only inet_masklen_inclusion_cmp() and inet_hist_match_divider() depend
  * on the exact codes assigned here; but many other places in this file

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -46,6 +46,7 @@
 #include "catalog/pg_description.h"
 #include "catalog/pg_enum.h"
 #include "catalog/pg_event_trigger.h"
+#include "catalog/pg_extension.h"
 #include "catalog/pg_foreign_data_wrapper.h"
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_foreign_table.h"
@@ -1064,6 +1065,18 @@ static const struct cachedesc cacheinfo[] = {
 			0
 		},
 		128
+	},
+	/* intentionally out of alphabetical order, to avoid an ABI break: */
+	{ExtensionRelationId,		/* EXTENSIONOID */
+		ExtensionOidIndexId,
+		1,
+		{
+			Anum_pg_extension_oid,
+			0,
+			0,
+			0
+		},
+		2
 	}
 };
 

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -225,6 +225,8 @@ extern long changeDependenciesOn(Oid refClassId, Oid oldRefObjectId,
 extern Oid	getExtensionOfObject(Oid classId, Oid objectId);
 extern List *getAutoExtensionsOfObject(Oid classId, Oid objectId);
 
+extern Oid	getExtensionType(Oid extensionOid, const char *typname);
+
 extern bool sequenceIsOwned(Oid seqId, char deptype, Oid *tableId, int32 *colId);
 extern List *getOwnedSequences(Oid relid, AttrNumber attnum);
 extern Oid	getOwnedSequence(Oid relid, AttrNumber attnum);

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -48,6 +48,8 @@ extern ObjectAddress ExecAlterExtensionContentsStmt(AlterExtensionContentsStmt *
 extern Oid	get_extension_oid(const char *extname, bool missing_ok);
 extern char *get_extension_name(Oid ext_oid);
 
+extern Oid	get_function_sibling_type(Oid funcoid, const char *typname);
+
 extern ObjectAddress AlterExtensionNamespace(const char *extensionName, const char *newschema,
 											 Oid *oldschema);
 

--- a/src/include/utils/syscache.h
+++ b/src/include/utils/syscache.h
@@ -115,9 +115,11 @@ enum SysCacheIdentifier
 	USERMAPPINGOID,
 	USERMAPPINGUSERSERVER,
 	APPENDONLYOID,
-	ATTENCODINGNUM
+	ATTENCODINGNUM,
+	/* intentionally out of alphabetical order, to avoid an ABI break: */
+	EXTENSIONOID
 
-#define SysCacheSize (ATTENCODINGNUM + 1)
+#define SysCacheSize (EXTENSIONOID + 1)
 };
 
 extern void InitCatalogCache(void);

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -640,6 +640,7 @@ ExtensibleNodeMethods
 ExtensionControlFile
 ExtensionInfo
 ExtensionMemberId
+ExtensionSiblingCache
 ExtensionVersionInfo
 FDWCollateState
 FD_SET


### PR DESCRIPTION
Summary:

Backport of the upstream fix for CVE-2026-2004 — a flaw where a non-superuser could attach a selectivity estimator that makes data-type assumptions to the wrong operator, causing the estimator to interpret pg_statistic data of an unexpected type. This can rise to the level of arbitrary code execution by any user able to create SQL objects. WarehousePG (PG12 base) still carries the vulnerable code, and PG12 is past upstream EOL, so the fix is backported here from REL_14 (the oldest branch that has it).

This PR is five commits: the main privilege fix, a small prerequisite infrastructure backport, the companion contrib/intarray hardening, and two small follow-up fixes to the same intarray selectivity function. They are kept separate (rather than squashed) so each cherry-pick matches upstream and the security change is reviewable in isolation.

The vulnerability:
Selectivity estimators come in two kinds: those that make assumptions about the data types they operate on, and those that don't. Most built-in estimators are of the latter kind and are safe on any operator. But an estimator that does assume a data type can malfunction if attached to an operator over a different type, since the pg_statistic data it reads won't be what it expects — a memory-safety hazard reachable by a user who can CREATE OPERATOR.

What's in this PR:
1. Require superuser to install a non-built-in selectivity estimator
Cherry-pick of upstream ea3bf349860 (CVE-2026-2004). Establishes two rules: built-in estimators must defend themselves against being called on the wrong data type (fixes a couple that didn't, in ts_selfuncs.c and network_selfuncs.c), and superuser privilege is now required to attach a non-built-in estimator via CREATE/ALTER OPERATOR. Since estimators are written in C — which already requires superuser to create — this has little practical impact on extensions.

2. Add a syscache on pg_extension.oid
Cherry-pick of upstream 9fa38c572a9 (same CVE). Prerequisite for the next commit, which needs the EXTENSIONOID syscache to track pg_extension updates. Upstream added this cache natively in v18 and backpatched it to 14–17; WHPG's PG12 base lacks it, so it is backported here.

3. Harden _int_matchsel() against being attached to the wrong operator
Cherry-pick of upstream 7e82d9a04d0 (same CVE). Prevents further abuse of any already-created operator exposing contrib/intarray's _int_matchsel to the wrong types, by verifying the query Const is actually a query_int. Since query_int is an extension type with no fixed OID, this adds infrastructure to securely look up the OID of a sibling datatype within the calling function's own extension (cached via the syscache from commit 2).

4. Fix incorrect lack of Datum conversion in _int_matchsel()
Cherry-pick of upstream 64dec8060c84. The empty-query path returned (Selectivity) 0.0 from a Datum-returning function instead of PG_RETURN_FLOAT8(0.0). Harmless on 64-bit (USE_FLOAT8_BYVAL) builds like WHPG's, and the path is believed unreachable, but included to keep _int_selfuncs.c byte-aligned with REL_14.

5. Fix missed ReleaseVariableStats() in intarray's _int_matchsel()
Cherry-pick of upstream a96b051a98e3 (bug #19492). The vartype != INT4ARRAYOID bail-out returned without releasing the fetched pg_statistic tuple, leaking a syscache pin (WARNING: cache reference leak) on every planning pass through it. This is exactly the path taken when the estimator is attached to a non-int4[] column — the wrong-operator scenario commit 3 hardens — so it belongs in this series.

WarehousePG adaptations:
- Main fix (ea3bf349860) — clean cherry-pick.
- Syscache (9fa38c572a9) — conflicts limited to the tails of the SysCacheIdentifier enum and the cacheinfo[] array, where WHPG carries its own APPENDONLYOID / ATTENCODINGNUM caches. EXTENSIONOID is appended after them, preserving upstream's intent of not disturbing existing syscache IDs (ABI-safe).
- Companion (7e82d9a04d0) — only conflict was the position of the new #include lines in _int_selfuncs.c.
- Follow-up fixes (64dec8060c84, a96b051a98e3) — clean cherry-picks.