### PR TITLE
fix: dispatch ALTER OPERATOR ... SET (RESTRICT/JOIN) to segments

### DIFF
--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -571,5 +571,20 @@ AlterOperator(AlterOperatorStmt *stmt)
 
 	table_close(catalog, NoLock);
 
+	/*
+	 * Update every segment's pg_operator too, or QE-local planning (SPI in
+	 * EXECUTE ON ALL SEGMENTS functions, utility-mode connections) keeps
+	 * using the stale oprrest/oprjoin.  The sibling DefineOperator()
+	 * dispatches via CdbDispatchUtilityStatement too.  ALTER assigns no new
+	 * OIDs, so pass NIL for the OID list.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		CdbDispatchUtilityStatement((Node *) stmt,
+									DF_CANCEL_ON_ERROR|
+									DF_WITH_SNAPSHOT|
+									DF_NEED_TWO_PHASE,
+									NIL,
+									NULL);
+
 	return address;
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -1380,6 +1380,10 @@ _outNode(StringInfo str, void *obj)
 				_outAlterCollationStmt(str, obj);
 				break;
 
+			case T_AlterOperatorStmt:
+				_outAlterOperatorStmt(str, obj);
+				break;
+
 			case T_DefineStmt:
 				_outDefineStmt(str,obj);
 				break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3788,6 +3788,15 @@ _outAlterCollationStmt(StringInfo str, const AlterCollationStmt *node)
 }
 
 static void
+_outAlterOperatorStmt(StringInfo str, const AlterOperatorStmt *node)
+{
+	WRITE_NODE_TYPE("ALTEROPERATORSTMT");
+
+	WRITE_NODE_FIELD(opername);
+	WRITE_NODE_FIELD(options);
+}
+
+static void
 _outDefineStmt(StringInfo str, const DefineStmt *node)
 {
 	WRITE_NODE_TYPE("DEFINESTMT");
@@ -6147,6 +6156,10 @@ outNode(StringInfo str, const void *obj)
 
 			case T_AlterCollationStmt:
 				_outAlterCollationStmt(str, obj);
+				break;
+
+			case T_AlterOperatorStmt:
+				_outAlterOperatorStmt(str, obj);
 				break;
 
 			case T_DefineStmt:

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2169,6 +2169,10 @@ readNodeBinary(void)
 				return_value = _readAlterCollationStmt();
 				break;
 
+			case T_AlterOperatorStmt:
+				return_value = _readAlterOperatorStmt();
+				break;
+
 			case T_DefineStmt:
 				return_value = _readDefineStmt();
 				break;

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3877,6 +3877,17 @@ _readAlterCollationStmt(void)
 	READ_DONE();
 }
 
+static AlterOperatorStmt *
+_readAlterOperatorStmt(void)
+{
+	READ_LOCALS(AlterOperatorStmt);
+
+	READ_NODE_FIELD(opername);
+	READ_NODE_FIELD(options);
+
+	READ_DONE();
+}
+
 static DefineStmt *
 _readDefineStmt(void)
 {
@@ -4760,6 +4771,8 @@ parseNodeString(void)
 		return_value = _readAlterFunctionStmt();
 	else if (MATCHX("ALTEROBJECTSCHEMASTMT"))
 		return_value = _readAlterObjectSchemaStmt();
+	else if (MATCHX("ALTEROPERATORSTMT"))
+		return_value = _readAlterOperatorStmt();
 	else if (MATCHX("ALTEROWNERSTMT"))
 		return_value = _readAlterOwnerStmt();
 	else if (MATCHX("ALTEROPFAMILYSTMT"))

--- a/src/test/regress/expected/gp_alter_operator.out
+++ b/src/test/regress/expected/gp_alter_operator.out
@@ -1,0 +1,70 @@
+--
+-- Verify that ALTER OPERATOR ... SET (RESTRICT/JOIN) updates pg_operator on
+-- the coordinator and on every segment.  Selectivity estimators are looked
+-- up wherever planning runs (QE-local planning happens for SPI inside
+-- EXECUTE ON ALL SEGMENTS functions and utility-mode connections), so the
+-- change must reach all of them.
+--
+CREATE SCHEMA alterop;
+SET search_path = alterop;
+CREATE FUNCTION alterop_fn(boolean, boolean) RETURNS boolean
+    AS $$ SELECT $1 = $2 $$ LANGUAGE sql IMMUTABLE;
+CREATE OPERATOR @+ (LEFTARG = boolean, RIGHTARG = boolean, PROCEDURE = alterop_fn);
+-- Sanity: the probe sees one pg_operator row per node (QD + every primary
+-- segment), so the mismatch checks below cannot pass vacuously.
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes
+FROM (SELECT oprrest FROM pg_operator
+      WHERE oprname = '@+' AND oprleft = 'boolean'::regtype
+      UNION ALL
+      SELECT oprrest FROM gp_dist_random('pg_operator')
+      WHERE oprname = '@+' AND oprleft = 'boolean'::regtype) q;
+ all_nodes 
+-----------
+ t
+(1 row)
+
+ALTER OPERATOR @+ (boolean, boolean) SET (RESTRICT = eqsel, JOIN = eqjoinsel);
+-- The QD row must show the new estimators, and every segment must agree
+-- with the QD.  Without the dispatch this returns 'mismatch on seg N' rows.
+SELECT oprrest, oprjoin FROM pg_operator
+WHERE oprname = '@+' AND oprleft = 'boolean'::regtype;
+ oprrest |  oprjoin  
+---------+-----------
+ eqsel   | eqjoinsel
+(1 row)
+
+SELECT 'mismatch on seg ' || seg.gp_segment_id AS problem
+FROM pg_operator qd, gp_dist_random('pg_operator') seg
+WHERE qd.oprname = '@+' AND seg.oprname = '@+'
+  AND qd.oprleft = 'boolean'::regtype AND seg.oprleft = 'boolean'::regtype
+  AND (qd.oprrest IS DISTINCT FROM seg.oprrest OR
+       qd.oprjoin IS DISTINCT FROM seg.oprjoin);
+ problem 
+---------
+(0 rows)
+
+-- Removing the estimators must be dispatched too.
+ALTER OPERATOR @+ (boolean, boolean) SET (RESTRICT = NONE, JOIN = NONE);
+SELECT oprrest, oprjoin FROM pg_operator
+WHERE oprname = '@+' AND oprleft = 'boolean'::regtype;
+ oprrest | oprjoin 
+---------+---------
+ -       | -
+(1 row)
+
+SELECT 'mismatch on seg ' || seg.gp_segment_id AS problem
+FROM pg_operator qd, gp_dist_random('pg_operator') seg
+WHERE qd.oprname = '@+' AND seg.oprname = '@+'
+  AND qd.oprleft = 'boolean'::regtype AND seg.oprleft = 'boolean'::regtype
+  AND (qd.oprrest IS DISTINCT FROM seg.oprrest OR
+       qd.oprjoin IS DISTINCT FROM seg.oprjoin);
+ problem 
+---------
+(0 rows)
+
+RESET search_path;
+DROP SCHEMA alterop CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function alterop.alterop_fn(boolean,boolean)
+drop cascades to operator alterop.@+(boolean,boolean)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -367,4 +367,7 @@ test: hba_conf
 # ALTER COLLATION ... REFRESH VERSION must update every node's pg_collation
 test: gp_collation_refresh
 
+# ALTER OPERATOR ... SET (RESTRICT/JOIN) must update every node's pg_operator
+test: gp_alter_operator
+
 # end of tests

--- a/src/test/regress/sql/gp_alter_operator.sql
+++ b/src/test/regress/sql/gp_alter_operator.sql
@@ -1,0 +1,51 @@
+--
+-- Verify that ALTER OPERATOR ... SET (RESTRICT/JOIN) updates pg_operator on
+-- the coordinator and on every segment.  Selectivity estimators are looked
+-- up wherever planning runs (QE-local planning happens for SPI inside
+-- EXECUTE ON ALL SEGMENTS functions and utility-mode connections), so the
+-- change must reach all of them.
+--
+CREATE SCHEMA alterop;
+SET search_path = alterop;
+
+CREATE FUNCTION alterop_fn(boolean, boolean) RETURNS boolean
+    AS $$ SELECT $1 = $2 $$ LANGUAGE sql IMMUTABLE;
+CREATE OPERATOR @+ (LEFTARG = boolean, RIGHTARG = boolean, PROCEDURE = alterop_fn);
+
+-- Sanity: the probe sees one pg_operator row per node (QD + every primary
+-- segment), so the mismatch checks below cannot pass vacuously.
+SELECT count(*) = (SELECT count(*) + 1 FROM gp_segment_configuration
+                   WHERE role = 'p' AND content >= 0) AS all_nodes
+FROM (SELECT oprrest FROM pg_operator
+      WHERE oprname = '@+' AND oprleft = 'boolean'::regtype
+      UNION ALL
+      SELECT oprrest FROM gp_dist_random('pg_operator')
+      WHERE oprname = '@+' AND oprleft = 'boolean'::regtype) q;
+
+ALTER OPERATOR @+ (boolean, boolean) SET (RESTRICT = eqsel, JOIN = eqjoinsel);
+
+-- The QD row must show the new estimators, and every segment must agree
+-- with the QD.  Without the dispatch this returns 'mismatch on seg N' rows.
+SELECT oprrest, oprjoin FROM pg_operator
+WHERE oprname = '@+' AND oprleft = 'boolean'::regtype;
+SELECT 'mismatch on seg ' || seg.gp_segment_id AS problem
+FROM pg_operator qd, gp_dist_random('pg_operator') seg
+WHERE qd.oprname = '@+' AND seg.oprname = '@+'
+  AND qd.oprleft = 'boolean'::regtype AND seg.oprleft = 'boolean'::regtype
+  AND (qd.oprrest IS DISTINCT FROM seg.oprrest OR
+       qd.oprjoin IS DISTINCT FROM seg.oprjoin);
+
+-- Removing the estimators must be dispatched too.
+ALTER OPERATOR @+ (boolean, boolean) SET (RESTRICT = NONE, JOIN = NONE);
+
+SELECT oprrest, oprjoin FROM pg_operator
+WHERE oprname = '@+' AND oprleft = 'boolean'::regtype;
+SELECT 'mismatch on seg ' || seg.gp_segment_id AS problem
+FROM pg_operator qd, gp_dist_random('pg_operator') seg
+WHERE qd.oprname = '@+' AND seg.oprname = '@+'
+  AND qd.oprleft = 'boolean'::regtype AND seg.oprleft = 'boolean'::regtype
+  AND (qd.oprrest IS DISTINCT FROM seg.oprrest OR
+       qd.oprjoin IS DISTINCT FROM seg.oprjoin);
+
+RESET search_path;
+DROP SCHEMA alterop CASCADE;


### PR DESCRIPTION
## Summary

`ALTER OPERATOR ... SET (RESTRICT/JOIN)` updated `pg_operator` on the coordinator only, leaving every segment with the stale estimator OIDs. This adds the missing dispatch at the end of `AlterOperator()` (mirroring `DefineOperator()`), the `AlterOperatorStmt` serialization support it needs, and a regress test.

## Background

Found while reviewing #219 (CVE-2026-2004): the new superuser gate on estimator changes runs QD-only for the ALTER path because the statement never reaches segments. Same class of bug as #205 (`ALTER COLLATION ... REFRESH VERSION`), fixed with the same recipe. I audited the remaining utility statements against their dispatch call sites: the only objects left QD-only are event triggers and extended statistics, which is by design (`shouldDispatchForObject`), so no other statement has this gap.

## Test plan

- New `gp_alter_operator` regress test cross-checks `pg_operator` on the QD against `gp_dist_random('pg_operator')` after `SET` and after `SET ... NONE`: it fails with "mismatch on seg 0/1/2" on an unpatched build and passes patched.
- `installcheck-small`: 194/194 passed.