### PR TITLE
Bounds-check multibyte character lengths (CVE-2025-4207, CVE-2026-2006)

### DIFF
--- a/contrib/btree_gist/btree_utils_var.c
+++ b/contrib/btree_gist/btree_utils_var.c
@@ -117,36 +117,47 @@ gbt_var_leaf2node(GBT_VARKEY *leaf, const gbtree_vinfo *tinfo, FmgrInfo *flinfo)
 
 /*
  * returns the common prefix length of a node key
+ *
+ * If the underlying type is character data, the prefix length may point in
+ * the middle of a multibyte character.
 */
 static int32
 gbt_var_node_cp_len(const GBT_VARKEY *node, const gbtree_vinfo *tinfo)
 {
 	GBT_VARKEY_R r = gbt_var_key_readable(node);
 	int32		i = 0;
-	int32		l = 0;
+	int32		l_left_to_match = 0;
+	int32		l_total = 0;
 	int32		t1len = VARSIZE(r.lower) - VARHDRSZ;
 	int32		t2len = VARSIZE(r.upper) - VARHDRSZ;
 	int32		ml = Min(t1len, t2len);
 	char	   *p1 = VARDATA(r.lower);
 	char	   *p2 = VARDATA(r.upper);
+	const char *end1 = p1 + t1len;
+	const char *end2 = p2 + t2len;
 
 	if (ml == 0)
 		return 0;
 
 	while (i < ml)
 	{
-		if (tinfo->eml > 1 && l == 0)
+		if (tinfo->eml > 1 && l_left_to_match == 0)
 		{
-			if ((l = pg_mblen(p1)) != pg_mblen(p2))
+			l_total = pg_mblen_range(p1, end1);
+			if (l_total != pg_mblen_range(p2, end2))
 			{
 				return i;
 			}
+			l_left_to_match = l_total;
 		}
 		if (*p1 != *p2)
 		{
 			if (tinfo->eml > 1)
 			{
-				return (i - l + 1);
+				int32		l_matched_subset = l_total - l_left_to_match;
+
+				/* end common prefix at final byte of last matching char */
+				return i - l_matched_subset;
 			}
 			else
 			{
@@ -156,7 +167,7 @@ gbt_var_node_cp_len(const GBT_VARKEY *node, const gbtree_vinfo *tinfo)
 
 		p1++;
 		p2++;
-		l--;
+		l_left_to_match--;
 		i++;
 	}
 	return ml;					/* lower == upper */

--- a/contrib/dict_xsyn/dict_xsyn.c
+++ b/contrib/dict_xsyn/dict_xsyn.c
@@ -48,15 +48,15 @@ find_word(char *in, char **end)
 	char	   *start;
 
 	*end = NULL;
-	while (*in && t_isspace(in))
-		in += pg_mblen(in);
+	while (*in && t_isspace_cstr(in))
+		in += pg_mblen_cstr(in);
 
 	if (!*in || *in == '#')
 		return NULL;
 	start = in;
 
-	while (*in && !t_isspace(in))
-		in += pg_mblen(in);
+	while (*in && !t_isspace_cstr(in))
+		in += pg_mblen_cstr(in);
 
 	*end = in;
 

--- a/contrib/hstore/hstore_io.c
+++ b/contrib/hstore/hstore_io.c
@@ -82,7 +82,7 @@ get_val(HSParser *state, bool ignoreeq, bool *escaped)
 			else if (*(state->ptr) == '=' && !ignoreeq)
 			{
 				elog(ERROR, "Syntax error near \"%.*s\" at position %d",
-					 pg_mblen(state->ptr), state->ptr,
+					 pg_mblen_cstr(state->ptr), state->ptr,
 					 (int32) (state->ptr - state->begin));
 			}
 			else if (*(state->ptr) == '\\')
@@ -223,7 +223,7 @@ parse_hstore(HSParser *state)
 			else if (!isspace((unsigned char) *(state->ptr)))
 			{
 				elog(ERROR, "Syntax error near \"%.*s\" at position %d",
-					 pg_mblen(state->ptr), state->ptr,
+					 pg_mblen_cstr(state->ptr), state->ptr,
 					 (int32) (state->ptr - state->begin));
 			}
 		}
@@ -240,7 +240,7 @@ parse_hstore(HSParser *state)
 			else
 			{
 				elog(ERROR, "Syntax error near \"%.*s\" at position %d",
-					 pg_mblen(state->ptr), state->ptr,
+					 pg_mblen_cstr(state->ptr), state->ptr,
 					 (int32) (state->ptr - state->begin));
 			}
 		}
@@ -275,7 +275,7 @@ parse_hstore(HSParser *state)
 			else if (!isspace((unsigned char) *(state->ptr)))
 			{
 				elog(ERROR, "Syntax error near \"%.*s\" at position %d",
-					 pg_mblen(state->ptr), state->ptr,
+					 pg_mblen_cstr(state->ptr), state->ptr,
 					 (int32) (state->ptr - state->begin));
 			}
 		}

--- a/contrib/ltree/lquery_op.c
+++ b/contrib/ltree/lquery_op.c
@@ -36,14 +36,14 @@ getlexeme(char *start, char *end, int *len)
 	char	   *ptr;
 	int			charlen;
 
-	while (start < end && (charlen = pg_mblen(start)) == 1 && t_iseq(start, '_'))
+	while (start < end && (charlen = pg_mblen_range(start, end)) == 1 && t_iseq(start, '_'))
 		start += charlen;
 
 	ptr = start;
 	if (ptr >= end)
 		return NULL;
 
-	while (ptr < end && !((charlen = pg_mblen(ptr)) == 1 && t_iseq(ptr, '_')))
+	while (ptr < end && !((charlen = pg_mblen_range(ptr, end)) == 1 && t_iseq(ptr, '_')))
 		ptr += charlen;
 
 	*len = ptr - start;

--- a/contrib/ltree/ltree.h
+++ b/contrib/ltree/ltree.h
@@ -82,7 +82,8 @@ typedef struct
 
 #define LQUERY_HASNOT		0x01
 
-#define ISALNUM(x)	( t_isalpha(x) || t_isdigit(x)	|| ( pg_mblen(x) == 1 && t_iseq((x), '_') ) )
+/* Caller has already called mblen, so we can use _unbounded variants safely. */
+#define ISALNUM(x)	( t_isalpha_unbounded(x) || t_isdigit_unbounded(x) || ( pg_mblen_unbounded(x) == 1 && t_iseq((x), '_') ) )
 
 /* full text query */
 

--- a/contrib/ltree/ltree_io.c
+++ b/contrib/ltree/ltree_io.c
@@ -53,7 +53,7 @@ ltree_in(PG_FUNCTION_ARGS)
 	ptr = buf;
 	while (*ptr)
 	{
-		charlen = pg_mblen(ptr);
+		charlen = pg_mblen_cstr(ptr);
 		if (charlen == 1 && t_iseq(ptr, '.'))
 			num++;
 		ptr += charlen;
@@ -68,7 +68,7 @@ ltree_in(PG_FUNCTION_ARGS)
 	ptr = buf;
 	while (*ptr)
 	{
-		charlen = pg_mblen(ptr);
+		charlen = pg_mblen_cstr(ptr);
 
 		if (state == LTPRS_WAITNAME)
 		{
@@ -214,7 +214,7 @@ lquery_in(PG_FUNCTION_ARGS)
 	ptr = buf;
 	while (*ptr)
 	{
-		charlen = pg_mblen(ptr);
+		charlen = pg_mblen_cstr(ptr);
 
 		if (charlen == 1)
 		{
@@ -237,7 +237,7 @@ lquery_in(PG_FUNCTION_ARGS)
 	ptr = buf;
 	while (*ptr)
 	{
-		charlen = pg_mblen(ptr);
+		charlen = pg_mblen_cstr(ptr);
 
 		if (state == LQPRS_WAITLEVEL)
 		{
@@ -361,7 +361,7 @@ lquery_in(PG_FUNCTION_ARGS)
 		{
 			if (charlen == 1 && t_iseq(ptr, ','))
 				state = LQPRS_WAITSNUM;
-			else if (t_isdigit(ptr))
+			else if (t_isdigit_cstr(ptr))
 			{
 				int			low = atoi(ptr);
 
@@ -380,7 +380,7 @@ lquery_in(PG_FUNCTION_ARGS)
 		}
 		else if (state == LQPRS_WAITSNUM)
 		{
-			if (t_isdigit(ptr))
+			if (t_isdigit_cstr(ptr))
 			{
 				int			high = atoi(ptr);
 
@@ -406,7 +406,7 @@ lquery_in(PG_FUNCTION_ARGS)
 		{
 			if (charlen == 1 && t_iseq(ptr, '}'))
 				state = LQPRS_WAITEND;
-			else if (!t_isdigit(ptr))
+			else if (!t_isdigit_cstr(ptr))
 				UNCHAR;
 		}
 		else if (state == LQPRS_WAITND)
@@ -418,7 +418,7 @@ lquery_in(PG_FUNCTION_ARGS)
 			}
 			else if (charlen == 1 && t_iseq(ptr, ','))
 				state = LQPRS_WAITSNUM;
-			else if (!t_isdigit(ptr))
+			else if (!t_isdigit_cstr(ptr))
 				UNCHAR;
 		}
 		else if (state == LQPRS_WAITEND)

--- a/contrib/ltree/ltxtquery_io.c
+++ b/contrib/ltree/ltxtquery_io.c
@@ -61,7 +61,7 @@ gettoken_query(QPRS_STATE *state, int32 *val, int32 *lenval, char **strval, uint
 
 	for (;;)
 	{
-		charlen = pg_mblen(state->buf);
+		charlen = pg_mblen_cstr(state->buf);
 
 		switch (state->state)
 		{
@@ -85,7 +85,7 @@ gettoken_query(QPRS_STATE *state, int32 *val, int32 *lenval, char **strval, uint
 					*lenval = charlen;
 					*flag = 0;
 				}
-				else if (!t_isspace(state->buf))
+				else if (!t_isspace_unbounded(state->buf))
 					ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
 							 errmsg("operand syntax error")));

--- a/contrib/pageinspect/heapfuncs.c
+++ b/contrib/pageinspect/heapfuncs.c
@@ -101,7 +101,7 @@ text_to_bits(char *str, int len)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
 					 errmsg("invalid character \"%.*s\" in t_bits string",
-							pg_mblen(str + off), str + off)));
+							pg_mblen_cstr(str + off), str + off)));
 
 		if (off % 8 == 7)
 			bits[off / 8] = byte;

--- a/contrib/pg_trgm/trgm.h
+++ b/contrib/pg_trgm/trgm.h
@@ -51,10 +51,10 @@ typedef char trgm[3];
 } while(0)
 
 #ifdef KEEPONLYALNUM
-#define ISWORDCHR(c)	(t_isalpha(c) || t_isdigit(c))
+#define ISWORDCHR(c, len)	(t_isalpha_with_len(c, len) || t_isdigit_with_len(c, len))
 #define ISPRINTABLECHAR(a)	( isascii( *(unsigned char*)(a) ) && (isalnum( *(unsigned char*)(a) ) || *(unsigned char*)(a)==' ') )
 #else
-#define ISWORDCHR(c)	(!t_isspace(c))
+#define ISWORDCHR(c, len)	(!t_isspace_with_len(c, len))
 #define ISPRINTABLECHAR(a)	( isascii( *(unsigned char*)(a) ) && isprint( *(unsigned char*)(a) ) )
 #endif
 #define ISPRINTABLETRGM(t)	( ISPRINTABLECHAR( ((char*)(t)) ) && ISPRINTABLECHAR( ((char*)(t))+1 ) && ISPRINTABLECHAR( ((char*)(t))+2 ) )

--- a/contrib/pg_trgm/trgm_op.c
+++ b/contrib/pg_trgm/trgm_op.c
@@ -191,18 +191,29 @@ static char *
 find_word(char *str, int lenstr, char **endword, int *charlen)
 {
 	char	   *beginword = str;
+	const char *endstr = str + lenstr;
 
-	while (beginword - str < lenstr && !ISWORDCHR(beginword))
-		beginword += pg_mblen(beginword);
+	while (beginword < endstr)
+	{
+		int			clen = pg_mblen_range(beginword, endstr);
 
-	if (beginword - str >= lenstr)
+		if (ISWORDCHR(beginword, clen))
+			break;
+		beginword += clen;
+	}
+
+	if (beginword >= endstr)
 		return NULL;
 
 	*endword = beginword;
 	*charlen = 0;
-	while (*endword - str < lenstr && ISWORDCHR(*endword))
+	while (*endword < endstr)
 	{
-		*endword += pg_mblen(*endword);
+		int			clen = pg_mblen_range(*endword, endstr);
+
+		if (!ISWORDCHR(*endword, clen))
+			break;
+		*endword += clen;
 		(*charlen)++;
 	}
 
@@ -250,9 +261,9 @@ make_trigrams(trgm *tptr, char *str, int bytelen, int charlen)
 	if (bytelen > charlen)
 	{
 		/* Find multibyte character boundaries and apply compact_trigram */
-		int			lenfirst = pg_mblen(str),
-					lenmiddle = pg_mblen(str + lenfirst),
-					lenlast = pg_mblen(str + lenfirst + lenmiddle);
+		int			lenfirst = pg_mblen_unbounded(str),
+					lenmiddle = pg_mblen_unbounded(str + lenfirst),
+					lenlast = pg_mblen_unbounded(str + lenfirst + lenmiddle);
 
 		while ((ptr - str) + lenfirst + lenmiddle + lenlast <= bytelen)
 		{
@@ -263,7 +274,7 @@ make_trigrams(trgm *tptr, char *str, int bytelen, int charlen)
 
 			lenfirst = lenmiddle;
 			lenmiddle = lenlast;
-			lenlast = pg_mblen(ptr + lenfirst + lenmiddle);
+			lenlast = pg_mblen_unbounded(ptr + lenfirst + lenmiddle);
 		}
 	}
 	else
@@ -743,6 +754,7 @@ get_wildcard_part(const char *str, int lenstr,
 {
 	const char *beginword = str;
 	const char *endword;
+	const char *endstr = str + lenstr;
 	char	   *s = buf;
 	bool		in_leading_wildcard_meta = false;
 	bool		in_trailing_wildcard_meta = false;
@@ -755,11 +767,13 @@ get_wildcard_part(const char *str, int lenstr,
 	 * from this loop to the next one, since we may exit at a word character
 	 * that is in_escape.
 	 */
-	while (beginword - str < lenstr)
+	while (beginword < endstr)
 	{
+		clen = pg_mblen_range(beginword, endstr);
+
 		if (in_escape)
 		{
-			if (ISWORDCHR(beginword))
+			if (ISWORDCHR(beginword, clen))
 				break;
 			in_escape = false;
 			in_leading_wildcard_meta = false;
@@ -770,12 +784,12 @@ get_wildcard_part(const char *str, int lenstr,
 				in_escape = true;
 			else if (ISWILDCARDCHAR(beginword))
 				in_leading_wildcard_meta = true;
-			else if (ISWORDCHR(beginword))
+			else if (ISWORDCHR(beginword, clen))
 				break;
 			else
 				in_leading_wildcard_meta = false;
 		}
-		beginword += pg_mblen(beginword);
+		beginword += clen;
 	}
 
 	/*
@@ -808,12 +822,12 @@ get_wildcard_part(const char *str, int lenstr,
 	 * string boundary.  Strip escapes during copy.
 	 */
 	endword = beginword;
-	while (endword - str < lenstr)
+	while (endword < endstr)
 	{
-		clen = pg_mblen(endword);
+		clen = pg_mblen_range(endword, endstr);
 		if (in_escape)
 		{
-			if (ISWORDCHR(endword))
+			if (ISWORDCHR(endword, clen))
 			{
 				memcpy(s, endword, clen);
 				(*charlen)++;
@@ -841,7 +855,7 @@ get_wildcard_part(const char *str, int lenstr,
 				in_trailing_wildcard_meta = true;
 				break;
 			}
-			else if (ISWORDCHR(endword))
+			else if (ISWORDCHR(endword, clen))
 			{
 				memcpy(s, endword, clen);
 				(*charlen)++;

--- a/contrib/pg_trgm/trgm_regexp.c
+++ b/contrib/pg_trgm/trgm_regexp.c
@@ -482,7 +482,7 @@ static TRGM *createTrgmNFAInternal(regex_t *regex, TrgmPackedGraph **graph,
 static void RE_compile(regex_t *regex, text *text_re,
 					   int cflags, Oid collation);
 static void getColorInfo(regex_t *regex, TrgmNFA *trgmNFA);
-static bool convertPgWchar(pg_wchar c, trgm_mb_char *result);
+static int	convertPgWchar(pg_wchar c, trgm_mb_char *result);
 static void transformGraph(TrgmNFA *trgmNFA);
 static void processState(TrgmNFA *trgmNFA, TrgmState *state);
 static void addKey(TrgmNFA *trgmNFA, TrgmState *state, TrgmStateKey *key);
@@ -820,10 +820,11 @@ getColorInfo(regex_t *regex, TrgmNFA *trgmNFA)
 		for (j = 0; j < charsCount; j++)
 		{
 			trgm_mb_char c;
+			int			clen = convertPgWchar(chars[j], &c);
 
-			if (!convertPgWchar(chars[j], &c))
+			if (!clen)
 				continue;		/* ok to ignore it altogether */
-			if (ISWORDCHR(c.bytes))
+			if (ISWORDCHR(c.bytes, clen))
 				colorInfo->wordChars[colorInfo->wordCharsCount++] = c;
 			else
 				colorInfo->containsNonWord = true;
@@ -835,13 +836,15 @@ getColorInfo(regex_t *regex, TrgmNFA *trgmNFA)
 
 /*
  * Convert pg_wchar to multibyte format.
- * Returns false if the character should be ignored completely.
+ * Returns 0 if the character should be ignored completely, else returns its
+ * byte length.
  */
-static bool
+static int
 convertPgWchar(pg_wchar c, trgm_mb_char *result)
 {
 	/* "s" has enough space for a multibyte character and a trailing NUL */
 	char		s[MAX_MULTIBYTE_CHAR_LEN + 1];
+	int			clen;
 
 	/*
 	 * We can ignore the NUL character, since it can never appear in a PG text
@@ -849,11 +852,11 @@ convertPgWchar(pg_wchar c, trgm_mb_char *result)
 	 * reconstructing trigrams.
 	 */
 	if (c == 0)
-		return false;
+		return 0;
 
 	/* Do the conversion, making sure the result is NUL-terminated */
 	memset(s, 0, sizeof(s));
-	pg_wchar2mb_with_len(&c, s, 1);
+	clen = pg_wchar2mb_with_len(&c, s, 1);
 
 	/*
 	 * In IGNORECASE mode, we can ignore uppercase characters.  We assume that
@@ -875,7 +878,7 @@ convertPgWchar(pg_wchar c, trgm_mb_char *result)
 		if (strcmp(lowerCased, s) != 0)
 		{
 			pfree(lowerCased);
-			return false;
+			return 0;
 		}
 		pfree(lowerCased);
 	}
@@ -883,7 +886,7 @@ convertPgWchar(pg_wchar c, trgm_mb_char *result)
 
 	/* Fill result with exactly MAX_MULTIBYTE_CHAR_LEN bytes */
 	memcpy(result->bytes, s, MAX_MULTIBYTE_CHAR_LEN);
-	return true;
+	return clen;
 }
 
 

--- a/contrib/unaccent/unaccent.c
+++ b/contrib/unaccent/unaccent.c
@@ -149,9 +149,9 @@ initTrie(const char *filename)
 				state = 0;
 				for (ptr = line; *ptr; ptr += ptrlen)
 				{
-					ptrlen = pg_mblen(ptr);
+					ptrlen = pg_mblen_cstr(ptr);
 					/* ignore whitespace, but end src or trg */
-					if (t_isspace(ptr))
+					if (t_isspace_cstr(ptr))
 					{
 						if (state == 1)
 							state = 2;
@@ -315,6 +315,7 @@ unaccent_lexize(PG_FUNCTION_ARGS)
 	char	   *srcchar = (char *) PG_GETARG_POINTER(1);
 	int32		len = PG_GETARG_INT32(2);
 	char	   *srcstart = srcchar;
+	const char *srcend = srcstart + len;
 	TSLexeme   *res;
 	StringInfoData buf;
 
@@ -342,7 +343,7 @@ unaccent_lexize(PG_FUNCTION_ARGS)
 		}
 		else
 		{
-			matchlen = pg_mblen(srcchar);
+			matchlen = pg_mblen_range(srcchar, srcend);
 			if (buf.data != NULL)
 				appendBinaryStringInfo(&buf, srcchar, matchlen);
 		}

--- a/gpcontrib/orafce/charpad.c
+++ b/gpcontrib/orafce/charpad.c
@@ -45,6 +45,7 @@ orafce_lpad(PG_FUNCTION_ARGS)
 	text	*string2 = PG_GETARG_TEXT_PP(2);
 	text	*ret;
 	char	*ptr1,
+			*ptr1end,
 			*ptr2 = NULL,
 			*ptr2start = NULL,
 			*ptr2end = NULL,
@@ -86,8 +87,11 @@ orafce_lpad(PG_FUNCTION_ARGS)
 		output_width = 0;	/* same behavior as Oracle database */
 	}
 
+	/* end of string1, for bounds checks below (s1blen is consumed) */
+	ptr1end = VARDATA_ANY(string1) + s1blen;
+
 	/* byte-length of half-width space */
-	hslen = pg_mblen(spc);
+	hslen = pg_mblen_cstr(spc);
 
 	/*
 	 * Calculate the length of the portion of string1 to include in
@@ -97,7 +101,7 @@ orafce_lpad(PG_FUNCTION_ARGS)
 	while (s1blen > 0)
 	{
 		/* byte-length and display length per character of string1 */
-		mlen = pg_mblen(ptr1);
+		mlen = pg_mblen_with_len(ptr1, s1blen);
 		dsplen = pg_dsplen(ptr1);
 
 		/* accumulate display length of string1 */
@@ -157,7 +161,7 @@ orafce_lpad(PG_FUNCTION_ARGS)
 		while (s2_add_width > 0)
 		{
 			/*  byte-length and display length per character of string2 */
-			mlen = pg_mblen(ptr2);
+			mlen = pg_mblen_range(ptr2, ptr2end);
 			dsplen = pg_dsplen(ptr2);
 
 			/*
@@ -216,7 +220,7 @@ orafce_lpad(PG_FUNCTION_ARGS)
 			ptr2 = ptr2start;
 		}
 
-		mlen = pg_mblen(ptr2);
+		mlen = pg_mblen_range(ptr2, ptr2end);
 		if ( s2_add_blen < mlen )
 			break;
 
@@ -244,7 +248,15 @@ orafce_lpad(PG_FUNCTION_ARGS)
 			ptr1 = VARDATA_ANY(string1);
 		}
 
-		mlen = pg_mblen(ptr1);
+		/*
+		 * s1_add_blen can outlast string1 itself, because it also covers the
+		 * half-width space accounted for above, so stop here rather than read
+		 * a character that starts at or past the end of string1.
+		 */
+		if (ptr1 >= ptr1end)
+			break;
+
+		mlen = pg_mblen_range(ptr1, ptr1end);
 
 		if( s1_add_blen < mlen )
 			break;
@@ -276,6 +288,7 @@ orafce_rpad(PG_FUNCTION_ARGS)
 	text	*string2 = PG_GETARG_TEXT_PP(2);
 	text	*ret;
 	char	*ptr1,
+			*ptr1end,
 			*ptr2 = NULL,
 			*ptr2start = NULL,
 			*ptr2end = NULL,
@@ -317,8 +330,11 @@ orafce_rpad(PG_FUNCTION_ARGS)
 		output_width = 0;	/* same behavior as Oracle database */
 	}
 
+	/* end of string1, for bounds checks below (s1blen is consumed) */
+	ptr1end = VARDATA_ANY(string1) + s1blen;
+
 	/* byte-length of half-width space */
-	hslen = pg_mblen(spc);
+	hslen = pg_mblen_cstr(spc);
 
 	/*
 	 * Calculate the length of the portion of string1 to include in
@@ -328,7 +344,7 @@ orafce_rpad(PG_FUNCTION_ARGS)
 	while (s1blen > 0)
 	{
 		/* byte-length and display length per character of string1 */
-		mlen = pg_mblen(ptr1);
+		mlen = pg_mblen_with_len(ptr1, s1blen);
 		dsplen = pg_dsplen(ptr1);
 
 		/* accumulate display length of string1 */
@@ -388,7 +404,7 @@ orafce_rpad(PG_FUNCTION_ARGS)
 		while (s2_add_width > 0)
 		{
 			/*  byte-length and display length per character of string2 */
-			mlen = pg_mblen(ptr2);
+			mlen = pg_mblen_range(ptr2, ptr2end);
 			dsplen = pg_dsplen(ptr2);
 
 			/*
@@ -434,7 +450,15 @@ orafce_rpad(PG_FUNCTION_ARGS)
 			ptr1 = VARDATA_ANY(string1);
 		}
 
-		mlen = pg_mblen(ptr1);
+		/*
+		 * s1_add_blen can outlast string1 itself, because it also covers the
+		 * half-width space accounted for above, so stop here rather than read
+		 * a character that starts at or past the end of string1.
+		 */
+		if (ptr1 >= ptr1end)
+			break;
+
+		mlen = pg_mblen_range(ptr1, ptr1end);
 
 		if( s1_add_blen < mlen )
 			break;
@@ -459,7 +483,7 @@ orafce_rpad(PG_FUNCTION_ARGS)
 			ptr2 = ptr2start;
 		}
 
-		mlen = pg_mblen(ptr2);
+		mlen = pg_mblen_range(ptr2, ptr2end);
 		if ( s2_add_blen < mlen )
 			break;
 

--- a/gpcontrib/orafce/convert.c
+++ b/gpcontrib/orafce/convert.c
@@ -606,6 +606,7 @@ orafce_to_single_byte(PG_FUNCTION_ARGS)
 	text	   *src;
 	text	   *dst;
 	char	   *s;
+	const char *srcend;
 	char	   *d;
 	int			srclen;
 
@@ -643,6 +644,7 @@ orafce_to_single_byte(PG_FUNCTION_ARGS)
 	src = PG_GETARG_TEXT_PP(0);
 	s = VARDATA_ANY(src);
 	srclen = VARSIZE_ANY_EXHDR(src);
+	srcend = s + srclen;
 
 	/* XXX - The output length should be <= input length */
 	dst = (text *) palloc0(VARHDRSZ + srclen);
@@ -654,7 +656,7 @@ orafce_to_single_byte(PG_FUNCTION_ARGS)
 		int		clen;
 		int		mapindex;
 
-		clen = pg_mblen(u);
+		clen = pg_mblen_range(u, srcend);
 		s += clen;
 
 		if (clen == 1)

--- a/gpcontrib/orafce/plvstr.c
+++ b/gpcontrib/orafce/plvstr.c
@@ -88,10 +88,6 @@ if (VARSIZE_ANY_EXHDR(str) == 0) \
 		 errdetail(detail)));
 
 
-#ifndef _pg_mblen
-#define _pg_mblen	pg_mblen
-#endif
-
 typedef enum
 {
 	POSITION,
@@ -123,7 +119,7 @@ ora_mb_strlen(text *str, char **sizes, int **positions)
 	{
 		int sz;
 
-		sz = _pg_mblen(p);
+		sz = pg_mblen_with_len(p, r_len - cur);
 		if (sizes)
 			(*sizes)[cur_size] = sz;
 		if (positions)
@@ -155,7 +151,7 @@ ora_mb_strlen1(text *str)
 	{
 		int sz;
 
-		sz = _pg_mblen(p);
+		sz = pg_mblen_with_len(p, r_len);
 		p += sz;
 		r_len -= sz;
 		c += 1;
@@ -312,6 +308,7 @@ plvstr_normalize(PG_FUNCTION_ARGS)
 	text	   *str = PG_GETARG_TEXT_PP(0);
 	text	   *result;
 	char	   *aux, *cur, *aux_cur;
+	const char *end;
 	int			i;
 
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(__amd64__))
@@ -336,6 +333,7 @@ plvstr_normalize(PG_FUNCTION_ARGS)
 
 	write_spc = false;
 	cur = VARDATA_ANY(str);
+	end = cur + l;
 
 	for (i = 0; i < l; i++)
 	{
@@ -354,7 +352,7 @@ plvstr_normalize(PG_FUNCTION_ARGS)
 
 				if (mb_encode)
 				{
-					sz = _pg_mblen(cur);
+					sz = pg_mblen_range(cur, end);
 					if (sz > 1 || (sz == 1 && c > 32))
 					{
 						int		j;
@@ -1072,7 +1070,8 @@ plvchr_is_kind_a (PG_FUNCTION_ARGS)
 	NON_EMPTY_CHECK(str);
 	if (pg_database_encoding_max_length() > 1)
 	{
-		if (_pg_mblen(VARDATA_ANY(str)) > 1)
+		if (pg_mblen_with_len(VARDATA_ANY(str),
+							  VARSIZE_ANY_EXHDR(str)) > 1)
 			PG_RETURN_INT32( (k == 5) );
 	}
 

--- a/gpcontrib/orafce/regexp.c
+++ b/gpcontrib/orafce/regexp.c
@@ -264,7 +264,7 @@ charlen_to_bytelen(const char *p, int n)
 		const char *s;
 
 		for (s = p; n > 0; n--)
-			s += pg_mblen(s);
+			s += pg_mblen_unbounded(s); /* caller verified encoding */
 
 		return s - p;
 	}
@@ -905,7 +905,8 @@ parse_re_flags(pg_re_flags *flags, text *opts)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 							 errmsg("invalid regular expression option: \"%.*s\"",
-									pg_mblen(opt_p + i), opt_p + i)));
+									pg_mblen_range(opt_p + i, opt_p + opt_len),
+									opt_p + i)));
 					break;
 			}
 		}
@@ -1137,7 +1138,9 @@ orafce_textregexreplace(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("invalid regular expression option: \"%.*s\"",
-							pg_mblen(opt_p), opt_p),
+							pg_mblen_range(opt_p,
+										   opt_p + VARSIZE_ANY_EXHDR(opt)),
+							opt_p),
 					 errhint("If you meant to use regexp_replace() with a start parameter, cast the fourth argument to integer explicitly.")));
 	}
 

--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -1211,7 +1211,7 @@ match_prosrc_to_literal(const char *prosrc, const char *literal,
 			if (cursorpos > 0)
 				newcp++;
 		}
-		chlen = pg_mblen(prosrc);
+		chlen = pg_mblen_cstr(prosrc);
 		if (strncmp(prosrc, literal, chlen) != 0)
 			goto fail;
 		prosrc += chlen;

--- a/src/backend/tsearch/dict_synonym.c
+++ b/src/backend/tsearch/dict_synonym.c
@@ -47,8 +47,8 @@ findwrd(char *in, char **end, uint16 *flags)
 	char	   *lastchar;
 
 	/* Skip leading spaces */
-	while (*in && t_isspace(in))
-		in += pg_mblen(in);
+	while (*in && t_isspace_cstr(in))
+		in += pg_mblen_cstr(in);
 
 	/* Return NULL on empty lines */
 	if (*in == '\0')
@@ -60,10 +60,10 @@ findwrd(char *in, char **end, uint16 *flags)
 	lastchar = start = in;
 
 	/* Find end of word */
-	while (*in && !t_isspace(in))
+	while (*in && !t_isspace_cstr(in))
 	{
 		lastchar = in;
-		in += pg_mblen(in);
+		in += pg_mblen_cstr(in);
 	}
 
 	if (in - lastchar == 1 && t_iseq(lastchar, '*') && flags)

--- a/src/backend/tsearch/dict_thesaurus.c
+++ b/src/backend/tsearch/dict_thesaurus.c
@@ -190,8 +190,8 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 		ptr = line;
 
 		/* is it a comment? */
-		while (*ptr && t_isspace(ptr))
-			ptr += pg_mblen(ptr);
+		while (*ptr && t_isspace_cstr(ptr))
+			ptr += pg_mblen_cstr(ptr);
 
 		if (t_iseq(ptr, '#') || *ptr == '\0' ||
 			t_iseq(ptr, '\n') || t_iseq(ptr, '\r'))
@@ -212,7 +212,7 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 								 errmsg("unexpected delimiter")));
 					state = TR_WAITSUBS;
 				}
-				else if (!t_isspace(ptr))
+				else if (!t_isspace_cstr(ptr))
 				{
 					beginwrd = ptr;
 					state = TR_INLEX;
@@ -225,7 +225,7 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 					newLexeme(d, beginwrd, ptr, idsubst, posinsubst++);
 					state = TR_WAITSUBS;
 				}
-				else if (t_isspace(ptr))
+				else if (t_isspace_cstr(ptr))
 				{
 					newLexeme(d, beginwrd, ptr, idsubst, posinsubst++);
 					state = TR_WAITLEX;
@@ -237,15 +237,15 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 				{
 					useasis = true;
 					state = TR_INSUBS;
-					beginwrd = ptr + pg_mblen(ptr);
+					beginwrd = ptr + pg_mblen_cstr(ptr);
 				}
 				else if (t_iseq(ptr, '\\'))
 				{
 					useasis = false;
 					state = TR_INSUBS;
-					beginwrd = ptr + pg_mblen(ptr);
+					beginwrd = ptr + pg_mblen_cstr(ptr);
 				}
-				else if (!t_isspace(ptr))
+				else if (!t_isspace_cstr(ptr))
 				{
 					useasis = false;
 					beginwrd = ptr;
@@ -254,7 +254,7 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 			}
 			else if (state == TR_INSUBS)
 			{
-				if (t_isspace(ptr))
+				if (t_isspace_cstr(ptr))
 				{
 					if (ptr == beginwrd)
 						ereport(ERROR,
@@ -267,7 +267,7 @@ thesaurusRead(const char *filename, DictThesaurus *d)
 			else
 				elog(ERROR, "unrecognized thesaurus state: %d", state);
 
-			ptr += pg_mblen(ptr);
+			ptr += pg_mblen_cstr(ptr);
 		}
 
 		if (state == TR_INSUBS)

--- a/src/backend/tsearch/spell.c
+++ b/src/backend/tsearch/spell.c
@@ -231,7 +231,7 @@ findchar(char *str, int c)
 	{
 		if (t_iseq(str, c))
 			return str;
-		str += pg_mblen(str);
+		str += pg_mblen_cstr(str);
 	}
 
 	return NULL;
@@ -244,7 +244,7 @@ findchar2(char *str, int c1, int c2)
 	{
 		if (t_iseq(str, c1) || t_iseq(str, c2))
 			return str;
-		str += pg_mblen(str);
+		str += pg_mblen_cstr(str);
 	}
 
 	return NULL;
@@ -351,6 +351,7 @@ getNextFlagFromString(IspellDict *Conf, char **sflagset, char *sflag)
 	char	   *next,
 			   *sbuf = *sflagset;
 	int			maxstep;
+	int			clen;
 	bool		stop = false;
 	bool		met_comma = false;
 
@@ -362,11 +363,11 @@ getNextFlagFromString(IspellDict *Conf, char **sflagset, char *sflag)
 		{
 			case FM_LONG:
 			case FM_CHAR:
-				COPYCHAR(sflag, *sflagset);
-				sflag += pg_mblen(*sflagset);
+				clen = ts_copychar_cstr(sflag, *sflagset);
+				sflag += clen;
 
 				/* Go to start of the next flag */
-				*sflagset += pg_mblen(*sflagset);
+				*sflagset += clen;
 
 				/* Check if we get all characters of flag */
 				maxstep--;
@@ -389,7 +390,7 @@ getNextFlagFromString(IspellDict *Conf, char **sflagset, char *sflag)
 				*sflagset = next;
 				while (**sflagset)
 				{
-					if (t_isdigit(*sflagset))
+					if (t_isdigit_cstr(*sflagset))
 					{
 						if (!met_comma)
 							ereport(ERROR,
@@ -407,7 +408,7 @@ getNextFlagFromString(IspellDict *Conf, char **sflagset, char *sflag)
 											*sflagset)));
 						met_comma = true;
 					}
-					else if (!t_isspace(*sflagset))
+					else if (!t_isspace_cstr(*sflagset))
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_CONFIG_FILE_ERROR),
@@ -415,7 +416,7 @@ getNextFlagFromString(IspellDict *Conf, char **sflagset, char *sflag)
 										*sflagset)));
 					}
 
-					*sflagset += pg_mblen(*sflagset);
+					*sflagset += pg_mblen_cstr(*sflagset);
 				}
 				stop = true;
 				break;
@@ -541,7 +542,7 @@ NIImportDictionary(IspellDict *Conf, const char *filename)
 			while (*s)
 			{
 				/* we allow only single encoded flags for faster works */
-				if (pg_mblen(s) == 1 && t_isprint(s) && !t_isspace(s))
+				if (pg_mblen_cstr(s) == 1 && t_isprint_unbounded(s) && !t_isspace_unbounded(s))
 					s++;
 				else
 				{
@@ -557,12 +558,12 @@ NIImportDictionary(IspellDict *Conf, const char *filename)
 		s = line;
 		while (*s)
 		{
-			if (t_isspace(s))
+			if (t_isspace_cstr(s))
 			{
 				*s = '\0';
 				break;
 			}
-			s += pg_mblen(s);
+			s += pg_mblen_cstr(s);
 		}
 		pstr = lowerstr_ctx(Conf, line);
 
@@ -814,17 +815,17 @@ get_nextfield(char **str, char *next)
 
 	while (**str)
 	{
+		int			clen = pg_mblen_cstr(*str);
+
 		if (state == PAE_WAIT_MASK)
 		{
 			if (t_iseq(*str, '#'))
 				return false;
-			else if (!t_isspace(*str))
+			else if (!t_isspace_cstr(*str))
 			{
-				int			clen = pg_mblen(*str);
-
 				if (clen < avail)
 				{
-					COPYCHAR(next, *str);
+					ts_copychar_with_len(next, *str, clen);
 					next += clen;
 					avail -= clen;
 				}
@@ -833,24 +834,22 @@ get_nextfield(char **str, char *next)
 		}
 		else					/* state == PAE_INMASK */
 		{
-			if (t_isspace(*str))
+			if (t_isspace_cstr(*str))
 			{
 				*next = '\0';
 				return true;
 			}
 			else
 			{
-				int			clen = pg_mblen(*str);
-
 				if (clen < avail)
 				{
-					COPYCHAR(next, *str);
+					ts_copychar_with_len(next, *str, clen);
 					next += clen;
 					avail -= clen;
 				}
 			}
 		}
-		*str += pg_mblen(*str);
+		*str += clen;
 	}
 
 	*next = '\0';
@@ -940,14 +939,15 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 
 	while (*str)
 	{
+		int			clen = pg_mblen_cstr(str);
+
 		if (state == PAE_WAIT_MASK)
 		{
 			if (t_iseq(str, '#'))
 				return false;
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 			{
-				COPYCHAR(pmask, str);
-				pmask += pg_mblen(str);
+				pmask += ts_copychar_with_len(pmask, str, clen);
 				state = PAE_INMASK;
 			}
 		}
@@ -958,10 +958,9 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 				*pmask = '\0';
 				state = PAE_WAIT_FIND;
 			}
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 			{
-				COPYCHAR(pmask, str);
-				pmask += pg_mblen(str);
+				pmask += ts_copychar_with_len(pmask, str, clen);
 			}
 		}
 		else if (state == PAE_WAIT_FIND)
@@ -970,13 +969,12 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 			{
 				state = PAE_INFIND;
 			}
-			else if (t_isalpha(str) || t_iseq(str, '\'') /* english 's */ )
+			else if (t_isalpha_cstr(str) || t_iseq(str, '\'') /* english 's */ )
 			{
-				COPYCHAR(prepl, str);
-				prepl += pg_mblen(str);
+				prepl += ts_copychar_with_len(prepl, str, clen);
 				state = PAE_INREPL;
 			}
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 				ereport(ERROR,
 						(errcode(ERRCODE_CONFIG_FILE_ERROR),
 						 errmsg("syntax error")));
@@ -988,12 +986,11 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 				*pfind = '\0';
 				state = PAE_WAIT_REPL;
 			}
-			else if (t_isalpha(str))
+			else if (t_isalpha_cstr(str))
 			{
-				COPYCHAR(pfind, str);
-				pfind += pg_mblen(str);
+				pfind += ts_copychar_with_len(pfind, str, clen);
 			}
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 				ereport(ERROR,
 						(errcode(ERRCODE_CONFIG_FILE_ERROR),
 						 errmsg("syntax error")));
@@ -1004,13 +1001,12 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 			{
 				break;			/* void repl */
 			}
-			else if (t_isalpha(str))
+			else if (t_isalpha_cstr(str))
 			{
-				COPYCHAR(prepl, str);
-				prepl += pg_mblen(str);
+				prepl += ts_copychar_with_len(prepl, str, clen);
 				state = PAE_INREPL;
 			}
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 				ereport(ERROR,
 						(errcode(ERRCODE_CONFIG_FILE_ERROR),
 						 errmsg("syntax error")));
@@ -1022,12 +1018,11 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 				*prepl = '\0';
 				break;
 			}
-			else if (t_isalpha(str))
+			else if (t_isalpha_cstr(str))
 			{
-				COPYCHAR(prepl, str);
-				prepl += pg_mblen(str);
+				prepl += ts_copychar_with_len(prepl, str, clen);
 			}
-			else if (!t_isspace(str))
+			else if (!t_isspace_cstr(str))
 				ereport(ERROR,
 						(errcode(ERRCODE_CONFIG_FILE_ERROR),
 						 errmsg("syntax error")));
@@ -1035,7 +1030,7 @@ parse_affentry(char *str, char *mask, char *find, char *repl)
 		else
 			elog(ERROR, "unrecognized state in parse_affentry: %d", state);
 
-		str += pg_mblen(str);
+		str += clen;
 	}
 
 	*pmask = *pfind = *prepl = '\0';
@@ -1087,10 +1082,9 @@ addCompoundAffixFlagValue(IspellDict *Conf, char *s, uint32 val)
 	CompoundAffixFlag *newValue;
 	char		sbuf[BUFSIZ];
 	char	   *sflag;
-	int			clen;
 
-	while (*s && t_isspace(s))
-		s += pg_mblen(s);
+	while (*s && t_isspace_cstr(s))
+		s += pg_mblen_cstr(s);
 
 	if (!*s)
 		ereport(ERROR,
@@ -1099,10 +1093,10 @@ addCompoundAffixFlagValue(IspellDict *Conf, char *s, uint32 val)
 
 	/* Get flag without \n */
 	sflag = sbuf;
-	while (*s && !t_isspace(s) && *s != '\n')
+	while (*s && !t_isspace_cstr(s) && *s != '\n')
 	{
-		clen = pg_mblen(s);
-		COPYCHAR(sflag, s);
+		int			clen = ts_copychar_cstr(sflag, s);
+
 		sflag += clen;
 		s += clen;
 	}
@@ -1244,7 +1238,7 @@ NIImportOOAffixes(IspellDict *Conf, const char *filename)
 
 	while ((recoded = tsearch_readline(&trst)) != NULL)
 	{
-		if (*recoded == '\0' || t_isspace(recoded) || t_iseq(recoded, '#'))
+		if (*recoded == '\0' || t_isspace_cstr(recoded) || t_iseq(recoded, '#'))
 		{
 			pfree(recoded);
 			continue;
@@ -1281,8 +1275,8 @@ NIImportOOAffixes(IspellDict *Conf, const char *filename)
 		{
 			char	   *s = recoded + strlen("FLAG");
 
-			while (*s && t_isspace(s))
-				s += pg_mblen(s);
+			while (*s && t_isspace_cstr(s))
+				s += pg_mblen_cstr(s);
 
 			if (*s)
 			{
@@ -1317,7 +1311,7 @@ NIImportOOAffixes(IspellDict *Conf, const char *filename)
 	{
 		int			fields_read;
 
-		if (*recoded == '\0' || t_isspace(recoded) || t_iseq(recoded, '#'))
+		if (*recoded == '\0' || t_isspace_cstr(recoded) || t_iseq(recoded, '#'))
 			goto nextline;
 
 		fields_read = parse_ooaffentry(recoded, type, sflag, find, repl, mask);
@@ -1480,12 +1474,12 @@ NIImportAffixes(IspellDict *Conf, const char *filename)
 			s = findchar2(recoded, 'l', 'L');
 			if (s)
 			{
-				while (*s && !t_isspace(s))
-					s += pg_mblen(s);
-				while (*s && t_isspace(s))
-					s += pg_mblen(s);
+				while (*s && !t_isspace_cstr(s))
+					s += pg_mblen_cstr(s);
+				while (*s && t_isspace_cstr(s))
+					s += pg_mblen_cstr(s);
 
-				if (*s && pg_mblen(s) == 1)
+				if (*s && pg_mblen_cstr(s) == 1)
 				{
 					addCompoundAffixFlagValue(Conf, s, FF_COMPOUNDFLAG);
 					Conf->usecompound = true;
@@ -1513,8 +1507,8 @@ NIImportAffixes(IspellDict *Conf, const char *filename)
 			s = recoded + 4;	/* we need non-lowercased string */
 			flagflags = 0;
 
-			while (*s && t_isspace(s))
-				s += pg_mblen(s);
+			while (*s && t_isspace_cstr(s))
+				s += pg_mblen_cstr(s);
 
 			if (*s == '*')
 			{
@@ -1535,14 +1529,13 @@ NIImportAffixes(IspellDict *Conf, const char *filename)
 			 * be followed by EOL, whitespace, or ':'.  Otherwise this is a
 			 * new-format flag command.
 			 */
-			if (*s && pg_mblen(s) == 1)
+			if (*s && pg_mblen_cstr(s) == 1)
 			{
-				COPYCHAR(flag, s);
+				flag[0] = *s++;
 				flag[1] = '\0';
 
-				s++;
 				if (*s == '\0' || *s == '#' || *s == '\n' || *s == ':' ||
-					t_isspace(s))
+					t_isspace_cstr(s))
 				{
 					oldformat = true;
 					goto nextline;
@@ -1764,7 +1757,7 @@ NISortDictionary(IspellDict *Conf)
 							(errcode(ERRCODE_CONFIG_FILE_ERROR),
 							 errmsg("invalid affix alias \"%s\"",
 									Conf->Spell[i]->p.flag)));
-				if (*end != '\0' && !t_isdigit(end) && !t_isspace(end))
+				if (*end != '\0' && !t_isdigit_cstr(end) && !t_isspace_cstr(end))
 					ereport(ERROR,
 							(errcode(ERRCODE_CONFIG_FILE_ERROR),
 							 errmsg("invalid affix alias \"%s\"",

--- a/src/backend/tsearch/ts_locale.c
+++ b/src/backend/tsearch/ts_locale.c
@@ -43,69 +43,43 @@ static void tsearch_readline_callback(void *arg);
  */
 #define WC_BUF_LEN  3
 
-int
-t_isdigit(const char *ptr)
-{
-	int			clen = pg_mblen(ptr);
-	wchar_t		character[WC_BUF_LEN];
-	Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
-	pg_locale_t mylocale = 0;	/* TODO */
-
-	if (clen == 1 || lc_ctype_is_c(collation))
-		return isdigit(TOUCHAR(ptr));
-
-	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
-
-	return iswdigit((wint_t) character[0]);
+#define GENERATE_T_ISCLASS_DEF(character_class) \
+/* mblen shall be that of the first character */ \
+int \
+t_is##character_class##_with_len(const char *ptr, int mblen) \
+{ \
+	int			clen = pg_mblen_with_len(ptr, mblen); \
+	wchar_t		character[WC_BUF_LEN]; \
+	pg_locale_t mylocale = 0;	/* TODO */ \
+	if (clen == 1 || lc_ctype_is_c(DEFAULT_COLLATION_OID)) \
+		return is##character_class(TOUCHAR(ptr)); \
+	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale); \
+	return isw##character_class((wint_t) character[0]); \
+} \
+\
+/* ptr shall point to a NUL-terminated string */ \
+int \
+t_is##character_class##_cstr(const char *ptr) \
+{ \
+	return t_is##character_class##_with_len(ptr, pg_mblen_cstr(ptr)); \
+} \
+/* ptr shall point to a string with pre-validated encoding */ \
+int \
+t_is##character_class##_unbounded(const char *ptr) \
+{ \
+	return t_is##character_class##_with_len(ptr, pg_mblen_unbounded(ptr)); \
+} \
+/* historical name for _unbounded */ \
+int \
+t_is##character_class(const char *ptr) \
+{ \
+	return t_is##character_class##_unbounded(ptr); \
 }
 
-int
-t_isspace(const char *ptr)
-{
-	int			clen = pg_mblen(ptr);
-	wchar_t		character[WC_BUF_LEN];
-	Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
-	pg_locale_t mylocale = 0;	/* TODO */
-
-	if (clen == 1 || lc_ctype_is_c(collation))
-		return isspace(TOUCHAR(ptr));
-
-	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
-
-	return iswspace((wint_t) character[0]);
-}
-
-int
-t_isalpha(const char *ptr)
-{
-	int			clen = pg_mblen(ptr);
-	wchar_t		character[WC_BUF_LEN];
-	Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
-	pg_locale_t mylocale = 0;	/* TODO */
-
-	if (clen == 1 || lc_ctype_is_c(collation))
-		return isalpha(TOUCHAR(ptr));
-
-	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
-
-	return iswalpha((wint_t) character[0]);
-}
-
-int
-t_isprint(const char *ptr)
-{
-	int			clen = pg_mblen(ptr);
-	wchar_t		character[WC_BUF_LEN];
-	Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
-	pg_locale_t mylocale = 0;	/* TODO */
-
-	if (clen == 1 || lc_ctype_is_c(collation))
-		return isprint(TOUCHAR(ptr));
-
-	char2wchar(character, WC_BUF_LEN, ptr, clen, mylocale);
-
-	return iswprint((wint_t) character[0]);
-}
+GENERATE_T_ISCLASS_DEF(alpha)
+GENERATE_T_ISCLASS_DEF(digit)
+GENERATE_T_ISCLASS_DEF(print)
+GENERATE_T_ISCLASS_DEF(space)
 
 
 /*

--- a/src/backend/tsearch/ts_utils.c
+++ b/src/backend/tsearch/ts_utils.c
@@ -88,8 +88,8 @@ readstoplist(const char *fname, StopList *s, char *(*wordop) (const char *))
 			char	   *pbuf = line;
 
 			/* Trim trailing space */
-			while (*pbuf && !t_isspace(pbuf))
-				pbuf += pg_mblen(pbuf);
+			while (*pbuf && !t_isspace_cstr(pbuf))
+				pbuf += pg_mblen_cstr(pbuf);
 			*pbuf = '\0';
 
 			/* Skip empty lines */

--- a/src/backend/tsearch/wparser_def.c
+++ b/src/backend/tsearch/wparser_def.c
@@ -1720,7 +1720,8 @@ TParserGet(TParser *prs)
 			prs->state->charlen = 0;
 		else
 			prs->state->charlen = (prs->charmaxlen == 1) ? prs->charmaxlen :
-				pg_mblen(prs->str + prs->state->posbyte);
+				pg_mblen_range(prs->str + prs->state->posbyte,
+							   prs->str + prs->lenstr);
 
 		Assert(prs->state->posbyte + prs->state->charlen <= prs->lenstr);
 		Assert(prs->state->state >= TPS_Base && prs->state->state < TPS_Null);

--- a/src/backend/utils/adt/encode.c
+++ b/src/backend/utils/adt/encode.c
@@ -138,7 +138,7 @@ hex_encode(const char *src, unsigned len, char *dst)
 }
 
 static inline char
-get_hex(const char *cp)
+get_hex(const char *cp, const char *end)
 {
 	unsigned char c = (unsigned char) *cp;
 	int			res = -1;
@@ -150,7 +150,7 @@ get_hex(const char *cp)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid hexadecimal digit: \"%.*s\"",
-						pg_mblen(cp), cp)));
+						pg_mblen_range(cp, end), cp)));
 
 	return (char) res;
 }
@@ -174,14 +174,14 @@ hex_decode(const char *src, unsigned len, char *dst)
 			s++;
 			continue;
 		}
-		v1 = get_hex(s) << 4;
+		v1 = get_hex(s, srcend) << 4;
 		s++;
 		if (s >= srcend)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("invalid hexadecimal data: odd number of digits")));
 
-		v2 = get_hex(s);
+		v2 = get_hex(s, srcend);
 		s++;
 		*p++ = v1 | v2;
 	}
@@ -310,7 +310,7 @@ pg_base64_decode(const char *src, unsigned len, char *dst)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("invalid symbol \"%.*s\" found while decoding base64 sequence",
-								pg_mblen(s - 1), s - 1)));
+								pg_mblen_range(s - 1, srcend), s - 1)));
 		}
 		/* add it to buffer */
 		buf = (buf << 6) + b;

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -1318,7 +1318,7 @@ parse_format(FormatNode *node, const char *str, const KeyWord *kw,
 					/* backslash quotes the next character, if any */
 					if (*str == '\\' && *(str + 1))
 						str++;
-					chlen = pg_mblen(str);
+					chlen = pg_mblen_cstr(str);
 					n->type = NODE_TYPE_CHAR;
 					memcpy(n->character, str, chlen);
 					n->character[chlen] = '\0';
@@ -1336,7 +1336,7 @@ parse_format(FormatNode *node, const char *str, const KeyWord *kw,
 				 */
 				if (*str == '\\' && *(str + 1) == '"')
 					str++;
-				chlen = pg_mblen(str);
+				chlen = pg_mblen_cstr(str);
 
 				if (ver == DCH_TYPE && is_separator_char(str))
 					n->type = NODE_TYPE_SEPARATOR;
@@ -2048,8 +2048,8 @@ asc_toupper_z(const char *buff)
 	do { \
 		if (S_THth(_suf)) \
 		{ \
-			if (*(ptr)) (ptr) += pg_mblen(ptr); \
-			if (*(ptr)) (ptr) += pg_mblen(ptr); \
+			if (*(ptr)) (ptr) += pg_mblen_cstr(ptr); \
+			if (*(ptr)) (ptr) += pg_mblen_cstr(ptr); \
 		} \
 	} while (0)
 
@@ -3109,7 +3109,7 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out)
 				 * insist that the consumed character match the format's
 				 * character.
 				 */
-				s += pg_mblen(s);
+				s += pg_mblen_cstr(s);
 			}
 			continue;
 		}
@@ -3131,11 +3131,11 @@ DCH_from_char(FormatNode *node, const char *in, TmFromChar *out)
 				if (extra_skip > 0)
 					extra_skip--;
 				else
-					s += pg_mblen(s);
+					s += pg_mblen_cstr(s);
 			}
 			else
 			{
-				s += pg_mblen(s);
+				s += pg_mblen_cstr(s);
 			}
 			continue;
 		}
@@ -4876,13 +4876,15 @@ NUM_numpart_to_char(NUMProc *Np, int id)
 static void
 NUM_eat_non_data_chars(NUMProc *Np, int n, int input_len)
 {
+	const char *end = Np->inout + input_len;
+
 	while (n-- > 0)
 	{
 		if (OVERLOAD_TEST)
 			break;				/* end of input */
 		if (strchr("0123456789.,+-", *Np->inout_p) != NULL)
 			break;				/* it's a data character */
-		Np->inout_p += pg_mblen(Np->inout_p);
+		Np->inout_p += pg_mblen_range(Np->inout_p, end);
 	}
 }
 
@@ -5332,7 +5334,7 @@ NUM_processor(FormatNode *node, NUMDesc *Num, char *inout,
 			}
 			else
 			{
-				Np->inout_p += pg_mblen(Np->inout_p);
+				Np->inout_p += pg_mblen_range(Np->inout_p, Np->inout + input_len);
 			}
 			continue;
 		}

--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -87,7 +87,9 @@ static void parse_array(JsonLexContext *lex, JsonSemAction *sem);
 static void report_parse_error(JsonParseContext ctx, JsonLexContext *lex) pg_attribute_noreturn();
 static void report_invalid_token(JsonLexContext *lex) pg_attribute_noreturn();
 static int	report_json_context(JsonLexContext *lex);
-static char *extract_mb_char(char *s);
+static char *extract_mb_char(char *s, const char *end);
+static void set_token_terminator_at_char_end(JsonLexContext *lex, char *s,
+											 char *end);
 static void composite_to_json(Datum composite, StringInfo result,
 							  bool use_line_feeds);
 static void array_dim_to_json(StringInfo result, int dim, int ndims, int *dims,
@@ -755,6 +757,7 @@ static inline void
 json_lex_string(JsonLexContext *lex)
 {
 	char	   *s;
+	char	   *const end = lex->input + lex->input_length;
 	int			len;
 	int			hi_surrogate = -1;
 
@@ -820,7 +823,7 @@ json_lex_string(JsonLexContext *lex)
 						ch = (ch * 16) + (*s - 'A') + 10;
 					else
 					{
-						lex->token_terminator = s + pg_mblen(s);
+						set_token_terminator_at_char_end(lex, s, end);
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 								 errmsg("invalid input syntax for type %s",
@@ -941,13 +944,13 @@ json_lex_string(JsonLexContext *lex)
 						break;
 					default:
 						/* Not a valid string escape, so error out. */
-						lex->token_terminator = s + pg_mblen(s);
+						set_token_terminator_at_char_end(lex, s, end);
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 								 errmsg("invalid input syntax for type %s",
 										"json"),
 								 errdetail("Escape sequence \"\\%s\" is invalid.",
-										   extract_mb_char(s)),
+										   extract_mb_char(s, end)),
 								 report_json_context(lex)));
 				}
 			}
@@ -960,12 +963,12 @@ json_lex_string(JsonLexContext *lex)
 				 * replace it with a switch statement, but testing so far has
 				 * shown it's not a performance win.
 				 */
-				lex->token_terminator = s + pg_mblen(s);
+				set_token_terminator_at_char_end(lex, s, end);
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 						 errmsg("invalid input syntax for type %s", "json"),
 						 errdetail("Escape sequence \"\\%s\" is invalid.",
-								   extract_mb_char(s)),
+								   extract_mb_char(s, end)),
 						 report_json_context(lex)));
 			}
 
@@ -1323,15 +1326,38 @@ report_json_context(JsonLexContext *lex)
 }
 
 /*
- * Extract a single, possibly multi-byte char from the input string.
+ * Set lex->token_terminator to the end of the character beginning at s, but
+ * never past the end of the input.  The input is not necessarily
+ * null-terminated, so a truncated multibyte sequence at the end of it would
+ * otherwise leave token_terminator pointing past the allocation, and
+ * report_json_context() copies everything up to it.
+ *
+ * pg_mblen_unbounded() is deliberate here: we want the encoding's idea of the
+ * length even when it overruns, so that we can clamp it ourselves rather than
+ * raise "invalid byte sequence" in place of the JSON syntax error we are
+ * actually here to report.
+ */
+static void
+set_token_terminator_at_char_end(JsonLexContext *lex, char *s, char *end)
+{
+	char	   *term = s + pg_mblen_unbounded(s);
+
+	lex->token_terminator = (term <= end) ? term : end;
+}
+
+/*
+ * Extract a single, possibly multi-byte char from the input string, without
+ * reading past "end".
  */
 static char *
-extract_mb_char(char *s)
+extract_mb_char(char *s, const char *end)
 {
 	char	   *res;
 	int			len;
 
-	len = pg_mblen(s);
+	len = pg_mblen_unbounded(s);
+	if (s + len > end)
+		len = end - s;
 	res = palloc(len + 1);
 	memcpy(res, s, len);
 	res[len] = '\0';

--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1290,7 +1290,7 @@ report_json_context(JsonLexContext *lex)
 			break;
 		/* Advance to next multibyte character */
 		if (IS_HIGHBIT_SET(*context_start))
-			context_start += pg_mblen(context_start);
+			context_start += pg_mblen_range(context_start, context_end);
 		else
 			context_start++;
 	}

--- a/src/backend/utils/adt/jsonpath_gram.y
+++ b/src/backend/utils/adt/jsonpath_gram.y
@@ -512,7 +512,7 @@ makeItemLikeRegex(JsonPathParseItem *expr, JsonPathString *pattern,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid input syntax for type %s", "jsonpath"),
 						 errdetail("unrecognized flag character \"%.*s\" in LIKE_REGEX predicate",
-								   pg_mblen(flags->val + i), flags->val + i)));
+								   pg_mblen_range(flags->val + i, flags->val + flags->len), flags->val + i)));
 				break;
 		}
 	}

--- a/src/backend/utils/adt/levenshtein.c
+++ b/src/backend/utils/adt/levenshtein.c
@@ -84,6 +84,8 @@ varstr_levenshtein(const char *source, int slen,
 	int			i,
 				j;
 	const char *y;
+	const char *send = source + slen;
+	const char *tend = target + tlen;
 
 	/*
 	 * For varstr_levenshtein_less_equal, we have real variables called
@@ -184,10 +186,10 @@ varstr_levenshtein(const char *source, int slen,
 #endif
 
 	/*
-	 * In order to avoid calling pg_mblen() repeatedly on each character in s,
-	 * we cache all the lengths before starting the main loop -- but if all
-	 * the characters in both strings are single byte, then we skip this and
-	 * use a fast-path in the main loop.  If only one string contains
+	 * In order to avoid calling pg_mblen_range() repeatedly on each character
+	 * in s, we cache all the lengths before starting the main loop -- but if
+	 * all the characters in both strings are single byte, then we skip this
+	 * and use a fast-path in the main loop.  If only one string contains
 	 * multi-byte characters, we still build the array, so that the fast-path
 	 * needn't deal with the case where the array hasn't been initialized.
 	 */
@@ -199,7 +201,7 @@ varstr_levenshtein(const char *source, int slen,
 		s_char_len = (int *) palloc((m + 1) * sizeof(int));
 		for (i = 0; i < m; ++i)
 		{
-			s_char_len[i] = pg_mblen(cp);
+			s_char_len[i] = pg_mblen_range(cp, send);
 			cp += s_char_len[i];
 		}
 		s_char_len[i] = 0;
@@ -225,7 +227,7 @@ varstr_levenshtein(const char *source, int slen,
 	{
 		int		   *temp;
 		const char *x = source;
-		int			y_char_len = n != tlen + 1 ? pg_mblen(y) : 1;
+		int			y_char_len = n != tlen + 1 ? pg_mblen_range(y, tend) : 1;
 
 #ifdef LEVENSHTEIN_LESS_EQUAL
 

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -293,6 +293,7 @@ do_like_escape(text *pat, text *esc)
 					 errhint("Escape string must be empty or one character.")));
 
 		e = VARDATA_ANY(esc);
+		elen = VARSIZE_ANY_EXHDR(esc);
 
 		/*
 		 * If specified escape is '\', just copy the pattern as-is.
@@ -311,7 +312,7 @@ do_like_escape(text *pat, text *esc)
 		afterescape = false;
 		while (plen > 0)
 		{
-			if (CHAREQ(p, e) && !afterescape)
+			if (CHAREQ(p, plen, e, elen) && !afterescape)
 			{
 				*r++ = '\\';
 				NextChar(p, plen);

--- a/src/backend/utils/adt/oracle_compat.c
+++ b/src/backend/utils/adt/oracle_compat.c
@@ -723,7 +723,8 @@ translate(PG_FUNCTION_ARGS)
 	text	   *to = PG_GETARG_TEXT_PP(2);
 	text	   *result;
 	char	   *from_ptr,
-			   *to_ptr;
+			   *to_ptr,
+			   *to_end;
 	char	   *source,
 			   *target;
 	int			m,
@@ -745,6 +746,7 @@ translate(PG_FUNCTION_ARGS)
 	from_ptr = VARDATA_ANY(from);
 	tolen = VARSIZE_ANY_EXHDR(to);
 	to_ptr = VARDATA_ANY(to);
+	to_end = to_ptr + tolen;
 
 	/*
 	 * The worst-case expansion is to substitute a max-length character for a
@@ -778,16 +780,16 @@ translate(PG_FUNCTION_ARGS)
 		}
 		if (i < fromlen)
 		{
-			/* substitute */
+			/* substitute, or delete if no corresponding "to" character */
 			char	   *p = to_ptr;
 
 			for (i = 0; i < from_index; i++)
 			{
-				p += pg_mblen(p);
-				if (p >= (to_ptr + tolen))
+				if (p >= to_end)
 					break;
+				p += pg_mblen(p);
 			}
-			if (p < (to_ptr + tolen))
+			if (p < to_end)
 			{
 				len = pg_mblen(p);
 				memcpy(target, p, len);

--- a/src/backend/utils/adt/oracle_compat.c
+++ b/src/backend/utils/adt/oracle_compat.c
@@ -148,8 +148,8 @@ lpad(PG_FUNCTION_ARGS)
 	char	   *ptr1,
 			   *ptr2,
 			   *ptr2start,
-			   *ptr2end,
 			   *ptr_ret;
+	const char *ptr2end;
 	int			m,
 				s1len,
 				s2len;
@@ -194,7 +194,7 @@ lpad(PG_FUNCTION_ARGS)
 
 	while (m--)
 	{
-		int			mlen = pg_mblen(ptr2);
+		int			mlen = pg_mblen_range(ptr2, ptr2end);
 
 		memcpy(ptr_ret, ptr2, mlen);
 		ptr_ret += mlen;
@@ -207,7 +207,7 @@ lpad(PG_FUNCTION_ARGS)
 
 	while (s1len--)
 	{
-		int			mlen = pg_mblen(ptr1);
+		int			mlen = pg_mblen_unbounded(ptr1);
 
 		memcpy(ptr_ret, ptr1, mlen);
 		ptr_ret += mlen;
@@ -246,8 +246,8 @@ rpad(PG_FUNCTION_ARGS)
 	char	   *ptr1,
 			   *ptr2,
 			   *ptr2start,
-			   *ptr2end,
 			   *ptr_ret;
+	const char *ptr2end;
 	int			m,
 				s1len,
 				s2len;
@@ -286,11 +286,12 @@ rpad(PG_FUNCTION_ARGS)
 	m = len - s1len;
 
 	ptr1 = VARDATA_ANY(string1);
+
 	ptr_ret = VARDATA(ret);
 
 	while (s1len--)
 	{
-		int			mlen = pg_mblen(ptr1);
+		int			mlen = pg_mblen_unbounded(ptr1);
 
 		memcpy(ptr_ret, ptr1, mlen);
 		ptr_ret += mlen;
@@ -302,7 +303,7 @@ rpad(PG_FUNCTION_ARGS)
 
 	while (m--)
 	{
-		int			mlen = pg_mblen(ptr2);
+		int			mlen = pg_mblen_range(ptr2, ptr2end);
 
 		memcpy(ptr_ret, ptr2, mlen);
 		ptr_ret += mlen;
@@ -387,6 +388,7 @@ dotrim(const char *string, int stringlen,
 			 */
 			const char **stringchars;
 			const char **setchars;
+			const char *setend;
 			int		   *stringmblen;
 			int		   *setmblen;
 			int			stringnchars;
@@ -394,6 +396,7 @@ dotrim(const char *string, int stringlen,
 			int			resultndx;
 			int			resultnchars;
 			const char *p;
+			const char *pend;
 			int			len;
 			int			mblen;
 			const char *str_pos;
@@ -404,10 +407,11 @@ dotrim(const char *string, int stringlen,
 			stringnchars = 0;
 			p = string;
 			len = stringlen;
+			pend = p + len;
 			while (len > 0)
 			{
 				stringchars[stringnchars] = p;
-				stringmblen[stringnchars] = mblen = pg_mblen(p);
+				stringmblen[stringnchars] = mblen = pg_mblen_range(p, pend);
 				stringnchars++;
 				p += mblen;
 				len -= mblen;
@@ -418,10 +422,11 @@ dotrim(const char *string, int stringlen,
 			setnchars = 0;
 			p = set;
 			len = setlen;
+			setend = set + setlen;
 			while (len > 0)
 			{
 				setchars[setnchars] = p;
-				setmblen[setnchars] = mblen = pg_mblen(p);
+				setmblen[setnchars] = mblen = pg_mblen_range(p, setend);
 				setnchars++;
 				p += mblen;
 				len -= mblen;
@@ -727,6 +732,8 @@ translate(PG_FUNCTION_ARGS)
 			   *to_end;
 	char	   *source,
 			   *target;
+	const char *source_end;
+	const char *from_end;
 	int			m,
 				fromlen,
 				tolen,
@@ -741,9 +748,11 @@ translate(PG_FUNCTION_ARGS)
 	if (m <= 0)
 		PG_RETURN_TEXT_P(string);
 	source = VARDATA_ANY(string);
+	source_end = source + m;
 
 	fromlen = VARSIZE_ANY_EXHDR(from);
 	from_ptr = VARDATA_ANY(from);
+	from_end = from_ptr + fromlen;
 	tolen = VARSIZE_ANY_EXHDR(to);
 	to_ptr = VARDATA_ANY(to);
 	to_end = to_ptr + tolen;
@@ -766,12 +775,12 @@ translate(PG_FUNCTION_ARGS)
 
 	while (m > 0)
 	{
-		source_len = pg_mblen(source);
+		source_len = pg_mblen_range(source, source_end);
 		from_index = 0;
 
 		for (i = 0; i < fromlen; i += len)
 		{
-			len = pg_mblen(&from_ptr[i]);
+			len = pg_mblen_range(&from_ptr[i], from_end);
 			if (len == source_len &&
 				memcmp(source, &from_ptr[i], len) == 0)
 				break;
@@ -787,11 +796,11 @@ translate(PG_FUNCTION_ARGS)
 			{
 				if (p >= to_end)
 					break;
-				p += pg_mblen(p);
+				p += pg_mblen_range(p, to_end);
 			}
 			if (p < to_end)
 			{
-				len = pg_mblen(p);
+				len = pg_mblen_range(p, to_end);
 				memcpy(target, p, len);
 				target += len;
 				retlen += len;

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -424,7 +424,7 @@ parse_re_flags(pg_re_flags *flags, text *opts)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 							 errmsg("invalid regular expression option: \"%.*s\"",
-									pg_mblen(opt_p + i), opt_p + i)));
+									pg_mblen_range(opt_p + i, opt_p + opt_len), opt_p + i)));
 					break;
 			}
 		}
@@ -669,6 +669,7 @@ similar_escape(PG_FUNCTION_ARGS)
 			   *r;
 	int			plen,
 				elen;
+	const char *pend;
 	bool		afterescape = false;
 	bool		incharclass = false;
 	int			nquotes = 0;
@@ -679,6 +680,7 @@ similar_escape(PG_FUNCTION_ARGS)
 	pat_text = PG_GETARG_TEXT_PP(0);
 	p = VARDATA_ANY(pat_text);
 	plen = VARSIZE_ANY_EXHDR(pat_text);
+	pend = p + plen;
 	if (PG_ARGISNULL(1))
 	{
 		/* No ESCAPE clause provided; default to backslash as escape */
@@ -768,7 +770,7 @@ similar_escape(PG_FUNCTION_ARGS)
 
 		if (elen > 1)
 		{
-			int			mblen = pg_mblen(p);
+			int			mblen = pg_mblen_range(p, pend);
 
 			if (mblen > 1)
 			{

--- a/src/backend/utils/adt/tsquery.c
+++ b/src/backend/utils/adt/tsquery.c
@@ -110,7 +110,7 @@ get_modifiers(char *buf, int16 *weight, bool *prefix)
 		return buf;
 
 	buf++;
-	while (*buf && pg_mblen(buf) == 1)
+	while (*buf && pg_mblen_cstr(buf) == 1)
 	{
 		switch (*buf)
 		{
@@ -187,7 +187,7 @@ parse_phrase_operator(TSQueryParserState pstate, int16 *distance)
 					continue;
 				}
 
-				if (!t_isdigit(ptr))
+				if (!t_isdigit_cstr(ptr))
 					return false;
 
 				errno = 0;
@@ -252,12 +252,12 @@ parse_or_operator(TSQueryParserState pstate)
 		return false;
 
 	/* it shouldn't be a part of any word */
-	if (t_iseq(ptr, '-') || t_iseq(ptr, '_') || t_isalpha(ptr) || t_isdigit(ptr))
+	if (t_iseq(ptr, '-') || t_iseq(ptr, '_') || t_isalpha_cstr(ptr) || t_isdigit_cstr(ptr))
 		return false;
 
 	for (;;)
 	{
-		ptr += pg_mblen(ptr);
+		ptr += pg_mblen_cstr(ptr);
 
 		if (*ptr == '\0')		/* got end of string without operand */
 			return false;
@@ -267,7 +267,7 @@ parse_or_operator(TSQueryParserState pstate)
 		 * So we still treat OR literal as operation with possibly incorrect
 		 * operand and  will not search it as lexeme
 		 */
-		if (!t_isspace(ptr))
+		if (!t_isspace_cstr(ptr))
 			break;
 	}
 
@@ -310,7 +310,7 @@ gettoken_query_standard(TSQueryParserState state, int8 *operator,
 							 errmsg("syntax error in tsquery: \"%s\"",
 									state->buffer)));
 				}
-				else if (!t_isspace(state->buf))
+				else if (!t_isspace_cstr(state->buf))
 				{
 					/*
 					 * We rely on the tsvector parser to parse the value for
@@ -368,14 +368,14 @@ gettoken_query_standard(TSQueryParserState state, int8 *operator,
 				{
 					return (state->count) ? PT_ERR : PT_END;
 				}
-				else if (!t_isspace(state->buf))
+				else if (!t_isspace_cstr(state->buf))
 				{
 					return PT_ERR;
 				}
 				break;
 		}
 
-		state->buf += pg_mblen(state->buf);
+		state->buf += pg_mblen_cstr(state->buf);
 	}
 }
 
@@ -438,7 +438,7 @@ gettoken_query_websearch(TSQueryParserState state, int8 *operator,
 					state->state = WAITOPERAND;
 					continue;
 				}
-				else if (!t_isspace(state->buf))
+				else if (!t_isspace_cstr(state->buf))
 				{
 					/*
 					 * We rely on the tsvector parser to parse the value for
@@ -496,7 +496,7 @@ gettoken_query_websearch(TSQueryParserState state, int8 *operator,
 				{
 					return PT_END;
 				}
-				else if (!t_isspace(state->buf))
+				else if (!t_isspace_cstr(state->buf))
 				{
 					if (state->in_quotes)
 					{
@@ -516,7 +516,7 @@ gettoken_query_websearch(TSQueryParserState state, int8 *operator,
 				break;
 		}
 
-		state->buf += pg_mblen(state->buf);
+		state->buf += pg_mblen_cstr(state->buf);
 	}
 }
 
@@ -1000,9 +1000,8 @@ infix(INFIX *in, int parentPriority, bool rightPhraseOp)
 				*(in->cur) = '\\';
 				in->cur++;
 			}
-			COPYCHAR(in->cur, op);
 
-			clen = pg_mblen(op);
+			clen = ts_copychar_cstr(in->cur, op);
 			op += clen;
 			in->cur += clen;
 		}

--- a/src/backend/utils/adt/tsvector.c
+++ b/src/backend/utils/adt/tsvector.c
@@ -315,9 +315,9 @@ tsvectorout(PG_FUNCTION_ARGS)
 				lenbuf = 0,
 				pp;
 	WordEntry  *ptr = ARRPTR(out);
-	char	   *curbegin,
-			   *curin,
+	char	   *curin,
 			   *curout;
+	const char *curend;
 
 	lenbuf = out->size * 2 /* '' */ + out->size - 1 /* space */ + 2 /* \0 */ ;
 	for (i = 0; i < out->size; i++)
@@ -330,13 +330,14 @@ tsvectorout(PG_FUNCTION_ARGS)
 	curout = outbuf = (char *) palloc(lenbuf);
 	for (i = 0; i < out->size; i++)
 	{
-		curbegin = curin = STRPTR(out) + ptr->pos;
+		curin = STRPTR(out) + ptr->pos;
+		curend = curin + ptr->len;
 		if (i != 0)
 			*curout++ = ' ';
 		*curout++ = '\'';
-		while (curin - curbegin < ptr->len)
+		while (curin < curend)
 		{
-			int			len = pg_mblen(curin);
+			int			len = pg_mblen_range(curin, curend);
 
 			if (t_iseq(curin, '\''))
 				*curout++ = '\'';

--- a/src/backend/utils/adt/tsvector_op.c
+++ b/src/backend/utils/adt/tsvector_op.c
@@ -2417,11 +2417,15 @@ ts_stat_sql(MemoryContext persistentContext, text *txt, text *ws)
 	if (ws)
 	{
 		char	   *buf;
+		const char *end;
 
 		buf = VARDATA_ANY(ws);
-		while (buf - VARDATA_ANY(ws) < VARSIZE_ANY_EXHDR(ws))
+		end = buf + VARSIZE_ANY_EXHDR(ws);
+		while (buf < end)
 		{
-			if (pg_mblen(buf) == 1)
+			int			len = pg_mblen_range(buf, end);
+
+			if (len == 1)
 			{
 				switch (*buf)
 				{
@@ -2445,7 +2449,7 @@ ts_stat_sql(MemoryContext persistentContext, text *txt, text *ws)
 						stat->weight |= 0;
 				}
 			}
-			buf += pg_mblen(buf);
+			buf += len;
 		}
 	}
 

--- a/src/backend/utils/adt/tsvector_parser.c
+++ b/src/backend/utils/adt/tsvector_parser.c
@@ -185,10 +185,9 @@ gettoken_tsvector(TSVectorParseState state,
 			else if ((state->oprisdelim && ISOPERATOR(state->prsbuf)) ||
 					 (state->is_web && t_iseq(state->prsbuf, '"')))
 				PRSSYNTAXERROR;
-			else if (!t_isspace(state->prsbuf))
+			else if (!t_isspace_cstr(state->prsbuf))
 			{
-				COPYCHAR(curpos, state->prsbuf);
-				curpos += pg_mblen(state->prsbuf);
+				curpos += ts_copychar_cstr(curpos, state->prsbuf);
 				statecode = WAITENDWORD;
 			}
 		}
@@ -202,8 +201,7 @@ gettoken_tsvector(TSVectorParseState state,
 			else
 			{
 				RESIZEPRSBUF;
-				COPYCHAR(curpos, state->prsbuf);
-				curpos += pg_mblen(state->prsbuf);
+				curpos += ts_copychar_cstr(curpos, state->prsbuf);
 				Assert(oldstate != 0);
 				statecode = oldstate;
 			}
@@ -215,7 +213,7 @@ gettoken_tsvector(TSVectorParseState state,
 				statecode = WAITNEXTCHAR;
 				oldstate = WAITENDWORD;
 			}
-			else if (t_isspace(state->prsbuf) || *(state->prsbuf) == '\0' ||
+			else if (t_isspace_cstr(state->prsbuf) || *(state->prsbuf) == '\0' ||
 					 (state->oprisdelim && ISOPERATOR(state->prsbuf)) ||
 					 (state->is_web && t_iseq(state->prsbuf, '"')))
 			{
@@ -238,8 +236,7 @@ gettoken_tsvector(TSVectorParseState state,
 			else
 			{
 				RESIZEPRSBUF;
-				COPYCHAR(curpos, state->prsbuf);
-				curpos += pg_mblen(state->prsbuf);
+				curpos += ts_copychar_cstr(curpos, state->prsbuf);
 			}
 		}
 		else if (statecode == WAITENDCMPLX)
@@ -258,8 +255,7 @@ gettoken_tsvector(TSVectorParseState state,
 			else
 			{
 				RESIZEPRSBUF;
-				COPYCHAR(curpos, state->prsbuf);
-				curpos += pg_mblen(state->prsbuf);
+				curpos += ts_copychar_cstr(curpos, state->prsbuf);
 			}
 		}
 		else if (statecode == WAITCHARCMPLX)
@@ -267,8 +263,7 @@ gettoken_tsvector(TSVectorParseState state,
 			if (!state->is_web && t_iseq(state->prsbuf, '\''))
 			{
 				RESIZEPRSBUF;
-				COPYCHAR(curpos, state->prsbuf);
-				curpos += pg_mblen(state->prsbuf);
+				curpos += ts_copychar_cstr(curpos, state->prsbuf);
 				statecode = WAITENDCMPLX;
 			}
 			else
@@ -279,7 +274,7 @@ gettoken_tsvector(TSVectorParseState state,
 					PRSSYNTAXERROR;
 				if (state->oprisdelim)
 				{
-					/* state->prsbuf+=pg_mblen(state->prsbuf); */
+					/* state->prsbuf+=pg_mblen_cstr(state->prsbuf); */
 					RETURN_TOKEN;
 				}
 				else
@@ -296,7 +291,7 @@ gettoken_tsvector(TSVectorParseState state,
 		}
 		else if (statecode == INPOSINFO)
 		{
-			if (t_isdigit(state->prsbuf))
+			if (t_isdigit_cstr(state->prsbuf))
 			{
 				if (posalen == 0)
 				{
@@ -351,10 +346,10 @@ gettoken_tsvector(TSVectorParseState state,
 					PRSSYNTAXERROR;
 				WEP_SETWEIGHT(pos[npos - 1], 0);
 			}
-			else if (t_isspace(state->prsbuf) ||
+			else if (t_isspace_cstr(state->prsbuf) ||
 					 *(state->prsbuf) == '\0')
 				RETURN_TOKEN;
-			else if (!t_isdigit(state->prsbuf))
+			else if (!t_isdigit_cstr(state->prsbuf))
 				PRSSYNTAXERROR;
 		}
 		else					/* internal error */
@@ -362,6 +357,6 @@ gettoken_tsvector(TSVectorParseState state,
 				 statecode);
 
 		/* get next char */
-		state->prsbuf += pg_mblen(state->prsbuf);
+		state->prsbuf += pg_mblen_cstr(state->prsbuf);
 	}
 }

--- a/src/backend/utils/adt/varbit.c
+++ b/src/backend/utils/adt/varbit.c
@@ -232,7 +232,7 @@ bit_in(PG_FUNCTION_ARGS)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 						 errmsg("\"%.*s\" is not a valid binary digit",
-								pg_mblen(sp), sp)));
+								pg_mblen_cstr(sp), sp)));
 
 			x >>= 1;
 			if (x == 0)
@@ -257,7 +257,7 @@ bit_in(PG_FUNCTION_ARGS)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 						 errmsg("\"%.*s\" is not a valid hexadecimal digit",
-								pg_mblen(sp), sp)));
+								pg_mblen_cstr(sp), sp)));
 
 			if (bc)
 			{
@@ -533,7 +533,7 @@ varbit_in(PG_FUNCTION_ARGS)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 						 errmsg("\"%.*s\" is not a valid binary digit",
-								pg_mblen(sp), sp)));
+								pg_mblen_cstr(sp), sp)));
 
 			x >>= 1;
 			if (x == 0)
@@ -558,7 +558,7 @@ varbit_in(PG_FUNCTION_ARGS)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 						 errmsg("\"%.*s\" is not a valid hexadecimal digit",
-								pg_mblen(sp), sp)));
+								pg_mblen_cstr(sp), sp)));
 
 			if (bc)
 			{

--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -750,8 +750,11 @@ text_catenate(text *t1, text *t2)
  * charlen_to_bytelen()
  *	Compute the number of bytes occupied by n characters starting at *p
  *
- * It is caller's responsibility that there actually are n characters;
- * the string need not be null-terminated.
+ * The caller shall ensure there are n complete characters.  Callers achieve
+ * this by deriving "n" from regmatch_t findings from searching a wchar array.
+ * pg_mb2wchar_with_len() skips any trailing incomplete character, so regex
+ * matches will end no later than the last complete character.  (The string
+ * need not be null-terminated.)
  */
 static int
 charlen_to_bytelen(const char *p, int n)
@@ -766,7 +769,7 @@ charlen_to_bytelen(const char *p, int n)
 		const char *s;
 
 		for (s = p; n > 0; n--)
-			s += pg_mblen(s);
+			s += pg_mblen_unbounded(s); /* caller verified encoding */
 
 		return s - p;
 	}
@@ -899,6 +902,7 @@ text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
 		int32		slice_start;
 		int32		slice_size;
 		int32		slice_strlen;
+		int32		slice_len;
 		text	   *slice;
 		int32		E1;
 		int32		i;
@@ -968,7 +972,8 @@ text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
 			slice = (text *) DatumGetPointer(str);
 
 		/* see if we got back an empty string */
-		if (VARSIZE_ANY_EXHDR(slice) == 0)
+		slice_len = VARSIZE_ANY_EXHDR(slice);
+		if (slice_len == 0)
 		{
 			if (slice != (text *) DatumGetPointer(str))
 				pfree(slice);
@@ -977,7 +982,7 @@ text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
 
 		/* Now we can get the actual length of the slice in MB characters */
 		slice_strlen = pg_mbstrlen_with_len(VARDATA_ANY(slice),
-											VARSIZE_ANY_EXHDR(slice));
+											slice_len);
 
 		/*
 		 * Check that the start position wasn't > slice_strlen. If so, SQL99
@@ -1004,7 +1009,7 @@ text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
 		 */
 		p = VARDATA_ANY(slice);
 		for (i = 0; i < S1 - 1; i++)
-			p += pg_mblen(p);
+			p += pg_mblen_unbounded(p);
 
 		/* hang onto a pointer to our start position */
 		s = p;
@@ -1014,7 +1019,7 @@ text_substring(Datum str, int32 start, int32 length, bool length_not_specified)
 		 * length.
 		 */
 		for (i = S1; i < E1; i++)
-			p += pg_mblen(p);
+			p += pg_mblen_unbounded(p);
 
 		ret = (text *) palloc(VARHDRSZ + (p - s));
 		SET_VARSIZE(ret, VARHDRSZ + (p - s));
@@ -1321,6 +1326,8 @@ retry:
 	 */
 	if (state->is_multibyte_char_in_char)
 	{
+		const char *haystack_end = state->str1 + state->len1;
+
 		/* Walk one character at a time, until we reach the match. */
 
 		/* the search should never move backwards. */
@@ -1329,7 +1336,7 @@ retry:
 		while (state->refpoint < matchptr)
 		{
 			/* step to next character. */
-			state->refpoint += pg_mblen(state->refpoint);
+			state->refpoint += pg_mblen_range(state->refpoint, haystack_end);
 			state->refpos++;
 
 			/*
@@ -1445,7 +1452,8 @@ text_position_get_match_pos(TextPositionState *state)
 		/* Convert the byte position to char position. */
 		while (state->refpoint < state->last_match)
 		{
-			state->refpoint += pg_mblen(state->refpoint);
+			state->refpoint += pg_mblen_range(state->refpoint,
+											  state->last_match);
 			state->refpos++;
 		}
 		Assert(state->refpoint == state->last_match);
@@ -4298,7 +4306,7 @@ check_replace_text_has_escape_char(const text *replace_text)
 	}
 	else
 	{
-		for (; p < p_end; p += pg_mblen(p))
+		for (; p < p_end; p += pg_mblen_range(p, p_end))
 		{
 			if (*p == '\\')
 				return true;
@@ -4338,7 +4346,7 @@ appendStringInfoRegexpSubstr(StringInfo str, text *replace_text,
 		}
 		else
 		{
-			for (; p < p_end && *p != '\\'; p += pg_mblen(p))
+			for (; p < p_end && *p != '\\'; p += pg_mblen_range(p, p_end))
 				 /* nothing */ ;
 		}
 
@@ -4806,6 +4814,8 @@ text_to_array_internal(PG_FUNCTION_ARGS)
 	}
 	else
 	{
+		const char *end_ptr;
+
 		/*
 		 * When fldsep is NULL, each character in the inputstring becomes an
 		 * element in the result array.  The separator is effectively the
@@ -4818,10 +4828,11 @@ text_to_array_internal(PG_FUNCTION_ARGS)
 			PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
 
 		start_ptr = VARDATA_ANY(inputstring);
+		end_ptr = start_ptr + inputstring_len;
 
 		while (inputstring_len > 0)
 		{
-			int			chunk_len = pg_mblen(start_ptr);
+			int			chunk_len = pg_mblen_range(start_ptr, end_ptr);
 
 			CHECK_FOR_INTERRUPTS();
 
@@ -5412,7 +5423,7 @@ text_reverse(PG_FUNCTION_ARGS)
 		{
 			int			sz;
 
-			sz = pg_mblen(p);
+			sz = pg_mblen_range(p, endp);
 			dst -= sz;
 			memcpy(dst, p, sz);
 			p += sz;
@@ -5573,7 +5584,7 @@ text_format(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("unrecognized format() type specifier \"%.*s\"",
-							pg_mblen(cp), cp),
+							pg_mblen_range(cp, end_ptr), cp),
 					 errhint("For a single \"%%\" use \"%%%%\".")));
 
 		/* If indirect width was specified, get its value */
@@ -5694,7 +5705,7 @@ text_format(PG_FUNCTION_ARGS)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("unrecognized format() type specifier \"%.*s\"",
-								pg_mblen(cp), cp),
+								pg_mblen_range(cp, end_ptr), cp),
 						 errhint("For a single \"%%\" use \"%%%%\".")));
 				break;
 		}

--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -2016,8 +2016,7 @@ sqlchar_to_unicode(const char *s)
 	char	   *utf8string;
 	pg_wchar	ret[2];			/* need space for trailing zero */
 
-	/* note we're not assuming s is null-terminated */
-	utf8string = pg_server_to_any(s, pg_mblen(s), PG_UTF8);
+	utf8string = pg_server_to_any(s, pg_mblen_cstr(s), PG_UTF8);
 
 	pg_encoding_mb2wchar_with_len(PG_UTF8, utf8string, ret,
 								  pg_encoding_mblen(PG_UTF8, utf8string));
@@ -2070,7 +2069,7 @@ map_sql_identifier_to_xml_name(const char *ident, bool fully_escaped,
 
 	initStringInfo(&buf);
 
-	for (p = ident; *p; p += pg_mblen(p))
+	for (p = ident; *p; p += pg_mblen_cstr(p))
 	{
 		if (*p == ':' && (p == ident || fully_escaped))
 			appendStringInfoString(&buf, "_x003A_");
@@ -2095,7 +2094,7 @@ map_sql_identifier_to_xml_name(const char *ident, bool fully_escaped,
 				: !is_valid_xml_namechar(u))
 				appendStringInfo(&buf, "_x%04X_", (unsigned int) u);
 			else
-				appendBinaryStringInfo(&buf, p, pg_mblen(p));
+				appendBinaryStringInfo(&buf, p, pg_mblen_cstr(p));
 		}
 	}
 
@@ -2138,7 +2137,7 @@ map_xml_name_to_sql_identifier(const char *name)
 
 	initStringInfo(&buf);
 
-	for (p = name; *p; p += pg_mblen(p))
+	for (p = name; *p; p += pg_mblen_cstr(p))
 	{
 		if (*p == '_' && *(p + 1) == 'x'
 			&& isxdigit((unsigned char) *(p + 2))
@@ -2154,7 +2153,7 @@ map_xml_name_to_sql_identifier(const char *name)
 			p += 6;
 		}
 		else
-			appendBinaryStringInfo(&buf, p, pg_mblen(p));
+			appendBinaryStringInfo(&buf, p, pg_mblen_cstr(p));
 	}
 
 	return buf.data;

--- a/src/backend/utils/mb/mbutils.c
+++ b/src/backend/utils/mb/mbutils.c
@@ -38,6 +38,7 @@
 #include "catalog/namespace.h"
 #include "mb/pg_wchar.h"
 #include "utils/builtins.h"
+#include "utils/memdebug.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 
@@ -934,11 +935,126 @@ pg_encoding_wchar2mb_with_len(int encoding,
 	return pg_wchar_table[encoding].wchar2mb_with_len(from, (unsigned char *) to, len);
 }
 
-/* returns the byte length of a multibyte character */
+/*
+ * Returns the byte length of a multibyte character sequence in a
+ * null-terminated string.  Raises an illegal byte sequence error if the
+ * sequence would hit a null terminator.
+ *
+ * The caller is expected to have checked for a terminator at *mbstr == 0
+ * before calling, but some callers want 1 in that case, so this function
+ * continues that tradition.
+ *
+ * This must only be used for strings that have a null-terminator to enable
+ * bounds detection.
+ */
+int
+pg_mblen_cstr(const char *mbstr)
+{
+	int			length = pg_wchar_table[DatabaseEncoding->encoding].mblen((const unsigned char *) mbstr);
+
+	/*
+	 * The .mblen functions return 1 when given a pointer to a terminator.
+	 * Some callers depend on that, so we tolerate it for now.  Well-behaved
+	 * callers check the leading byte for a terminator *before* calling.
+	 */
+	for (int i = 1; i < length; ++i)
+		if (unlikely(mbstr[i] == 0))
+			report_invalid_encoding_db(mbstr, length, i);
+
+	/*
+	 * String should be NUL-terminated, but checking that would make typical
+	 * callers O(N^2), tripling Valgrind check-world time.  Unless
+	 * VALGRIND_EXPENSIVE, check 1 byte after each actual character.  (If we
+	 * found a character, not a terminator, the next byte must be a terminator
+	 * or the start of the next character.)  If the caller iterates the whole
+	 * string, the last call will diagnose a missing terminator.
+	 */
+	if (mbstr[0] != '\0')
+	{
+#ifdef VALGRIND_EXPENSIVE
+		VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, strlen(mbstr));
+#else
+		VALGRIND_CHECK_MEM_IS_DEFINED(mbstr + length, 1);
+#endif
+	}
+
+	return length;
+}
+
+/*
+ * Returns the byte length of a multibyte character sequence bounded by a range
+ * [mbstr, end) of at least one byte in size.  Raises an illegal byte sequence
+ * error if the sequence would exceed the range.
+ */
+int
+pg_mblen_range(const char *mbstr, const char *end)
+{
+	int			length = pg_wchar_table[DatabaseEncoding->encoding].mblen((const unsigned char *) mbstr);
+
+	Assert(end > mbstr);
+#ifdef VALGRIND_EXPENSIVE
+	VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, end - mbstr);
+#else
+	VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, length);
+#endif
+
+	if (unlikely(mbstr + length > end))
+		report_invalid_encoding_db(mbstr, length, end - mbstr);
+
+	return length;
+}
+
+/*
+ * Returns the byte length of a multibyte character sequence bounded by a range
+ * extending for 'limit' bytes, which must be at least one.  Raises an illegal
+ * byte sequence error if the sequence would exceed the range.
+ */
+int
+pg_mblen_with_len(const char *mbstr, int limit)
+{
+	int			length = pg_wchar_table[DatabaseEncoding->encoding].mblen((const unsigned char *) mbstr);
+
+	Assert(limit >= 1);
+#ifdef VALGRIND_EXPENSIVE
+	VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, limit);
+#else
+	VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, length);
+#endif
+
+	if (unlikely(length > limit))
+		report_invalid_encoding_db(mbstr, length, limit);
+
+	return length;
+}
+
+
+/*
+ * Returns the length of a multibyte character sequence, without any
+ * validation of bounds.
+ *
+ * PLEASE NOTE:  This function can only be used safely if the caller has
+ * already verified the input string, since otherwise there is a risk of
+ * overrunning the buffer if the string is invalid.  A prior call to a
+ * pg_mbstrlen* function suffices.
+ */
+int
+pg_mblen_unbounded(const char *mbstr)
+{
+	int			length = pg_wchar_table[DatabaseEncoding->encoding].mblen((const unsigned char *) mbstr);
+
+	VALGRIND_CHECK_MEM_IS_DEFINED(mbstr, length);
+
+	return length;
+}
+
+/*
+ * Historical name for pg_mblen_unbounded().  Should not be used and will be
+ * removed in a later version.
+ */
 int
 pg_mblen(const char *mbstr)
 {
-	return pg_wchar_table[DatabaseEncoding->encoding].mblen((const unsigned char *) mbstr);
+	return pg_mblen_unbounded(mbstr);
 }
 
 /* returns the display length of a multibyte character */
@@ -960,14 +1076,14 @@ pg_mbstrlen(const char *mbstr)
 
 	while (*mbstr)
 	{
-		mbstr += pg_mblen(mbstr);
+		mbstr += pg_mblen_cstr(mbstr);
 		len++;
 	}
 	return len;
 }
 
 /* returns the length (counted in wchars) of a multibyte string
- * (not necessarily NULL terminated)
+ * (stops at the first of "limit" or a NUL)
  */
 int
 pg_mbstrlen_with_len(const char *mbstr, int limit)
@@ -980,7 +1096,7 @@ pg_mbstrlen_with_len(const char *mbstr, int limit)
 
 	while (limit > 0 && *mbstr)
 	{
-		int			l = pg_mblen(mbstr);
+		int			l = pg_mblen_with_len(mbstr, limit);
 
 		limit -= l;
 		mbstr += l;
@@ -1050,7 +1166,7 @@ pg_mbcharcliplen(const char *mbstr, int len, int limit)
 
 	while (len > 0 && *mbstr)
 	{
-		l = pg_mblen(mbstr);
+		l = pg_mblen_with_len(mbstr, len);
 		nch++;
 		if (nch > limit)
 			break;

--- a/src/backend/utils/mb/mbutils.c
+++ b/src/backend/utils/mb/mbutils.c
@@ -1003,7 +1003,7 @@ pg_mbcliplen(const char *mbstr, int len, int limit)
 }
 
 /*
- * pg_mbcliplen with specified encoding
+ * pg_mbcliplen with specified encoding; string must be valid in encoding
  */
 int
 pg_encoding_mbcliplen(int encoding, const char *mbstr,

--- a/src/backend/utils/mb/wchar.c
+++ b/src/backend/utils/mb/wchar.c
@@ -2035,6 +2035,10 @@ pg_encoding_max_length(int encoding)
 
 #ifndef FRONTEND
 
+pg_attribute_noreturn()
+static void report_invalid_encoding_int(int encoding, const char *mbstr,
+										int mblen, int len);
+
 /*
  * fetch maximum length of the encoding for the current database
  */
@@ -2204,12 +2208,19 @@ void
 report_invalid_encoding(int encoding, const char *mbstr, int len)
 {
 	int			l = pg_encoding_mblen_or_incomplete(encoding, mbstr, len);
+
+	report_invalid_encoding_int(encoding, mbstr, l, len);
+}
+
+static void
+report_invalid_encoding_int(int encoding, const char *mbstr, int mblen, int len)
+{
 	char		buf[8 * 5 + 1];
 	char	   *p = buf;
 	int			j,
 				jlimit;
 
-	jlimit = Min(l, len);
+	jlimit = Min(mblen, len);
 	jlimit = Min(jlimit, 8);	/* prevent buffer overrun */
 
 	for (j = 0; j < jlimit; j++)
@@ -2224,6 +2235,12 @@ report_invalid_encoding(int encoding, const char *mbstr, int len)
 			 errmsg("invalid byte sequence for encoding \"%s\": %s",
 					pg_enc2name_tbl[encoding].name,
 					buf)));
+}
+
+void
+report_invalid_encoding_db(const char *mbstr, int mblen, int len)
+{
+	report_invalid_encoding_int(GetDatabaseEncoding(), mbstr, mblen, len);
 }
 
 /*

--- a/src/backend/utils/mb/wchar.c
+++ b/src/backend/utils/mb/wchar.c
@@ -11,6 +11,8 @@
 #include "postgres.h"
 #endif
 
+#include <limits.h>
+
 #include "mb/pg_wchar.h"
 
 
@@ -1875,6 +1877,27 @@ pg_mic_mblen(const unsigned char *mbstr)
 
 /*
  * Returns the byte length of a multibyte character.
+ *
+ * Choose "mblen" functions based on the input string characteristics.
+ * pg_encoding_mblen() can be used when ANY of these conditions are met:
+ *
+ * - The input string is zero-terminated
+ *
+ * - The input string is known to be valid in the encoding (e.g., string
+ *   converted from database encoding)
+ *
+ * - The encoding is not GB18030 (e.g., when only database encodings are
+ *   passed to 'encoding' parameter)
+ *
+ * encoding==GB18030 requires examining up to two bytes to determine character
+ * length.  Therefore, callers satisfying none of those conditions must use
+ * pg_encoding_mblen_or_incomplete() instead, as access to mbstr[1] cannot be
+ * guaranteed to be within allocation bounds.
+ *
+ * When dealing with text that is not certainly valid in the specified
+ * encoding, the result may exceed the actual remaining string length.
+ * Callers that are not prepared to deal with that should use Min(remaining,
+ * pg_encoding_mblen_or_incomplete()).
  */
 int
 pg_encoding_mblen(int encoding, const char *mbstr)
@@ -1882,6 +1905,25 @@ pg_encoding_mblen(int encoding, const char *mbstr)
 	return (PG_VALID_ENCODING(encoding) ?
 			pg_wchar_table[encoding].mblen((const unsigned char *) mbstr) :
 			pg_wchar_table[PG_SQL_ASCII].mblen((const unsigned char *) mbstr));
+}
+
+/*
+ * Returns the byte length of a multibyte character (possibly not
+ * zero-terminated), or INT_MAX if too few bytes remain to determine a length.
+ */
+int
+pg_encoding_mblen_or_incomplete(int encoding, const char *mbstr,
+								size_t remaining)
+{
+	/*
+	 * Define zero remaining as too few, even for single-byte encodings.
+	 * pg_gb18030_mblen() reads one or two bytes; single-byte encodings read
+	 * zero; others read one.
+	 */
+	if (remaining < 1 ||
+		(encoding == PG_GB18030 && IS_HIGHBIT_SET(*mbstr) && remaining < 2))
+		return INT_MAX;
+	return pg_encoding_mblen(encoding, mbstr);
 }
 
 /*
@@ -2156,12 +2198,12 @@ check_encoding_conversion_args(int src_encoding,
  * report_invalid_encoding: complain about invalid multibyte character
  *
  * note: len is remaining length of string, not length of character;
- * len must be greater than zero, as we always examine the first byte.
+ * len must be greater than zero (or we'd neglect initializing "buf").
  */
 void
 report_invalid_encoding(int encoding, const char *mbstr, int len)
 {
-	int			l = pg_encoding_mblen(encoding, mbstr);
+	int			l = pg_encoding_mblen_or_incomplete(encoding, mbstr, len);
 	char		buf[8 * 5 + 1];
 	char	   *p = buf;
 	int			j,
@@ -2188,18 +2230,26 @@ report_invalid_encoding(int encoding, const char *mbstr, int len)
  * report_untranslatable_char: complain about untranslatable character
  *
  * note: len is remaining length of string, not length of character;
- * len must be greater than zero, as we always examine the first byte.
+ * len must be greater than zero (or we'd neglect initializing "buf").
  */
 void
 report_untranslatable_char(int src_encoding, int dest_encoding,
 						   const char *mbstr, int len)
 {
-	int			l = pg_encoding_mblen(src_encoding, mbstr);
+	int			l;
 	char		buf[8 * 5 + 1];
 	char	   *p = buf;
 	int			j,
 				jlimit;
 
+	/*
+	 * We probably could use plain pg_encoding_mblen(), because
+	 * gb18030_to_utf8() verifies before it converts.  All conversions should.
+	 * For src_encoding!=GB18030, len>0 meets pg_encoding_mblen() needs.  Even
+	 * so, be defensive, since a buggy conversion might pass invalid data.
+	 * This is not a performance-critical path.
+	 */
+	l = pg_encoding_mblen_or_incomplete(src_encoding, mbstr, len);
 	jlimit = Min(l, len);
 	jlimit = Min(jlimit, 8);	/* prevent buffer overrun */
 

--- a/src/include/mb/pg_wchar.h
+++ b/src/include/mb/pg_wchar.h
@@ -532,7 +532,14 @@ extern int	pg_char_and_wchar_strcmp(const char *s1, const pg_wchar *s2);
 extern int	pg_wchar_strncmp(const pg_wchar *s1, const pg_wchar *s2, size_t n);
 extern int	pg_char_and_wchar_strncmp(const char *s1, const pg_wchar *s2, size_t n);
 extern size_t pg_wchar_strlen(const pg_wchar *wstr);
+extern int	pg_mblen_cstr(const char *mbstr);
+extern int	pg_mblen_range(const char *mbstr, const char *end);
+extern int	pg_mblen_with_len(const char *mbstr, int limit);
+extern int	pg_mblen_unbounded(const char *mbstr);
+
+/* deprecated */
 extern int	pg_mblen(const char *mbstr);
+
 extern int	pg_dsplen(const char *mbstr);
 extern void pg_encoding_set_invalid(int encoding, char *dst);
 extern int	pg_encoding_mblen(int encoding, const char *mbstr);
@@ -616,6 +623,7 @@ extern void check_encoding_conversion_args(int src_encoding,
 										   int expected_dest_encoding);
 
 extern void report_invalid_encoding(int encoding, const char *mbstr, int len) pg_attribute_noreturn();
+extern void report_invalid_encoding_db(const char *mbstr, int mblen, int len) pg_attribute_noreturn();
 extern void report_untranslatable_char(int src_encoding, int dest_encoding,
 									   const char *mbstr, int len) pg_attribute_noreturn();
 

--- a/src/include/mb/pg_wchar.h
+++ b/src/include/mb/pg_wchar.h
@@ -536,6 +536,8 @@ extern int	pg_mblen(const char *mbstr);
 extern int	pg_dsplen(const char *mbstr);
 extern void pg_encoding_set_invalid(int encoding, char *dst);
 extern int	pg_encoding_mblen(int encoding, const char *mbstr);
+extern int	pg_encoding_mblen_or_incomplete(int encoding, const char *mbstr,
+											size_t remaining);
 extern int	pg_encoding_dsplen(int encoding, const char *mbstr);
 extern int	pg_encoding_verifymb(int encoding, const char *mbstr, int len);
 extern int	pg_encoding_verifymbchar(int encoding, const char *mbstr, int len);

--- a/src/include/tsearch/ts_locale.h
+++ b/src/include/tsearch/ts_locale.h
@@ -44,12 +44,36 @@ typedef struct
 /* The second argument of t_iseq() must be a plain ASCII character */
 #define t_iseq(x,c)		(TOUCHAR(x) == (unsigned char) (c))
 
-#define COPYCHAR(d,s)	memcpy(d, s, pg_mblen(s))
+/* Copy multibyte character of known byte length, return byte length. */
+static inline int
+ts_copychar_with_len(void *dest, const void *src, int length)
+{
+	memcpy(dest, src, length);
+	return length;
+}
 
-extern int	t_isdigit(const char *ptr);
-extern int	t_isspace(const char *ptr);
-extern int	t_isalpha(const char *ptr);
-extern int	t_isprint(const char *ptr);
+/* Copy multibyte character from null-terminated string,  return byte length. */
+static inline int
+ts_copychar_cstr(void *dest, const void *src)
+{
+	return ts_copychar_with_len(dest, src, pg_mblen_cstr((const char *) src));
+}
+
+/* Historical macro for the above. */
+#define COPYCHAR ts_copychar_cstr
+
+#define GENERATE_T_ISCLASS_DECL(character_class) \
+extern int	t_is##character_class##_with_len(const char *ptr, int len); \
+extern int	t_is##character_class##_cstr(const char *ptr); \
+extern int	t_is##character_class##_unbounded(const char *ptr); \
+\
+/* deprecated */ \
+extern int	t_is##character_class(const char *ptr);
+
+GENERATE_T_ISCLASS_DECL(alpha);
+GENERATE_T_ISCLASS_DECL(digit);
+GENERATE_T_ISCLASS_DECL(print);
+GENERATE_T_ISCLASS_DECL(space);
 
 extern char *lowerstr(const char *str);
 extern char *lowerstr_with_len(const char *str, int len);

--- a/src/include/tsearch/ts_utils.h
+++ b/src/include/tsearch/ts_utils.h
@@ -38,14 +38,12 @@ extern bool gettoken_tsvector(TSVectorParseState state,
 extern void close_tsvector_parser(TSVectorParseState state);
 
 /* phrase operator begins with '<' */
-#define ISOPERATOR(x) \
-	( pg_mblen(x) == 1 && ( *(x) == '!' ||	\
-							*(x) == '&' ||	\
-							*(x) == '|' ||	\
-							*(x) == '(' ||	\
-							*(x) == ')' ||	\
-							*(x) == '<'		\
-						  ) )
+#define ISOPERATOR(x)		(*(x) == '!' ||	\
+							 *(x) == '&' ||	\
+							 *(x) == '|' ||	\
+							 *(x) == '(' ||	\
+							 *(x) == ')' ||	\
+							 *(x) == '<')
 
 /* parse_tsquery */
 

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -3418,7 +3418,8 @@ PQescapeStringInternal(PGconn *conn,
 		}
 
 		/* Slow path for possible multibyte characters */
-		charlen = pg_encoding_mblen(encoding, source);
+		charlen = pg_encoding_mblen_or_incomplete(encoding,
+												  source, remaining);
 
 		if (remaining < charlen ||
 			pg_encoding_verifymbchar(encoding, source, charlen) == -1)
@@ -3579,7 +3580,8 @@ PQescapeInternal(PGconn *conn, const char *str, size_t len, bool as_ident)
 			int			charlen;
 
 			/* Slow path for possible multibyte characters */
-			charlen = pg_encoding_mblen(conn->client_encoding, s);
+			charlen = pg_encoding_mblen_or_incomplete(conn->client_encoding,
+													  s, remaining);
 
 			if (charlen > remaining)
 			{

--- a/src/interfaces/libpq/fe-misc.c
+++ b/src/interfaces/libpq/fe-misc.c
@@ -1335,8 +1335,9 @@ pqSocketPoll(int sock, int forRead, int forWrite, time_t end_time)
  */
 
 /*
- * returns the byte length of the character beginning at s, using the
- * specified encoding.
+ * Like pg_encoding_mblen().  Use this in callers that want the
+ * dynamically-linked libpq's stance on encodings, even if that means
+ * different behavior in different startups of the executable.
  */
 int
 PQmblen(const char *s, int encoding)

--- a/src/test/modules/test_escape/test_escape.c
+++ b/src/test/modules/test_escape/test_escape.c
@@ -376,8 +376,18 @@ static pe_test_vector pe_test_vectors[] =
 	 * Testcases that are not null terminated for the specified input length.
 	 * That's interesting to verify that escape functions don't read beyond
 	 * the intended input length.
+	 *
+	 * One interesting special case is GB18030, which has the odd behaviour
+	 * needing to read beyond the first byte to determine the length of a
+	 * multi-byte character.
 	 */
 	TV_LEN("gbk", "\x80", 1),
+	TV_LEN("GB18030", "\x80", 1),
+	TV_LEN("GB18030", "\x80\0", 2),
+	TV_LEN("GB18030", "\x80\x30", 2),
+	TV_LEN("GB18030", "\x80\x30\0", 3),
+	TV_LEN("GB18030", "\x80\x30\x30", 3),
+	TV_LEN("GB18030", "\x80\x30\x30\0", 4),
 	TV_LEN("UTF-8", "\xC3\xb6  ", 1),
 	TV_LEN("UTF-8", "\xC3\xb6  ", 2),
 };
@@ -456,6 +466,51 @@ encoding_conflicts_ascii(int encoding)
 	if (encoding > PG_ENCODING_BE_LAST)
 		return true;
 	return false;
+}
+
+
+/*
+ * Confirm escaping doesn't read past the end of an allocation.  Consider the
+ * result of malloc(4096), in the absence of freelist entries satisfying the
+ * allocation.  On OpenBSD, reading one byte past the end of that object
+ * yields SIGSEGV.
+ *
+ * Run this test before the program's other tests, so freelists are minimal.
+ * len=4096 didn't SIGSEGV, likely due to free() calls in libpq.  len=8192
+ * did.  Use 128 KiB, to somewhat insulate the outcome from distant new free()
+ * calls and libc changes.
+ */
+static void
+test_gb18030_page_multiple(pe_test_config *tc)
+{
+	PQExpBuffer testname;
+	PQExpBuffer details;
+	size_t		input_len = 0x20000;
+	char	   *input;
+
+	/* prepare input */
+	input = pg_malloc(input_len);
+	memset(input, '-', input_len - 1);
+	input[input_len - 1] = 0xfe;
+
+	/* name to describe the test */
+	testname = createPQExpBuffer();
+	appendPQExpBuffer(testname, ">repeat(%c, %zu)", input[0], input_len - 1);
+	escapify(testname, input + input_len - 1, 1);
+	appendPQExpBuffer(testname, "< - GB18030 - PQescapeLiteral");
+
+	/* this test has no details to print */
+	details = createPQExpBuffer();
+
+	/* test itself */
+	PQsetClientEncoding(tc->conn, "GB18030");
+	report_result(tc, PQescapeLiteral(tc->conn, input, input_len) == NULL,
+				  testname, details,
+				  "input validity vs escape success", "ok");
+
+	destroyPQExpBuffer(details);
+	destroyPQExpBuffer(testname);
+	pg_free(input);
 }
 
 static const char *
@@ -861,6 +916,8 @@ main(int argc, char *argv[])
 				PQerrorMessage(tc.conn));
 		exit(1);
 	}
+
+	test_gb18030_page_multiple(&tc);
 
 	for (int i = 0; i < lengthof(pe_test_vectors); i++)
 	{

--- a/src/test/regress/expected/strings.out
+++ b/src/test/regress/expected/strings.out
@@ -2008,6 +2008,12 @@ SELECT translate('12345', '14', 'ax');
  a23x5
 (1 row)
 
+SELECT translate('12345', '134', 'a');
+ translate 
+-----------
+ a25
+(1 row)
+
 SELECT ascii('x');
  ascii 
 -------

--- a/src/test/regress/sql/strings.sql
+++ b/src/test/regress/sql/strings.sql
@@ -695,6 +695,7 @@ SELECT ltrim('zzzytrim', 'xyz');
 
 SELECT translate('', '14', 'ax');
 SELECT translate('12345', '14', 'ax');
+SELECT translate('12345', '134', 'a');
 
 SELECT ascii('x');
 SELECT ascii('');


### PR DESCRIPTION
Summary:

Backport of the upstream fixes for CVE-2025-4207 and CVE-2026-2006, two
multibyte-length overreads. They are sent together because the second builds
directly on the first and they touch the same files. WarehousePG's PG12 base is
past upstream EOL, so each is taken from the oldest upstream branch that has it.

Five commits:

1. With GB18030, prevent SIGSEGV from reading past end of allocation.
   Cherry-pick of upstream cbadeaca927 (REL_13, CVE-2025-4207).
2. Avoid fetching one past the end of translate()'s "to" parameter.
   Cherry-pick of upstream b162660d3ac (REL_12).
3. Replace pg_mblen() with bounds-checked versions.
   Cherry-pick of upstream cecedb912ae (REL_14, CVE-2026-2006).
4. Fix overread in JSON parsing errors for incomplete byte sequences.
   Cherry-pick of upstream 377c25d3227 (REL_13).
5. orafce: replace pg_mblen() with bounds-checked versions.
   WarehousePG-specific, no upstream counterpart.

Commit 2 is a prerequisite, not a CVE fix: it is a plain upstream cherry-pick we
never took, and commit 3 rewrites the same translate() loop and does not apply
without the to_end variable it introduces. It also removes a real one-byte
overread we were carrying (translate('abc', 'xb', '') reads to_ptr with tolen
== 0).

Commits 4 and 5 finish the job in the two places the cherry-picks cannot reach.
Neither is a hunk that failed to apply -- the file sets match upstream exactly,
41 files and 280 of its 281 hunks, the one exception being a formatting.c hunk
for datetime "standard mode" separator code that PG12 does not have. But
upstream's *equivalent* code is safe for reasons that never reached PG12, so
without these two commits our tree would still carry 22 unbounded pg_mblen()
call sites that upstream no longer has:

- The JSON lexer is still backend-only in src/backend/utils/adt/json.c here; it
  became src/common/jsonapi.c in PG13. Upstream's copy is safe because of
  CVE-2025-4207 plus 377c25d3227, and neither has a PG12 backpatch. Commit 4
  takes the latter.

- gpcontrib/orafce is a vendored fork of several of the very functions commit 3
  rewrites. orafce/regexp.c's parse_re_flags() and charpad.c's lpad()/rpad()
  loops are copies of src/backend/utils/adt/regexp.c and oracle_compat.c, so
  they are the same CVE-2026-2006 pattern in a file the patch cannot touch.
  Commit 5 converts them, choosing the same variant upstream chose for each
  corresponding site.

Background:

pg_encoding_mblen() has to look at two bytes to decide a GB18030 character's
length, so callers handed unterminated input could read one byte past the
allocation (CVE-2025-4207). More generally, pg_mblen() returns a length that its
callers never checked against the bytes actually remaining, so a corrupted
string could make an iterating caller overrun its buffer (CVE-2026-2006).

The fixes add bounds-checked variants — pg_encoding_mblen_or_incomplete(), and
pg_mblen_cstr() / _range() / _with_len() / _unbounded() — and convert every core
caller to whichever one matches what it actually knows about its input.
pg_mblen(), the COPYCHAR macro and the t_isXXX() functions remain for
compatibility but are deprecated and no longer used by core code.

No catalog, ABI or WAL changes.

WarehousePG adaptations:

The per-file details are in the commit messages. The one deviation worth calling
out here: upstream keeps report_invalid_encoding_db() static in mbutils.c, but
report_invalid_encoding() still lives in wchar.c for us (it moved when wchar.c
became src/common/wchar.c in PG13), while the new pg_mblen_*() functions belong
in mbutils.c. It is therefore extern here, declared in pg_wchar.h next to
report_invalid_encoding(). Everything else is either a plain cherry-pick or a
mechanical re-application caused by PG12 file layout.

Commit 4 carries one hunk beyond upstream's diff, for extract_mb_char(). It has
exactly the overread the commit sets out to remove, one function away from the
one upstream fixed; upstream has no counterpart hunk only because PG13's
refactor deleted the function outright.

Test plan:

- Clean make and make install, no new warnings.
- Full make installcheck against a gpdemo cluster. Everything passes except
  gporca, qp_full_join, dpe and most of contrib/btree_gist, whose diffs are all
  "Server has been compiled without ORCA" / "Optimizer: Postgres-based planner"
  against ORCA-generated expected files — my box has no ORCA libraries, so those
  are down to CI. contrib/pageinspect likewise fails only on GPDB artifacts
  (DISTRIBUTED BY notices, "block number 0 is out of range" because the pages
  live on segments). No data or error-message differences anywhere, and nothing
  touching text_to_bits() or gbt_var_node_cp_len(). contrib dict_xsyn, hstore,
  ltree, pg_trgm and unaccent all pass outright.
- src/test/modules/test_escape: 1031 assertions pass, 0 fail, 208 of them
  GB18030 — including the six new truncated-sequence vectors and the 128 KiB
  page-boundary PQescapeLiteral() case that the CVE-2025-4207 commit adds. The
  run then stops early on mule_internal, because upstream's driver wants a
  SQL_ASCII database and we reject SQL_ASCII as a server encoding; that is a
  pre-existing limitation of this module in our tree, not a regression.
- Guard-page check for the libpq half of CVE-2025-4207: a GB18030 lead byte
  placed as the last byte of a mapped page with the next page PROT_NONE.
  PQescapeStringConn(), PQescapeLiteral() and PQescapeIdentifier() all complete
  without faulting, while PQmblen() — plain pg_encoding_mblen(), i.e. exactly
  what those functions called before the fix — takes SIGSEGV on the same
  pointer. Confirms both that the guard is armed and that the overread is gone.
- Commit 4: the multibyte JSON error paths still render correctly -- a valid
  multibyte document round-trips, '{"k":"\uZZ..."}' reports the hex-digit error
  with its CONTEXT line intact, and a backslash followed by a multibyte
  character reaches extract_mb_char() and prints that character whole in the
  detail.
- Commit 5: orafce's own suite passes 17/17, and an A/B against an unpatched
  orafce build -- multibyte lpad/rpad across every width with multibyte padding,
  plvstr.normalize, plvstr.rvrs/left/right, plvchr._is_kind, oracle.length,
  to_multi_byte/to_single_byte round trips and both regexp option error messages
  -- is byte-identical.
- No discriminating SQL-level test is available for CVE-2026-2006 on PG12: the
  reachable error messages are identical before and after, since the bogus
  length is clamped by Min(mblen, len) either way, and the v14+ conversion.sql
  coverage rides on the noError conversion API that PG12 does not have. Upstream
  ships no new tests for it either.

What commits 4 and 5 actually fix:

Most of these reads are harmless in themselves: for any encoding a database can
use, .mblen() looks only at the leading byte. The damage comes from using the
returned length afterwards. Three sites do worse than overread:

- json.c set token_terminator to s + pg_mblen(s) unclamped, and
  report_json_context() memcpy()s everything up to token_terminator out of a
  buffer that is a bare text payload, not null-terminated. extract_mb_char()
  has the same problem building the "Escape sequence ... is invalid" detail.
- orafce's plvstr_normalize() copies the character out byte by byte into a
  buffer sized palloc(VARSIZE_ANY_EXHDR(str)), so an overshooting length reads
  past the input *and* writes past that allocation.
- orafce's to_single_byte() memcpy()s clen bytes into a buffer sized
  VARHDRSZ + srclen, overrunning both sides likewise.

Commit 4 keeps pg_mblen_unbounded() plus an explicit clamp rather than the
erroring pg_mblen_range(), matching what upstream's lexer does: the point is to
report the JSON syntax error we came here for, not to replace it with "invalid
byte sequence".

charpad.c's two string1 copy loops in commit 5 needed a real guard rather than
just a different call, since the loop counter also covers a half-width space and
so is not by itself a bound on string1. That guard cannot fire for input valid in
the database encoding; it earns its place on truncated input, where it stops
pg_mblen_range() from being called on a pointer already at the end of the datum.

Deliberately left alone:

- src/backend/parser/scan.l's three pg_mblen() calls are correct as they stand.
  They measure a freshly written, deliberately non-terminated UTF-8 sequence, so
  pg_mblen_cstr() there would be a bug. Upstream reads strlen() at the
  equivalent spot only because PG13's a6525588b7c started null-terminating that
  buffer, which is a feature commit unrelated to any of this.

After the series the only bare pg_mblen() references left in the tree are those
three, plus the deprecated function's own definition and declaration.
