### PR TITLE
fix: stop gpload runs from failing with no error recorded

### DIFF
--- a/gpMgmt/bin/gpload
+++ b/gpMgmt/bin/gpload
@@ -6,4 +6,4 @@ if [ ! -z "$GPHOME_LOADERS" ]; then
     . $GPHOME_LOADERS/greenplum_loaders_path.sh
 fi
 
-exec gpload.py $*
+exec gpload.py "$@"

--- a/gpMgmt/bin/gpload.bat
+++ b/gpMgmt/bin/gpload.bat
@@ -2,7 +2,7 @@
 set FOUND=
 for %%X in (python.exe) do (set FOUND=%%~$PATH:X)
 if not defined FOUND (
-    echo "Ensure python2.7 64-bit is installed and set in PATH"
+    echo "Ensure python3 64-bit is installed and set in PATH"
     exit /B 1
 )
 

--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -1177,18 +1177,46 @@ class gpload:
 
         # default to gpAdminLogs for a log file, may be overwritten
         if self.options.l is None:
-            self.options.l = os.path.join(os.environ.get('HOME', '.'),'gpAdminLogs')
-            if not os.path.isdir(self.options.l):
-                os.mkdir(self.options.l)
-
-            self.options.l = os.path.join(self.options.l, 'gpload_' + \
+            self.options.l = os.path.join(os.environ.get('HOME', '.'), 'gpAdminLogs',
+                                          'gpload_' + \
                                           datetime.date.today().strftime('%Y%m%d') + '.log')
 
-        try:
-            self.logfile = open(self.options.l,'a')
-        except Exception as e:
-            self.log(self.ERROR, "could not open logfile %s: %s" % \
-                      (self.options.l, e))
+        # Make sure we always end up with an open log file. The path given to -l
+        # is used as it stands: a directory we were not asked to create is not
+        # created for us, so a typo does not quietly leave one behind. When that
+        # path cannot be opened, reopen the same file name under
+        # $HOME/gpAdminLogs, which gpload creates for itself anyway, so that the
+        # error output is never silently lost.
+        self.logfile = None
+        requested = self.options.l
+        base = os.path.basename(requested) or \
+               ('gpload_' + datetime.date.today().strftime('%Y%m%d') + '.log')
+        fallback = os.path.join(os.environ.get('HOME', '.'), 'gpAdminLogs', base)
+
+        candidates = [requested]
+        if fallback != requested:
+            candidates.append(fallback)
+
+        for logpath in candidates:
+            try:
+                if logpath == fallback:
+                    os.makedirs(os.path.dirname(fallback), exist_ok=True)
+                self.logfile = open(logpath, 'a')
+                self.options.l = logpath
+                break
+            except Exception as e:
+                sys.stderr.write("gpload: could not open logfile %s: %s\n" %
+                                 (logpath, e))
+
+        if self.logfile is None:
+            self.log(self.ERROR, "could not open logfile %s" % requested)
+
+        # Name both paths, so that this is just as clear on stdout as it is
+        # to whoever reads the log file we did manage to open.
+        if self.options.l != requested:
+            self.log(self.WARN, "could not use requested log file %s, "
+                                "logging to %s instead"
+                                % (requested, self.options.l))
 
         if seenv and seenq:
             self.log(self.ERROR, "-q conflicts with -v and -V")

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_logging.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_logging.py
@@ -2,8 +2,8 @@
 """
 Tests for how gpload is invoked and where it writes its log.
 
-Both are settled before gpload connects to the database, so these do not
-need a running cluster.
+Both cases are settled before gpload connects to the database, so these
+do not need a running cluster.
 """
 
 import os
@@ -44,3 +44,58 @@ def test_config_file_path_containing_spaces():
         assert os.path.exists(logfile)
         with open(logfile) as f:
             assert 'gpload session started' in f.read()
+
+
+def test_log_falls_back_to_gpadminlogs():
+    "gpload logs to $HOME/gpAdminLogs when the requested log cannot be opened"
+    with tempfile.TemporaryDirectory() as tmp:
+        conf = os.path.join(tmp, 'load.yml')
+        with open(conf, 'w') as f:
+            f.write(INCOMPLETE_CONFIG)
+
+        # Put a regular file where the log's parent directory would go, so
+        # that the path cannot be opened however gpload goes about it.
+        blocker = os.path.join(tmp, 'not-a-directory')
+        open(blocker, 'w').close()
+
+        name = 'gpload_fallback_%d.log' % os.getpid()
+        requested = os.path.join(blocker, name)
+        fallback = os.path.join(os.environ['HOME'], 'gpAdminLogs', name)
+
+        try:
+            rc, out, err = run_gpload(['-f', conf, '-l', requested])
+
+            assert 'could not open logfile' in err
+            assert os.path.exists(fallback)
+            with open(fallback) as f:
+                log = f.read()
+            assert 'could not use requested log file' in log
+            assert 'gpload session started' in log
+        finally:
+            if os.path.exists(fallback):
+                os.remove(fallback)
+
+
+def test_missing_log_directory_is_not_created():
+    "gpload does not create a directory named by -l, it falls back instead"
+    name = 'gpload_nodir_%d.log' % os.getpid()
+    fallback = os.path.join(os.environ['HOME'], 'gpAdminLogs', name)
+    with tempfile.TemporaryDirectory() as tmp:
+        conf = os.path.join(tmp, 'load.yml')
+        with open(conf, 'w') as f:
+            f.write(INCOMPLETE_CONFIG)
+
+        missing = os.path.join(tmp, 'no such dir')
+        try:
+            rc, out, err = run_gpload(['-f', conf,
+                                       '-l', os.path.join(missing, name)])
+
+            # A mistyped -l should show up as a warning, not as a directory
+            # that gpload invented on the user's behalf.
+            assert not os.path.exists(missing)
+            assert os.path.exists(fallback)
+            with open(fallback) as f:
+                assert 'could not use requested log file' in f.read()
+        finally:
+            if os.path.exists(fallback):
+                os.remove(fallback)

--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_logging.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_logging.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env pytest
+"""
+Tests for how gpload is invoked and where it writes its log.
+
+Both are settled before gpload connects to the database, so these do not
+need a running cluster.
+"""
+
+import os
+import subprocess
+import tempfile
+
+# Parses as YAML but is rejected by gpload's own validation. Reaching that
+# complaint means gpload got through option parsing, opened its log file and
+# read the control file, which is what these tests are looking for.
+INCOMPLETE_CONFIG = "VERSION: 1.0.0.1\n"
+
+
+def run_gpload(args):
+    p = subprocess.Popen(['gpload'] + args,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         universal_newlines=True)
+    out, err = p.communicate()
+    return p.returncode, out, err
+
+
+def test_config_file_path_containing_spaces():
+    "gpload accepts a control file whose path contains spaces"
+    with tempfile.TemporaryDirectory() as tmp:
+        confdir = os.path.join(tmp, 'my config dir')
+        os.makedirs(confdir)
+        conf = os.path.join(confdir, 'load me.yml')
+        with open(conf, 'w') as f:
+            f.write(INCOMPLETE_CONFIG)
+
+        logfile = os.path.join(tmp, 'gpload.log')
+        rc, out, err = run_gpload(['-f', conf, '-l', logfile])
+
+        # The wrapper used to expand $*, which joined the arguments and let
+        # the shell split the path again, so gpload rejected the leftovers
+        # and printed its usage text without ever opening a log file.
+        assert 'COMMAND NAME: gpload' not in out
+        assert os.path.exists(logfile)
+        with open(logfile) as f:
+            assert 'gpload session started' in f.read()


### PR DESCRIPTION
Two ways a gpload run could end with an exit code and nothing to explain
it. Both matter most to a caller that sends stdout to /dev/null, such as
an Informatica workflow, where the log file is meant to be the surviving
record.

### The shell wrapper split arguments on whitespace

`gpMgmt/bin/gpload` expanded `$*`, which joins the arguments into a single
string that the shell then splits again. A control file path containing a
space reached `gpload.py` as three arguments, so the option parser
rejected them and printed the usage text, before a session had started or
the log file had been opened:

```
$ gpload -f "/tmp/my configs/load.yml"      # before
COMMAND NAME: gpload

Runs a load job as defined in a YAML formatted control file.

$ gpload -f "/tmp/my configs/load.yml"      # after
2026-08-12 11:34:33|INFO|gpload session started 2026-08-12 11:34:33
2026-08-12 11:34:33|ERROR|A gpload control file processing error occurred. ...
```

`"$@"` keeps the original argument boundaries.

`gpload.bat` needs no equivalent change, because `%*` already preserves
the quoting of the original command line. Its "install python2.7" message
is corrected in passing, since gpload.py has run under Python 3 since
7306abea28. The probe itself stays as it is: the Python 3 installer on
Windows provides `python.exe`, which is what the wrapper looks for.

### An unusable -l path took the log with it

gpload gave up as soon as it could not open the log file named by `-l`,
and the reason only reached stdout. It now reopens the same file name
under `$HOME/gpAdminLogs` instead:

```
stdout   ...|WARN|could not use requested log file /nope/informatica.log, logging to /home/gpadmin/gpAdminLogs/informatica.log instead
stderr   gpload: could not open logfile /nope/informatica.log: [Errno 2] No such file or directory
```

The path given to `-l` is used as it stands: a directory we were not asked
to create is not created for us, so a mistyped argument surfaces as this
warning rather than as a stray directory left behind. The same WARN goes
into the log that was opened, so whoever reads that file later can tell it
is not the one that was asked for. gpload only gives up if both locations
fail.

### Tests

`gpMgmt/bin/gpload_test/gpload2/TEST_local_logging.py`, collected by
`make installcheck`. All three cases are settled before gpload connects to
the database, so none of them needs a running cluster. Each fix carries
its own check, and every check was confirmed to fail against an unpatched
gpload.
