### PR TITLE
Fix "ORDER/GROUP BY expression not found in targetlist" for correlated EXISTS sublinks

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1946,15 +1946,36 @@ simplify_EXISTS_query(PlannerInfo *root, Query *query)
 	/*
 	 * Delete GROUP BY if no aggregates.
 	 *
-	 * Note: It's important that we don't clear hasAggs, even though we
-	 * removed any possible aggregates from the targetList! If you have a
-	 * subquery like "SELECT SUM(foo) ...", we don't need to compute the sum,
-	 * but we must still aggregate all the rows, and return a single row,
-	 * regardless of how many input rows there are. (In particular, even
-	 * if there are no input rows).
+	 * Note: If the subquery has aggregates, it's usually important that we
+	 * don't clear hasAggs. For an uncorrelated sublink we kept the
+	 * targetlist above, so any aggregates are still in it; and even for a
+	 * correlated sublink, whose targetlist we threw away, a subquery like
+	 * "SELECT SUM(foo) ..." without GROUP BY must still aggregate all the
+	 * rows and return a single row, regardless of how many input rows there
+	 * are. (In particular, even if there are no input rows). Only for a
+	 * correlated sublink that also has a GROUP BY clause can the aggregation
+	 * be discarded along with it; see below.
 	 */
 	if (!query->hasAggs)
 		query->groupClause = NIL;
+	else if (is_correlated && query->groupClause)
+	{
+		/*
+		 * Since we threw away the targetlist of this correlated sublink, we
+		 * can throw away the GROUP BY and the aggregation altogether: a
+		 * grouped query (without grouping sets, which we refused above)
+		 * returns one row per group, so it returns at least one row iff its
+		 * FROM/WHERE clauses yield at least one row.  No aggregates remain
+		 * anywhere in the query: the targetlist is empty, HAVING was demoted
+		 * to WHERE (or we gave up), and the other clauses that could contain
+		 * aggregate references are discarded here as well.  Keeping a GROUP
+		 * BY clause whose sortgroup references point into the discarded
+		 * targetlist would trigger "ORDER/GROUP BY expression not found in
+		 * targetlist" errors later in the planner.
+		 */
+		query->groupClause = NIL;
+		query->hasAggs = false;
+	}
 
 	/*
 	 * Those clauses could be throwed in correlated and uncorrelated sublinks,

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -2576,6 +2576,60 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 (0 rows)
 
 drop table if exists simplify_sub;
+-- Correlated EXISTS sublink with an aggregate and GROUP BY. simplify_EXISTS_query
+-- used to throw away the subquery's targetlist but keep the GROUP BY clause, which
+-- caused an "ORDER/GROUP BY expression not found in targetlist" error when the
+-- sublink couldn't be pulled up as a join (correlation outside the WHERE clause).
+drop table if exists simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
+NOTICE:  table "simplify_grp_foo" does not exist, skipping
+NOTICE:  table "simplify_grp_bar" does not exist, skipping
+NOTICE:  table "simplify_grp_buz" does not exist, skipping
+create table simplify_grp_foo (a int, b int) distributed by (a);
+create table simplify_grp_bar (c int, d int) distributed by (c);
+create table simplify_grp_buz (x int, y int) distributed by (x);
+insert into simplify_grp_foo values (1, 10);
+insert into simplify_grp_bar values (1, 5), (1, 7);
+insert into simplify_grp_buz values (99, 99);
+-- foo.b = 10 matches no bar row in the join clause, so EXISTS is false
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+ a | b 
+---+---
+(0 rows)
+
+-- ... and NOT EXISTS is true
+select * from simplify_grp_foo foo
+where not exists (select max(d) from simplify_grp_bar bar
+                  join simplify_grp_buz buz on bar.c = foo.b
+                  where foo.a = bar.c group by d);
+ a | b  
+---+----
+ 1 | 10
+(1 row)
+
+update simplify_grp_foo set b = 1;
+-- now the subquery's join produces rows, so EXISTS is true
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- an aggregate without GROUP BY always returns one row, so EXISTS must remain
+-- true even though no bar row satisfies the correlated qual
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar where foo.a = bar.c + 100);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+drop table simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
 --
 -- Test a couple of cases where a SubPlan is used in a Motion's hash key.
 --

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2679,6 +2679,60 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 (0 rows)
 
 drop table if exists simplify_sub;
+-- Correlated EXISTS sublink with an aggregate and GROUP BY. simplify_EXISTS_query
+-- used to throw away the subquery's targetlist but keep the GROUP BY clause, which
+-- caused an "ORDER/GROUP BY expression not found in targetlist" error when the
+-- sublink couldn't be pulled up as a join (correlation outside the WHERE clause).
+drop table if exists simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
+NOTICE:  table "simplify_grp_foo" does not exist, skipping
+NOTICE:  table "simplify_grp_bar" does not exist, skipping
+NOTICE:  table "simplify_grp_buz" does not exist, skipping
+create table simplify_grp_foo (a int, b int) distributed by (a);
+create table simplify_grp_bar (c int, d int) distributed by (c);
+create table simplify_grp_buz (x int, y int) distributed by (x);
+insert into simplify_grp_foo values (1, 10);
+insert into simplify_grp_bar values (1, 5), (1, 7);
+insert into simplify_grp_buz values (99, 99);
+-- foo.b = 10 matches no bar row in the join clause, so EXISTS is false
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+ a | b 
+---+---
+(0 rows)
+
+-- ... and NOT EXISTS is true
+select * from simplify_grp_foo foo
+where not exists (select max(d) from simplify_grp_bar bar
+                  join simplify_grp_buz buz on bar.c = foo.b
+                  where foo.a = bar.c group by d);
+ a | b  
+---+----
+ 1 | 10
+(1 row)
+
+update simplify_grp_foo set b = 1;
+-- now the subquery's join produces rows, so EXISTS is true
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- an aggregate without GROUP BY always returns one row, so EXISTS must remain
+-- true even though no bar row satisfies the correlated qual
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar where foo.a = bar.c + 100);
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+drop table simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
 --
 -- Test a couple of cases where a SubPlan is used in a Motion's hash key.
 --

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1075,6 +1075,40 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 
 drop table if exists simplify_sub;
 
+-- Correlated EXISTS sublink with an aggregate and GROUP BY. simplify_EXISTS_query
+-- used to throw away the subquery's targetlist but keep the GROUP BY clause, which
+-- caused an "ORDER/GROUP BY expression not found in targetlist" error when the
+-- sublink couldn't be pulled up as a join (correlation outside the WHERE clause).
+drop table if exists simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
+create table simplify_grp_foo (a int, b int) distributed by (a);
+create table simplify_grp_bar (c int, d int) distributed by (c);
+create table simplify_grp_buz (x int, y int) distributed by (x);
+insert into simplify_grp_foo values (1, 10);
+insert into simplify_grp_bar values (1, 5), (1, 7);
+insert into simplify_grp_buz values (99, 99);
+
+-- foo.b = 10 matches no bar row in the join clause, so EXISTS is false
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+-- ... and NOT EXISTS is true
+select * from simplify_grp_foo foo
+where not exists (select max(d) from simplify_grp_bar bar
+                  join simplify_grp_buz buz on bar.c = foo.b
+                  where foo.a = bar.c group by d);
+update simplify_grp_foo set b = 1;
+-- now the subquery's join produces rows, so EXISTS is true
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar
+              join simplify_grp_buz buz on bar.c = foo.b
+              where foo.a = bar.c group by d);
+-- an aggregate without GROUP BY always returns one row, so EXISTS must remain
+-- true even though no bar row satisfies the correlated qual
+select * from simplify_grp_foo foo
+where exists (select max(d) from simplify_grp_bar bar where foo.a = bar.c + 100);
+drop table simplify_grp_foo, simplify_grp_bar, simplify_grp_buz;
+
 --
 -- Test a couple of cases where a SubPlan is used in a Motion's hash key.
 --


### PR DESCRIPTION
## Problem

```sql
CREATE TABLE foo (a int, b int);
CREATE TABLE bar (c int, d int);
CREATE TABLE buz (x int, y int);

EXPLAIN SELECT * FROM foo
WHERE EXISTS (SELECT max(d) FROM bar JOIN buz ON bar.c = foo.b
              WHERE foo.a = bar.c GROUP BY d);
-- ERROR:  ORDER/GROUP BY expression not found in targetlist (tlist.c:421)
```

## Root cause

Unlike upstream PostgreSQL, GPDB's `simplify_EXISTS_query()` also accepts subqueries with aggregates (the `hasAggs` rejection is `#if 0`-ed out). For a **correlated** sublink it unconditionally throws away the targetlist, but it only removed the GROUP BY clause when the subquery had **no** aggregates. A correlated subquery with both an aggregate and GROUP BY was therefore left in an inconsistent state: `targetList = NIL` while `groupClause` still carried sortgroup references pointing into the discarded targetlist.

This usually goes unnoticed because `convert_EXISTS_sublink_to_join()` pulls the sublink up as a semi-join and drops the groupClause wholesale. But when the pull-up is rejected — here the correlated var `foo.b` appears in a JOIN/ON clause rather than in WHERE — the query falls back to `make_subplan()`, and planning the subquery fails in `standard_qp_callback()` → `make_pathkeys_for_sortclauses(root, groupClause, tlist = NIL)`.

## Fix

When the targetlist of a correlated EXISTS sublink is discarded and the subquery has a GROUP BY, discard the GROUP BY and the aggregation altogether (`groupClause = NIL; hasAggs = false`). This preserves semantics: a grouped query (grouping sets are refused earlier in the function) returns one row per group, so it returns at least one row **iff** its FROM/WHERE clauses yield at least one row — which is all EXISTS cares about. No aggregate expressions can remain anywhere in the query at that point (targetlist is empty; HAVING was demoted to WHERE or we gave up; ORDER BY/DISTINCT/window clauses are discarded too), so clearing `hasAggs` is safe.

The aggregate-without-GROUP-BY case is deliberately left alone: such a subquery always returns exactly one row, so it must keep aggregating (see the existing comment).