### PR TITLE
Fix compile-time issue

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1798,7 +1798,7 @@ destroyConnHashTable(ConnHashTable *ht)
 static inline void
 sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerLen)
 {
-	int			n;
+	int			n = -1;
 
 #ifdef USE_ASSERT_CHECKING
 	if (testmode_inject_fault(gp_udpic_dropacks_percent))


### PR DESCRIPTION
```
reshke@yezzey-cbdb-bench:~/warehouse-pg$ make -j32 install  > /dev/null In function ‘sendControlMessage’,
    inlined from ‘sendAck’ at ic_udpifc.c:1885:2,
    inlined from ‘doSendStopMessageUDPIFC’ at ic_udpifc.c:5840:6,
    inlined from ‘doSendStopMessageUDPIFC’ at ic_udpifc.c:5763:1:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘doSendStopMessageUDPIFC’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAck’ at ic_udpifc.c:1885:2,
    inlined from ‘putRxBufferAndSendAck’ at ic_udpifc.c:1993:4,
    inlined from ‘doSendStopMessageUDPIFC’ at ic_udpifc.c:5809:6,
    inlined from ‘doSendStopMessageUDPIFC’ at ic_udpifc.c:5763:1:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘doSendStopMessageUDPIFC’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendDisorderAck’ at ic_udpifc.c:1916:2,
    inlined from ‘handleDisorderPacket’ at ic_udpifc.c:4958:2,
    inlined from ‘handleDataPacket’ at ic_udpifc.c:6194:4:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘handleDataPacket’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAck’ at ic_udpifc.c:1885:2,
    inlined from ‘handleMismatch’ at ic_udpifc.c:6674:4,
    inlined from ‘rxThreadFunc’ at ic_udpifc.c:6466:10:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘rxThreadFunc’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAckWithParam’ at ic_udpifc.c:1861:2,
    inlined from ‘rxThreadFunc’ at ic_udpifc.c:6481:5:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘rxThreadFunc’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendStatusQueryMessage’ at ic_udpifc.c:1942:2,
    inlined from ‘checkDeadlock’ at ic_udpifc.c:5327:4,
    inlined from ‘checkExceptions’ at ic_udpifc.c:5466:3:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘checkExceptions’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAckWithParam’ at ic_udpifc.c:1861:2,
    inlined from ‘MlPutRxBufferIFC’ at ic_udpifc.c:2036:3:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘MlPutRxBufferIFC’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAckWithParam’ at ic_udpifc.c:1861:2,
    inlined from ‘handleCachedPackets’ at ic_udpifc.c:2958:6,
    inlined from ‘SetupUDPIFCInterconnect_Internal’ at ic_udpifc.c:3235:3,
    inlined from ‘SetupUDPIFCInterconnect’ at ic_udpifc.c:3260:15:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘SetupUDPIFCInterconnect’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
In function ‘sendControlMessage’,
    inlined from ‘sendAck’ at ic_udpifc.c:1885:2,
    inlined from ‘putRxBufferAndSendAck’ at ic_udpifc.c:1993:4,
    inlined from ‘TeardownUDPIFCInterconnect_Internal’ at ic_udpifc.c:3571:7,
    inlined from ‘TeardownUDPIFCInterconnect’ at ic_udpifc.c:3703:3:
ic_udpifc.c:1834:12: error: ‘n’ may be used uninitialized [-Werror=maybe-uninitialized]
 1834 |         if (n < pkt->len)
      |            ^
ic_udpifc.c: In function ‘TeardownUDPIFCInterconnect’:
ic_udpifc.c:1801:33: note: ‘n’ was declared here
 1801 |         int                     n;
      |                                 ^
cc1: some warnings being treated as errors
make[4]: *** [../../../../src/Makefile.global:1026: ic_udpifc.o] Error 1
make[3]: *** [../../../src/backend/common.mk:39: motion-recursive] Error 2
make[2]: *** [common.mk:39: cdb-recursive] Error 2
make[1]: *** [Makefile:45: install-backend-recurse] Error 2
make: *** [GNUmakefile:11: install-src-recurse] Error 2
reshke@yezzey-cbdb-bench:~/warehouse-pg$

```