### PR TITLE
Decrease severity of "Dump syncmate" message to DEBUG5

### DIFF
--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -766,7 +766,8 @@ dumpSharedLocalSnapshot_forCursor(void)
 	pDump->distributedXid = src->distributedXid;
 	pDump->localXid = src->fullXid;
 
-	elog(LOG, "Dump syncmate : %u snapshot to slot %d", src->segmateSync, id);
+	elog((Debug_print_full_dtm ? LOG : DEBUG5),
+		 "Dump syncmate : %u snapshot to slot %d", src->segmateSync, id);
 
 	src->cur_dump_id =
 		(src->cur_dump_id + 1) % SNAPSHOTDUMPARRAYSZ;


### PR DESCRIPTION
The message "Dump syncmate : %u snapshot to slot %d" was emitted at LOG level every time a writer QE dumps a shared snapshot for cursor readers, flooding server logs on busy clusters. Lower it to DEBUG5 as it is only useful for tracing shared-snapshot synchronization.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
