### PR TITLE
Fix volatile multiply-referenced CTEs re-evaluated per reference

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3095,8 +3095,17 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			is_shared = true;
 			break;
 		default:
-			/* if plan sharing is enabled and contains volatile functions in the CTE query, also generate a shared scan plan */
-			is_shared =  root->config->gp_cte_sharing && (cte->cterefcount > 1 || contain_volatile_function);
+			/*
+			 * Force sharing when the CTE is both multiply-referenced and
+			 * volatile, regardless of gp_cte_sharing: a volatile CTE with
+			 * more than one reference must be evaluated exactly once, or
+			 * results would depend on how many references there happen to
+			 * be. Otherwise, fall back to the original gp_cte_sharing-gated
+			 * behavior.
+			 */
+			is_shared = (cte->cterefcount > 1 && contain_volatile_function) ||
+				(root->config->gp_cte_sharing &&
+				 (cte->cterefcount > 1 || contain_volatile_function));
 
 	}
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3095,25 +3095,48 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			is_shared = true;
 			break;
 		default:
-			/*
-			 * Force sharing when the CTE is both multiply-referenced and
-			 * volatile, regardless of gp_cte_sharing: a volatile CTE with
-			 * more than one reference must be evaluated exactly once, or
-			 * results would depend on how many references there happen to
-			 * be. Otherwise, fall back to the original gp_cte_sharing-gated
-			 * behavior.
-			 */
-			is_shared = (cte->cterefcount > 1 && contain_volatile_function) ||
-				(root->config->gp_cte_sharing &&
-				 (cte->cterefcount > 1 || contain_volatile_function));
-
+			is_shared = root->config->gp_cte_sharing &&
+				(cte->cterefcount > 1 || contain_volatile_function);
+			break;
 	}
 
 	/*
-	 * since shareinputscan with outer refs is not supported by GPDB, if
-	 * contain outer self references, the cte need to be inlined.
+	 * A CTE with side effects (volatile functions, or a data-modifying
+	 * statement) that is referenced more than once must be evaluated
+	 * exactly once, or results would depend on how many references there
+	 * happen to be. Force sharing for it regardless of gp_cte_sharing or
+	 * the MATERIALIZED hint.
 	 */
-	if (is_shared && contain_outer_selfref(cte->ctequery))
+	if (cte->cterefcount > 1 &&
+		(contain_volatile_function || subquery->commandType != CMD_SELECT))
+		is_shared = true;
+
+	/*
+	 * ... unless a ShareInputScan cannot be placed here at all.
+	 *
+	 * A lone reference is always safe to share (there is no other consumer
+	 * for its producer to conflict with), so these only matter once there
+	 * is more than one reference:
+	 *
+	 * Inside an InitPlan-capable sublink, or at a nested CTE level, a
+	 * second reference might live outside the current InitPlan/nesting;
+	 * the producer would then wait forever for a consumer dispatched on a
+	 * different schedule (or deadlock against another nested SharedScan).
+	 * Per-reference evaluation is what pre-PR234 already did here.
+	 */
+	if (cte->cterefcount > 1 && !root->config->cte_sharing_allowed)
+		is_shared = false;
+
+	/*
+	 * These, on the other hand, are structural limitations of
+	 * ShareInputScan itself and apply regardless of how many references
+	 * there are: it has no slice table to synchronize producer/consumer on
+	 * a QE, and it cannot be rescanned under an outer correlation (nor,
+	 * pre-existing, under an outer recursive self-reference).
+	 */
+	if (Gp_role != GP_ROLE_DISPATCH ||
+		contain_outer_selfref(cte->ctequery) ||
+		contain_vars_of_level_or_above((Node *) cte->ctequery, 1))
 		is_shared = false;
 
 	if (!is_shared)
@@ -3125,6 +3148,7 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		 * disallow sharing of ctes at lower levels.
 		 */
 		config->gp_cte_sharing = false;
+		config->cte_sharing_allowed = false;
 
 		config->honor_order_by = false;
 
@@ -3183,6 +3207,7 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			 * disallow sharing of ctes at lower levels.
 			 */
 			config->gp_cte_sharing = false;
+			config->cte_sharing_allowed = false;
 
 			config->honor_order_by = false;
 

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -340,6 +340,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->may_rescan = false;
 
+	c1->cte_sharing_allowed = true;
+
 	return c1;
 }
 

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -409,6 +409,20 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 				 subLinkType == EXPR_SUBLINK ||
 				 subLinkType == MULTIEXPR_SUBLINK ||
 				 subLinkType == EXISTS_SUBLINK) : config->gp_cte_sharing;
+
+		/*
+		 * These sublink types may be planned as an InitPlan, which is
+		 * dispatched and awaited ahead of the main plan. A CTE referenced
+		 * both here and by the main plan (or by another InitPlan) can never
+		 * be shared: the producer would wait forever for a consumer that
+		 * hasn't been dispatched yet.
+		 */
+		if (subLinkType == ROWCOMPARE_SUBLINK ||
+			subLinkType == ARRAY_SUBLINK ||
+			subLinkType == EXPR_SUBLINK ||
+			subLinkType == MULTIEXPR_SUBLINK ||
+			subLinkType == EXISTS_SUBLINK)
+			config->cte_sharing_allowed = false;
 	}
 	/*
 	 * Strictly speaking, the order of rows in a subquery doesn't matter.

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -49,6 +49,17 @@ typedef struct PlannerConfig
 	 */
 	bool        force_entry;
 	struct Bitmapset *force_entry_rels;
+
+	/*
+	 * False when a second reference to the CTE being planned might fall
+	 * outside the current planning context and be unreachable from here:
+	 * inside a sublink that may be planned as an InitPlan, or at a nested
+	 * CTE level (multiple SharedScans there can deadlock). Only matters
+	 * for a multiply-referenced CTE; a lone reference has no other
+	 * consumer to lose track of. Independent of gp_cte_sharing, which is
+	 * only the user's performance preference.
+	 */
+	bool        cte_sharing_allowed;
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -21,6 +21,22 @@ SELECT count(*) FROM (
      5
 (1 row)
 
+-- Same as above, but with gp_cte_sharing at its default (off): a
+-- multiply-referenced CTE must still be evaluated only once regardless
+-- of the sharing GUC.
+set gp_cte_sharing to off;
+SELECT count(*) FROM (
+  WITH q1(x) AS (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+ count 
+-------
+     5
+(1 row)
+
+set gp_cte_sharing to on;
 -- WITH RECURSIVE
 -- sum of 1..100
 WITH RECURSIVE t(n) AS (

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -37,6 +37,97 @@ SELECT count(*) FROM (
 (1 row)
 
 set gp_cte_sharing to on;
+-- Forcing the sharing above must not bypass the planner's guards against
+-- placing a ShareInputScan where it cannot work: inside a sublink that may
+-- be planned as an InitPlan, or where the CTE has an outer correlation.
+-- Those cases must still fall back to per-reference evaluation rather than
+-- crash, hang, or error out.
+CREATE TABLE cte_vol_t (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO cte_vol_t SELECT i, i % 10 FROM generate_series(1, 100) i;
+set gp_cte_sharing to off;
+-- EXISTS pulled into an AlternativeSubPlan, referencing the CTE from both
+-- the main query and the EXISTS test.
+WITH q1 AS (SELECT random() r, a FROM generate_series(1,5) a)
+SELECT count(*) >= 0 FROM cte_vol_t t, q1
+WHERE t.b = 1 OR EXISTS (SELECT 1 FROM q1 WHERE q1.r >= 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- CTE referenced by the main query and by an EXISTS sublink that may be
+-- planned as an InitPlan.
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+ count 
+-------
+   100
+(1 row)
+
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE q.r <= 1;
+ count 
+-------
+   100
+(1 row)
+
+-- Two InitPlans sharing the same CTE; the main query does not reference it.
+WITH a AS (SELECT i, random() r FROM generate_series(1,100) i)
+SELECT (SELECT max(i) FROM a), (SELECT min(i) FROM a);
+ max | min 
+-----+-----
+ 100 |   1
+(1 row)
+
+-- A distributed-table (general locus) CTE plus an InitPlan reference.
+WITH q AS (SELECT random() AS r FROM generate_series(1,5))
+SELECT count(*) FROM cte_vol_t, q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+ count 
+-------
+   500
+(1 row)
+
+-- A CTE with an outer correlation must not attempt to share.
+SELECT count(*) FROM cte_vol_t t1
+WHERE t1.a > (WITH q AS (SELECT random() r, t2.b FROM cte_vol_t t2 WHERE t2.a = t1.a)
+              SELECT min(q1.r) FROM q q1, q q2 WHERE q1.b = q2.b);
+ count 
+-------
+   100
+(1 row)
+
+-- AS NOT MATERIALIZED with a volatile function must still be evaluated
+-- exactly once when multiply referenced.
+SELECT count(*) FROM (
+  WITH q1(x) AS NOT MATERIALIZED (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+ count 
+-------
+     5
+(1 row)
+
+-- A data-modifying CTE must also be evaluated exactly once when multiply
+-- referenced.
+CREATE TABLE cte_dml_t (a int) DISTRIBUTED BY (a);
+WITH ins AS (INSERT INTO cte_dml_t VALUES (1), (2) RETURNING a)
+SELECT count(*) FROM (SELECT a FROM ins UNION ALL SELECT a FROM ins) x;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM cte_dml_t;
+ count 
+-------
+     2
+(1 row)
+
+DROP TABLE cte_dml_t;
+set gp_cte_sharing to on;
+DROP TABLE cte_vol_t;
 -- WITH RECURSIVE
 -- sum of 1..100
 WITH RECURSIVE t(n) AS (

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -40,6 +40,97 @@ SELECT count(*) FROM (
 (1 row)
 
 set gp_cte_sharing to on;
+-- Forcing the sharing above must not bypass the planner's guards against
+-- placing a ShareInputScan where it cannot work: inside a sublink that may
+-- be planned as an InitPlan, or where the CTE has an outer correlation.
+-- Those cases must still fall back to per-reference evaluation rather than
+-- crash, hang, or error out.
+CREATE TABLE cte_vol_t (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO cte_vol_t SELECT i, i % 10 FROM generate_series(1, 100) i;
+set gp_cte_sharing to off;
+-- EXISTS pulled into an AlternativeSubPlan, referencing the CTE from both
+-- the main query and the EXISTS test.
+WITH q1 AS (SELECT random() r, a FROM generate_series(1,5) a)
+SELECT count(*) >= 0 FROM cte_vol_t t, q1
+WHERE t.b = 1 OR EXISTS (SELECT 1 FROM q1 WHERE q1.r >= 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- CTE referenced by the main query and by an EXISTS sublink that may be
+-- planned as an InitPlan.
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+ count 
+-------
+   100
+(1 row)
+
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE q.r <= 1;
+ count 
+-------
+   100
+(1 row)
+
+-- Two InitPlans sharing the same CTE; the main query does not reference it.
+WITH a AS (SELECT i, random() r FROM generate_series(1,100) i)
+SELECT (SELECT max(i) FROM a), (SELECT min(i) FROM a);
+ max | min 
+-----+-----
+ 100 |   1
+(1 row)
+
+-- A distributed-table (general locus) CTE plus an InitPlan reference.
+WITH q AS (SELECT random() AS r FROM generate_series(1,5))
+SELECT count(*) FROM cte_vol_t, q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+ count 
+-------
+   500
+(1 row)
+
+-- A CTE with an outer correlation must not attempt to share.
+SELECT count(*) FROM cte_vol_t t1
+WHERE t1.a > (WITH q AS (SELECT random() r, t2.b FROM cte_vol_t t2 WHERE t2.a = t1.a)
+              SELECT min(q1.r) FROM q q1, q q2 WHERE q1.b = q2.b);
+ count 
+-------
+   100
+(1 row)
+
+-- AS NOT MATERIALIZED with a volatile function must still be evaluated
+-- exactly once when multiply referenced.
+SELECT count(*) FROM (
+  WITH q1(x) AS NOT MATERIALIZED (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+ count 
+-------
+     5
+(1 row)
+
+-- A data-modifying CTE must also be evaluated exactly once when multiply
+-- referenced.
+CREATE TABLE cte_dml_t (a int) DISTRIBUTED BY (a);
+WITH ins AS (INSERT INTO cte_dml_t VALUES (1), (2) RETURNING a)
+SELECT count(*) FROM (SELECT a FROM ins UNION ALL SELECT a FROM ins) x;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM cte_dml_t;
+ count 
+-------
+     2
+(1 row)
+
+DROP TABLE cte_dml_t;
+set gp_cte_sharing to on;
+DROP TABLE cte_vol_t;
 -- WITH RECURSIVE
 -- sum of 1..100
 WITH RECURSIVE t(n) AS (

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -24,6 +24,22 @@ SELECT count(*) FROM (
      5
 (1 row)
 
+-- Same as above, but with gp_cte_sharing at its default (off): a
+-- multiply-referenced CTE must still be evaluated only once regardless
+-- of the sharing GUC.
+set gp_cte_sharing to off;
+SELECT count(*) FROM (
+  WITH q1(x) AS (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+ count 
+-------
+     5
+(1 row)
+
+set gp_cte_sharing to on;
 -- WITH RECURSIVE
 -- sum of 1..100
 WITH RECURSIVE t(n) AS (

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -30,6 +30,64 @@ SELECT count(*) FROM (
 ) ss;
 set gp_cte_sharing to on;
 
+-- Forcing the sharing above must not bypass the planner's guards against
+-- placing a ShareInputScan where it cannot work: inside a sublink that may
+-- be planned as an InitPlan, or where the CTE has an outer correlation.
+-- Those cases must still fall back to per-reference evaluation rather than
+-- crash, hang, or error out.
+CREATE TABLE cte_vol_t (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO cte_vol_t SELECT i, i % 10 FROM generate_series(1, 100) i;
+
+set gp_cte_sharing to off;
+
+-- EXISTS pulled into an AlternativeSubPlan, referencing the CTE from both
+-- the main query and the EXISTS test.
+WITH q1 AS (SELECT random() r, a FROM generate_series(1,5) a)
+SELECT count(*) >= 0 FROM cte_vol_t t, q1
+WHERE t.b = 1 OR EXISTS (SELECT 1 FROM q1 WHERE q1.r >= 0);
+
+-- CTE referenced by the main query and by an EXISTS sublink that may be
+-- planned as an InitPlan.
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+
+WITH q AS (SELECT random() r, a FROM cte_vol_t)
+SELECT count(*) FROM q WHERE q.r <= 1;
+
+-- Two InitPlans sharing the same CTE; the main query does not reference it.
+WITH a AS (SELECT i, random() r FROM generate_series(1,100) i)
+SELECT (SELECT max(i) FROM a), (SELECT min(i) FROM a);
+
+-- A distributed-table (general locus) CTE plus an InitPlan reference.
+WITH q AS (SELECT random() AS r FROM generate_series(1,5))
+SELECT count(*) FROM cte_vol_t, q WHERE EXISTS (SELECT 1 FROM q q2 WHERE q2.r >= 0);
+
+-- A CTE with an outer correlation must not attempt to share.
+SELECT count(*) FROM cte_vol_t t1
+WHERE t1.a > (WITH q AS (SELECT random() r, t2.b FROM cte_vol_t t2 WHERE t2.a = t1.a)
+              SELECT min(q1.r) FROM q q1, q q2 WHERE q1.b = q2.b);
+
+-- AS NOT MATERIALIZED with a volatile function must still be evaluated
+-- exactly once when multiply referenced.
+SELECT count(*) FROM (
+  WITH q1(x) AS NOT MATERIALIZED (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+
+-- A data-modifying CTE must also be evaluated exactly once when multiply
+-- referenced.
+CREATE TABLE cte_dml_t (a int) DISTRIBUTED BY (a);
+WITH ins AS (INSERT INTO cte_dml_t VALUES (1), (2) RETURNING a)
+SELECT count(*) FROM (SELECT a FROM ins UNION ALL SELECT a FROM ins) x;
+SELECT count(*) FROM cte_dml_t;
+DROP TABLE cte_dml_t;
+
+set gp_cte_sharing to on;
+
+DROP TABLE cte_vol_t;
+
 -- WITH RECURSIVE
 
 -- sum of 1..100

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -18,6 +18,18 @@ SELECT count(*) FROM (
     SELECT * FROM q1
 ) ss;
 
+-- Same as above, but with gp_cte_sharing at its default (off): a
+-- multiply-referenced CTE must still be evaluated only once regardless
+-- of the sharing GUC.
+set gp_cte_sharing to off;
+SELECT count(*) FROM (
+  WITH q1(x) AS (SELECT random() FROM generate_series(1, 5))
+    SELECT * FROM q1
+  UNION
+    SELECT * FROM q1
+) ss;
+set gp_cte_sharing to on;
+
 -- WITH RECURSIVE
 
 -- sum of 1..100


### PR DESCRIPTION
## Summary
- `set_cte_pathlist()`'s default case only forced a shared scan plan for a
  CTE when `gp_cte_sharing` was on. With it at its default (off), a CTE
  referenced more than once that also contains a volatile function fell
  through to the unshared branch, which plans an independent copy per
  reference -- re-running the volatile expression once per reference instead
  of once for the whole query, so results silently depended on how many
  references happened to exist.
- Force sharing whenever a CTE is both multiply-referenced and volatile,
  regardless of `gp_cte_sharing`, matching the guarantee upstream's own
  CTE-inlining rule already relies on (a volatile CTE is never inlined, so
  it's always evaluated exactly once). The `gp_cte_sharing`-gated condition
  is kept as-is for every other case, so existing sharing behavior is
  unchanged.

Fixes #233

## Test plan
- [x] Added a regression case in `with.sql` covering the repro with
      `gp_cte_sharing` explicitly off; blessed both `with.out` (Postgres
      planner) and `with_optimizer.out` (ORCA).
- [x] Verified the repro returns `5` (not `10`) with `gp_cte_sharing` at its
      default and with it explicitly `on`.
- [x] Verified a singly-referenced volatile CTE is unaffected -- same plan
      as before, no spurious Shared Scan introduced.
- [x] Verified `subselect.sql`'s existing `gp_cte_sharing=on` forced-share
      block (singly-referenced volatile CTE) still blesses the same plan.
- [x] Ran the full dependency-chain prefix of `parallel_schedule` through
      `with`/`subselect` under both `optimizer=off` and `optimizer=on`
      (ORCA) -- all tests pass, zero diffs.