### PR TITLE
build: build on macOS and against libxml2 >= 2.12

### DIFF
--- a/contrib/xml2/xpath.c
+++ b/contrib/xml2/xpath.c
@@ -75,7 +75,6 @@ pgxml_parser_init(PgXmlStrictness strictness)
 	xmlInitParser();
 
 	xmlSubstituteEntitiesDefault(1);
-	xmlLoadExtDtdDefaultValue = 1;
 
 	return xmlerrcxt;
 }

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -7021,7 +7021,7 @@ ConvertToIPv4MappedAddr(struct sockaddr_storage *sockaddr, socklen_t *o_len)
 
 	((uint16 *) &in6_new->sin6_addr)[5] = 0xffff;
 
-	in6_new->sin6_addr.s6_addr32[3] = in->sin_addr.s_addr;
+	((uint32 *) &in6_new->sin6_addr)[3] = in->sin_addr.s_addr;
 	in6_new->sin6_scope_id = 0;
 
 	/* copy it back */

--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -65,6 +65,16 @@
 #if LIBXML_VERSION >= 20704
 #define HAVE_XMLSTRUCTUREDERRORCONTEXT 1
 #endif
+
+/*
+ * libxml2 2.12 decided to insert "const" into the error handler API.
+ */
+#if LIBXML_VERSION >= 21200
+#define PgXmlErrorPtr const xmlError *
+#else
+#define PgXmlErrorPtr xmlErrorPtr
+#endif
+
 #endif							/* USE_LIBXML */
 
 #include "access/htup_details.h"
@@ -121,7 +131,7 @@ struct PgXmlErrorContext
 
 static xmlParserInputPtr xmlPgEntityLoader(const char *URL, const char *ID,
 										   xmlParserCtxtPtr ctxt);
-static void xml_errorHandler(void *data, xmlErrorPtr error);
+static void xml_errorHandler(void *data, PgXmlErrorPtr error);
 static void xml_ereport_by_code(int level, int sqlcode,
 								const char *msg, int errcode);
 static void chopStringInfoNewlines(StringInfo str);
@@ -1764,7 +1774,7 @@ xml_ereport(PgXmlErrorContext *errcxt, int level, int sqlcode, const char *msg)
  * Error handler for libxml errors and warnings
  */
 static void
-xml_errorHandler(void *data, xmlErrorPtr error)
+xml_errorHandler(void *data, PgXmlErrorPtr error)
 {
 	PgXmlErrorContext *xmlerrcxt = (PgXmlErrorContext *) data;
 	xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) error->ctxt;


### PR DESCRIPTION
Two build-environment differences that surface outside the Linux/glibc
toolchain CI builds with. Neither changes runtime behaviour.

### `s6_addr32` is a glibc extension

`ConvertToIPv4MappedAddr()` writes the mapped IPv4 address through
`in6_addr.s6_addr32`. glibc exposes that union member; macOS's
`<netinet6/in6.h>` names the members `__u6_addr8/16/32` and exposes only
`s6_addr`, so the build stops there:

    ic_udpifc.c:7024:21: error: no member named 's6_addr32' in 'struct in6_addr'

Writing through a `uint32` cast works on both, and matches how the
`0xffff` prefix is already stored two lines above.

### libxml2 2.12 added `const` to the error handler API

libxml2 2.12 changed `xmlStructuredErrorFunc` to take a
`const xmlError *`, so the four `xmlSetStructuredErrorFunc()` calls in
`xml.c` no longer type-check:

    xml.c:1025:45: error: incompatible function pointer types passing
    'void (void *, xmlErrorPtr)' to parameter of type 'xmlStructuredErrorFunc'
    (aka 'void (*)(void *, const struct _xmlError *)')

This is upstream PostgreSQL's fix, cherry-picked unchanged from
REL_12_STABLE (b2fd1dab90240ebb9017cd2fddd731c3641ba434). It carries the
accompanying removal of `contrib/xml2/xpath.c`'s assignment to
`xmlLoadExtDtdDefaultValue`, which 2.12 deprecates and which has had no
effect since external DTDs were disabled at a lower level.

This one is not macOS-specific — any platform shipping libxml2 >= 2.12
runs into it. Homebrew is currently on 2.15.3.
