### PR TITLE
[WHPG6]pgcrypto: reset debug handler after PGP pipeline errors

### DIFF
--- a/contrib/pgcrypto/expected/pgp-decrypt.out
+++ b/contrib/pgcrypto/expected/pgp-decrypt.out
@@ -449,3 +449,21 @@ ww0EBAMC8wIKbtvzJtxi0jABUleCwFJWGCkYKcsNdABqdtXaU2VjcmV0LtMUlnPH3A2QBmZrcucm
 -----END PGP MESSAGE-----
 '), 'wrong key', 'ignore-cipher-failure=1');
 ERROR:  Wrong key or corrupt data
+-- Check that an error thrown from inside the PGP pipeline does not leave
+-- the debug handler installed.  Decrypt the broken-bf message from above
+-- with debug=1: if Blowfish is unsupported, cipher setup ereports from
+-- the middle of the pipeline; otherwise decryption fails normally.
+select pgp_sym_decrypt(dearmor('
+-----BEGIN PGP MESSAGE-----
+
+ww0EBAMC8wIKbtvzJtxi0jABUleCwFJWGCkYKcsNdABqdtXaU2VjcmV0LtMUlnPH3A2QBmZrcucm
+1GPb/s2Bkdg=
+=6aqD
+-----END PGP MESSAGE-----
+'), 'wrong key', 'debug=1');
+NOTICE:  dbg: prefix_init: corrupt prefix
+NOTICE:  dbg: process_data_packets: unexpected pkt tag=63
+ERROR:  Wrong key or corrupt data
+-- This must not emit any "dbg:" NOTICE, since it doesn't ask for debug.
+select pgp_sym_decrypt('\xdeadbeef01020304'::bytea, 'key');
+ERROR:  Wrong key or corrupt data

--- a/contrib/pgcrypto/pgp-pgsql.c
+++ b/contrib/pgcrypto/pgp-pgsql.c
@@ -373,74 +373,88 @@ encrypt_internal(int is_pubenc, int is_text,
 
 	init_work(&ctx, is_text, args, &ex);
 
-	if (is_text && pgp_get_unicode_mode(ctx))
+	/*
+	 * The PGP pipeline can ereport() directly (e.g. on cipher init failure),
+	 * bypassing the px_set_debug_handler(NULL) resets on the regular exit
+	 * paths below.  Guard the whole pipeline so the global debug handler
+	 * installed by init_work() cannot outlive this call.
+	 */
+	PG_TRY();
 	{
-		tmp_data = convert_to_utf8(data);
-		if (tmp_data == data)
-			tmp_data = NULL;
+		if (is_text && pgp_get_unicode_mode(ctx))
+		{
+			tmp_data = convert_to_utf8(data);
+			if (tmp_data == data)
+				tmp_data = NULL;
+			else
+				data = tmp_data;
+		}
+
+		src = create_mbuf_from_vardata(data);
+		dst = mbuf_create(VARSIZE(data) + 128);
+
+		/*
+		 * reserve room for header
+		 */
+		mbuf_append(dst, tmp, VARHDRSZ);
+
+		/*
+		 * set key
+		 */
+		if (is_pubenc)
+		{
+			MBuf	   *kbuf = create_mbuf_from_vardata(key);
+
+			err = pgp_set_pubkey(ctx, kbuf,
+								 NULL, 0, 0);
+			mbuf_free(kbuf);
+		}
 		else
-			data = tmp_data;
-	}
+			err = pgp_set_symkey(ctx, (uint8 *) VARDATA(key),
+								 VARSIZE(key) - VARHDRSZ);
 
-	src = create_mbuf_from_vardata(data);
-	dst = mbuf_create(VARSIZE(data) + 128);
+		/*
+		 * encrypt
+		 */
+		if (err >= 0)
+			err = pgp_encrypt(ctx, src, dst);
 
-	/*
-	 * reserve room for header
-	 */
-	mbuf_append(dst, tmp, VARHDRSZ);
+		/*
+		 * check for error
+		 */
+		if (err)
+		{
+			if (tmp_data)
+				clear_and_pfree(tmp_data);
+			pgp_free(ctx);
+			mbuf_free(src);
+			mbuf_free(dst);
+			px_THROW_ERROR(err);
+		}
 
-	/*
-	 * set key
-	 */
-	if (is_pubenc)
-	{
-		MBuf	   *kbuf = create_mbuf_from_vardata(key);
+		/* res_len includes VARHDRSZ */
+		res_len = mbuf_steal_data(dst, &restmp);
+		res = (bytea *) restmp;
+		SET_VARSIZE(res, res_len);
 
-		err = pgp_set_pubkey(ctx, kbuf,
-							 NULL, 0, 0);
-		mbuf_free(kbuf);
-	}
-	else
-		err = pgp_set_symkey(ctx, (uint8 *) VARDATA(key),
-							 VARSIZE(key) - VARHDRSZ);
-
-	/*
-	 * encrypt
-	 */
-	if (err >= 0)
-		err = pgp_encrypt(ctx, src, dst);
-
-	/*
-	 * check for error
-	 */
-	if (err)
-	{
-		if (ex.debug)
-			px_set_debug_handler(NULL);
 		if (tmp_data)
 			clear_and_pfree(tmp_data);
 		pgp_free(ctx);
 		mbuf_free(src);
 		mbuf_free(dst);
-		px_THROW_ERROR(err);
 	}
-
-	/* res_len includes VARHDRSZ */
-	res_len = mbuf_steal_data(dst, &restmp);
-	res = (bytea *) restmp;
-	SET_VARSIZE(res, res_len);
-
-	if (tmp_data)
-		clear_and_pfree(tmp_data);
-	pgp_free(ctx);
-	mbuf_free(src);
-	mbuf_free(dst);
+	PG_CATCH();
+	{
+		px_set_debug_handler(NULL);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	px_set_debug_handler(NULL);
 
 	return res;
 }
+
 
 static bytea *
 decrypt_internal(int is_pubenc, int need_text, text *data,
@@ -460,80 +474,96 @@ decrypt_internal(int is_pubenc, int need_text, text *data,
 
 	init_work(&ctx, need_text, args, &ex);
 
-	src = mbuf_create_from_data((uint8 *) VARDATA(data),
-								VARSIZE(data) - VARHDRSZ);
-	dst = mbuf_create(VARSIZE(data) + 2048);
-
 	/*
-	 * reserve room for header
+	 * As in encrypt_internal(), guard the whole pipeline so the global
+	 * debug handler installed by init_work() cannot survive an error
+	 * thrown from inside the PGP code (including secret-key decryption
+	 * in pgp_set_pubkey()).
 	 */
-	mbuf_append(dst, tmp, VARHDRSZ);
-
-	/*
-	 * set key
-	 */
-	if (is_pubenc)
+	PG_TRY();
 	{
-		uint8	   *psw = NULL;
-		int			psw_len = 0;
-		MBuf	   *kbuf;
+		src = mbuf_create_from_data((uint8 *) VARDATA(data),
+									VARSIZE(data) - VARHDRSZ);
+		dst = mbuf_create(VARSIZE(data) + 2048);
 
-		if (keypsw)
+		/*
+		 * reserve room for header
+		 */
+		mbuf_append(dst, tmp, VARHDRSZ);
+
+		/*
+		 * set key
+		 */
+		if (is_pubenc)
 		{
-			psw = (uint8 *) VARDATA(keypsw);
-			psw_len = VARSIZE(keypsw) - VARHDRSZ;
+			uint8	   *psw = NULL;
+			int			psw_len = 0;
+			MBuf	   *kbuf;
+
+			if (keypsw)
+			{
+				psw = (uint8 *) VARDATA(keypsw);
+				psw_len = VARSIZE(keypsw) - VARHDRSZ;
+			}
+			kbuf = create_mbuf_from_vardata(key);
+			err = pgp_set_pubkey(ctx, kbuf, psw, psw_len, 1);
+			mbuf_free(kbuf);
 		}
-		kbuf = create_mbuf_from_vardata(key);
-		err = pgp_set_pubkey(ctx, kbuf, psw, psw_len, 1);
-		mbuf_free(kbuf);
+		else
+			err = pgp_set_symkey(ctx, (uint8 *) VARDATA(key),
+								 VARSIZE(key) - VARHDRSZ);
+
+		/* decrypt */
+		if (err >= 0)
+		{
+			err = pgp_decrypt(ctx, src, dst);
+
+			if (ex.expect)
+				check_expect(ctx, &ex);
+
+			/* remember the setting */
+			got_unicode = pgp_get_unicode_mode(ctx);
+		}
+
+		mbuf_free(src);
+		pgp_free(ctx);
+
+		if (err)
+		{
+			mbuf_free(dst);
+			px_THROW_ERROR(err);
+		}
+
+		res_len = mbuf_steal_data(dst, &restmp);
+		mbuf_free(dst);
+
+		/* res_len includes VARHDRSZ */
+		res = (bytea *) restmp;
+		SET_VARSIZE(res, res_len);
+
+		if (need_text && got_unicode)
+		{
+			text	   *utf = convert_from_utf8(res);
+
+			if (utf != res)
+			{
+				clear_and_pfree(res);
+				res = utf;
+			}
+		}
 	}
-	else
-		err = pgp_set_symkey(ctx, (uint8 *) VARDATA(key),
-							 VARSIZE(key) - VARHDRSZ);
-
-	/* decrypt */
-	if (err >= 0)
-	{
-		err = pgp_decrypt(ctx, src, dst);
-
-		if (ex.expect)
-			check_expect(ctx, &ex);
-
-		/* remember the setting */
-		got_unicode = pgp_get_unicode_mode(ctx);
-	}
-
-	mbuf_free(src);
-	pgp_free(ctx);
-
-	if (err)
+	PG_CATCH();
 	{
 		px_set_debug_handler(NULL);
-		mbuf_free(dst);
-		px_THROW_ERROR(err);
+		PG_RE_THROW();
 	}
+	PG_END_TRY();
 
-	res_len = mbuf_steal_data(dst, &restmp);
-	mbuf_free(dst);
-
-	/* res_len includes VARHDRSZ */
-	res = (bytea *) restmp;
-	SET_VARSIZE(res, res_len);
-
-	if (need_text && got_unicode)
-	{
-		text	   *utf = convert_from_utf8(res);
-
-		if (utf != res)
-		{
-			clear_and_pfree(res);
-			res = utf;
-		}
-	}
 	px_set_debug_handler(NULL);
 
 	return res;
 }
+
 
 /*
  * Wrappers for symmetric-key functions

--- a/contrib/pgcrypto/sql/pgp-decrypt.sql
+++ b/contrib/pgcrypto/sql/pgp-decrypt.sql
@@ -339,3 +339,19 @@ ww0EBAMC8wIKbtvzJtxi0jABUleCwFJWGCkYKcsNdABqdtXaU2VjcmV0LtMUlnPH3A2QBmZrcucm
 =6aqD
 -----END PGP MESSAGE-----
 '), 'wrong key', 'ignore-cipher-failure=1');
+
+-- Check that an error thrown from inside the PGP pipeline does not leave
+-- the debug handler installed.  Decrypt the broken-bf message from above
+-- with debug=1: if Blowfish is unsupported, cipher setup ereports from
+-- the middle of the pipeline; otherwise decryption fails normally.
+select pgp_sym_decrypt(dearmor('
+-----BEGIN PGP MESSAGE-----
+
+ww0EBAMC8wIKbtvzJtxi0jABUleCwFJWGCkYKcsNdABqdtXaU2VjcmV0LtMUlnPH3A2QBmZrcucm
+1GPb/s2Bkdg=
+=6aqD
+-----END PGP MESSAGE-----
+'), 'wrong key', 'debug=1');
+
+-- This must not emit any "dbg:" NOTICE, since it doesn't ask for debug.
+select pgp_sym_decrypt('\xdeadbeef01020304'::bytea, 'key');


### PR DESCRIPTION
After CVE-2026-14663, cipher initialization failures can ereport() from inside the PGP pipeline.  With debug=1, that could bypass the regular px_set_debug_handler(NULL) cleanup and leave the global pgcrypto debug handler installed in the backend, making later non-debug calls emit "dbg: ..." NOTICEs.

Wrap the encrypt and decrypt pipelines in PG_TRY()/PG_CATCH() to reset the handler before rethrowing, and keep the normal-path reset after PG_END_TRY() since PG_FINALLY() is not available on the PG 9.4 base.

Add a regression test that verifies a failed debug call does not leak debug NOTICEs into a subsequent non-debug call.

Reported-by: Zhenglong Li <zhenglong.li@enterprisedb.com>
(cherry picked from commit af4b3f3b4eafc239abdc75cc5f467ca5de5bff2e)
