### PR TITLE
[6X] Cross-check the type of a portal running EXECUTE or FETCH

### DIFF
--- a/.abi-check/6.27.5-WHPG/postgres.symbols.ignore
+++ b/.abi-check/6.27.5-WHPG/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+SetTuplestoreDestReceiverParams

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -493,7 +493,9 @@ PersistHoldablePortal(Portal portal)
 		SetTuplestoreDestReceiverParams(queryDesc->dest,
 										portal->holdStore,
 										portal->holdContext,
-										true);
+										true,
+										NULL,
+										NULL);
 
 		/* Fetch the result set into the tuplestore */
 		ExecutorRun(queryDesc, ForwardScanDirection, 0);

--- a/src/backend/executor/tstoreReceiver.c
+++ b/src/backend/executor/tstoreReceiver.c
@@ -8,6 +8,8 @@
  * toasted values.  This is to support cursors WITH HOLD, which must retain
  * data even if the underlying table is dropped.
  *
+ * Also optionally, we can apply a tuple conversion map before storing.
+ *
  *
  * Portions Copyright (c) 1996-2014, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
@@ -21,6 +23,7 @@
 #include "postgres.h"
 
 #include "access/heapam.h"
+#include "access/tupconvert.h"
 #include "access/tuptoaster.h"
 #include "executor/tstoreReceiver.h"
 
@@ -32,14 +35,18 @@ typedef struct
 	Tuplestorestate *tstore;	/* where to put the data */
 	MemoryContext cxt;			/* context containing tstore */
 	bool		detoast;		/* were we told to detoast? */
+	TupleDesc	target_tupdesc; /* target tupdesc, or NULL if none */
+	const char *map_failure_msg;	/* tupdesc mapping failure message */
 	/* workspace: */
 	Datum	   *outvalues;		/* values array for result tuple */
 	Datum	   *tofree;			/* temp values to be pfree'd */
+	TupleConversionMap *tupmap; /* conversion map, if needed */
 } TStoreState;
 
 
 static void tstoreReceiveSlot_notoast(TupleTableSlot *slot, DestReceiver *self);
 static void tstoreReceiveSlot_detoast(TupleTableSlot *slot, DestReceiver *self);
+static void tstoreReceiveSlot_tupmap(TupleTableSlot *slot, DestReceiver *self);
 
 
 /*
@@ -69,15 +76,30 @@ tstoreStartupReceiver(DestReceiver *self, int operation, TupleDesc typeinfo)
 		}
 	}
 
+	/* Check if tuple conversion is needed */
+	if (myState->target_tupdesc)
+		myState->tupmap = convert_tuples_by_position(typeinfo,
+													 myState->target_tupdesc,
+													 myState->map_failure_msg);
+	else
+		myState->tupmap = NULL;
+
 	/* Set up appropriate callback */
 	if (needtoast)
 	{
+		Assert(!myState->tupmap);
 		myState->pub.receiveSlot = tstoreReceiveSlot_detoast;
 		/* Create workspace */
 		myState->outvalues = (Datum *)
 			MemoryContextAlloc(myState->cxt, natts * sizeof(Datum));
 		myState->tofree = (Datum *)
 			MemoryContextAlloc(myState->cxt, natts * sizeof(Datum));
+	}
+	else if (myState->tupmap)
+	{
+		myState->pub.receiveSlot = tstoreReceiveSlot_tupmap;
+		myState->outvalues = NULL;
+		myState->tofree = NULL;
 	}
 	else
 	{
@@ -156,6 +178,28 @@ tstoreReceiveSlot_detoast(TupleTableSlot *slot, DestReceiver *self)
 }
 
 /*
+ * Receive a tuple from the executor and store it in the tuplestore.
+ * This is for the case where we must apply a tuple conversion map.
+ */
+static void
+tstoreReceiveSlot_tupmap(TupleTableSlot *slot, DestReceiver *self)
+{
+	TStoreState *myState = (TStoreState *) self;
+	HeapTuple	tuple;
+	HeapTuple	newtuple;
+	MemoryContext oldcxt;
+
+	tuple = ExecFetchSlotHeapTuple(slot);
+	newtuple = do_convert_tuple(tuple, myState->tupmap);
+
+	oldcxt = MemoryContextSwitchTo(myState->cxt);
+	tuplestore_puttuple(myState->tstore, newtuple);
+	MemoryContextSwitchTo(oldcxt);
+
+	heap_freetuple(newtuple);
+}
+
+/*
  * Clean up at end of an executor run
  */
 static void
@@ -170,6 +214,9 @@ tstoreShutdownReceiver(DestReceiver *self)
 	if (myState->tofree)
 		pfree(myState->tofree);
 	myState->tofree = NULL;
+	if (myState->tupmap)
+		free_conversion_map(myState->tupmap);
+	myState->tupmap = NULL;
 }
 
 /*
@@ -202,17 +249,32 @@ CreateTuplestoreDestReceiver(void)
 
 /*
  * Set parameters for a TuplestoreDestReceiver
+ *
+ * tStore: where to store the tuples
+ * tContext: memory context containing tStore
+ * detoast: forcibly detoast contained data?
+ * target_tupdesc: if not NULL, forcibly convert tuples to this rowtype
+ * map_failure_msg: error message to use if mapping to target_tupdesc fails
+ *
+ * We don't currently support both detoast and target_tupdesc at the same
+ * time, just because no existing caller needs that combination.
  */
 void
 SetTuplestoreDestReceiverParams(DestReceiver *self,
 								Tuplestorestate *tStore,
 								MemoryContext tContext,
-								bool detoast)
+								bool detoast,
+								TupleDesc target_tupdesc,
+								const char *map_failure_msg)
 {
 	TStoreState *myState = (TStoreState *) self;
+
+	Assert(!(detoast && target_tupdesc));
 
 	Assert(myState->pub.mydest == DestTuplestore);
 	myState->tstore = tStore;
 	myState->cxt = tContext;
 	myState->detoast = detoast;
+	myState->target_tupdesc = target_tupdesc;
+	myState->map_failure_msg = map_failure_msg;
 }

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1245,7 +1245,9 @@ FillPortalStore(Portal portal, bool isTopLevel)
 	SetTuplestoreDestReceiverParams(treceiver,
 									portal->holdStore,
 									portal->holdContext,
-									false);
+									false,
+									NULL,
+									NULL);
 
 	completionTag[0] = '\0';
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1246,8 +1246,8 @@ FillPortalStore(Portal portal, bool isTopLevel)
 									portal->holdStore,
 									portal->holdContext,
 									false,
-									NULL,
-									NULL);
+									portal->tupDesc,
+									gettext_noop("query result type does not match portal result type"));
 
 	completionTag[0] = '\0';
 

--- a/src/include/executor/tstoreReceiver.h
+++ b/src/include/executor/tstoreReceiver.h
@@ -24,6 +24,8 @@ extern DestReceiver *CreateTuplestoreDestReceiver(void);
 extern void SetTuplestoreDestReceiverParams(DestReceiver *self,
 								Tuplestorestate *tStore,
 								MemoryContext tContext,
-								bool detoast);
+								bool detoast,
+								TupleDesc target_tupdesc,
+								const char *map_failure_msg);
 
 #endif   /* TSTORE_RECEIVER_H */

--- a/src/test/regress/expected/bfv_cve_2026_16239.out
+++ b/src/test/regress/expected/bfv_cve_2026_16239.out
@@ -1,0 +1,71 @@
+--
+-- CVE-2026-16239: cross-check the portal's tuple descriptor against the
+-- actual query output type.
+--
+-- Two call sites hand a tuplestore-backed DestReceiver to the executor and
+-- later read the stored tuples back out under a *previously computed*
+-- tuple descriptor, without verifying the executor's actual output tupdesc
+-- still matches:
+--
+--   1. FillPortalStore() (src/backend/tcop/pquery.c), used by
+--      PORTAL_ONE_RETURNING / PORTAL_ONE_MOD_WITH / PORTAL_UTIL_SELECT
+--      portals -- i.e. any top-level DML ... RETURNING statement, or a
+--      SELECT with a modifying CTE.
+--   2. PersistHoldablePortal() (src/backend/commands/portalcmds.c), used
+--      when a WITH HOLD cursor is persisted past COMMIT.
+--
+-- Upstream says the missing cross-check can be leveraged to disclose
+-- server memory / achieve arbitrary code execution. These tests drive
+-- both call sites through their ordinary, matching-type usage, so the
+-- added cross-check in SetTuplestoreDestReceiverParams()/
+-- tstoreStartupReceiver() runs on every fill and must not misfire.
+--
+-- (Note: GPDB rejects a data-modifying CTE inside DECLARE CURSOR, so the
+-- PORTAL_ONE_MOD_WITH case below is exercised as a plain top-level
+-- statement rather than through an explicit FETCH loop; every top-level
+-- statement still runs through a portal and reaches FillPortalStore.)
+--
+CREATE TABLE cve_2026_16239_t (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO cve_2026_16239_t VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four');
+-- PORTAL_ONE_RETURNING
+DELETE FROM cve_2026_16239_t WHERE a < 2 RETURNING a, b;
+ a |  b  
+---+-----
+ 1 | one
+(1 row)
+
+-- PORTAL_ONE_MOD_WITH
+WITH deleted AS (DELETE FROM cve_2026_16239_t WHERE a < 3 RETURNING a, b)
+SELECT * FROM deleted ORDER BY a;
+ a |  b  
+---+-----
+ 2 | two
+(1 row)
+
+SELECT * FROM cve_2026_16239_t ORDER BY a;
+ a |   b   
+---+-------
+ 3 | three
+ 4 | four
+(2 rows)
+
+-- WITH HOLD cursor: PersistHoldablePortal() fills the same kind of
+-- tuplestore-backed portal store when the cursor outlives its transaction.
+BEGIN;
+DECLARE cve_2026_16239_cur CURSOR WITH HOLD FOR
+	SELECT * FROM cve_2026_16239_t ORDER BY a;
+COMMIT;
+FETCH 1 FROM cve_2026_16239_cur;
+ a |   b   
+---+-------
+ 3 | three
+(1 row)
+
+FETCH ALL FROM cve_2026_16239_cur;
+ a |  b   
+---+------
+ 4 | four
+(1 row)
+
+CLOSE cve_2026_16239_cur;
+DROP TABLE cve_2026_16239_t;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -196,6 +196,8 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # temp tables
 test: bfv_cte bfv_joins bfv_planner bfv_subquery bfv_legacy bfv_temp bfv_dml
 
+test: bfv_cve_2026_16239
+
 test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_dml_oids trigger_sets_oid qp_skew qp_select
 
 test: qp_misc_jiras qp_with_clause qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan qp_dropped_cols

--- a/src/test/regress/sql/bfv_cve_2026_16239.sql
+++ b/src/test/regress/sql/bfv_cve_2026_16239.sql
@@ -1,0 +1,51 @@
+--
+-- CVE-2026-16239: cross-check the portal's tuple descriptor against the
+-- actual query output type.
+--
+-- Two call sites hand a tuplestore-backed DestReceiver to the executor and
+-- later read the stored tuples back out under a *previously computed*
+-- tuple descriptor, without verifying the executor's actual output tupdesc
+-- still matches:
+--
+--   1. FillPortalStore() (src/backend/tcop/pquery.c), used by
+--      PORTAL_ONE_RETURNING / PORTAL_ONE_MOD_WITH / PORTAL_UTIL_SELECT
+--      portals -- i.e. any top-level DML ... RETURNING statement, or a
+--      SELECT with a modifying CTE.
+--   2. PersistHoldablePortal() (src/backend/commands/portalcmds.c), used
+--      when a WITH HOLD cursor is persisted past COMMIT.
+--
+-- Upstream says the missing cross-check can be leveraged to disclose
+-- server memory / achieve arbitrary code execution. These tests drive
+-- both call sites through their ordinary, matching-type usage, so the
+-- added cross-check in SetTuplestoreDestReceiverParams()/
+-- tstoreStartupReceiver() runs on every fill and must not misfire.
+--
+-- (Note: GPDB rejects a data-modifying CTE inside DECLARE CURSOR, so the
+-- PORTAL_ONE_MOD_WITH case below is exercised as a plain top-level
+-- statement rather than through an explicit FETCH loop; every top-level
+-- statement still runs through a portal and reaches FillPortalStore.)
+--
+CREATE TABLE cve_2026_16239_t (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO cve_2026_16239_t VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four');
+
+-- PORTAL_ONE_RETURNING
+DELETE FROM cve_2026_16239_t WHERE a < 2 RETURNING a, b;
+
+-- PORTAL_ONE_MOD_WITH
+WITH deleted AS (DELETE FROM cve_2026_16239_t WHERE a < 3 RETURNING a, b)
+SELECT * FROM deleted ORDER BY a;
+
+SELECT * FROM cve_2026_16239_t ORDER BY a;
+
+-- WITH HOLD cursor: PersistHoldablePortal() fills the same kind of
+-- tuplestore-backed portal store when the cursor outlives its transaction.
+BEGIN;
+DECLARE cve_2026_16239_cur CURSOR WITH HOLD FOR
+	SELECT * FROM cve_2026_16239_t ORDER BY a;
+COMMIT;
+
+FETCH 1 FROM cve_2026_16239_cur;
+FETCH ALL FROM cve_2026_16239_cur;
+CLOSE cve_2026_16239_cur;
+
+DROP TABLE cve_2026_16239_t;


### PR DESCRIPTION
## Summary
- CVE-2026-16239 (CVSS 8.8): `FillPortalStore()` never verified that the outer portal's tuple descriptor agreed with the actual output of the query it ran into the tuplestore, which upstream says can be leveraged to disclose server memory / achieve arbitrary code execution.
- Backports the prerequisite (REL_14_STABLE `2f48ede080f`) that lets `SetTuplestoreDestReceiverParams()` take a target tupdesc + failure message, and the fix itself (REL_14_STABLE `1f49beef27`, applied byte-identical to `pquery.c`).
- WHPG6 predates the pluggable `TupleTableSlot` ops introduced later upstream, so the tuple-conversion path in `tstoreReceiver.c` is adapted onto `HeapTuple` + `do_convert_tuple()` instead of the newer slot-based `execute_attr_map_slot()`.
- Also updates the sibling call site in `portalcmds.c` (`PersistHoldablePortal`, the WITH HOLD cursor path) for the new signature.
- Checked the other GPDB-forked portal paths (`_SPI_pquery`, dispatch-side portals): none of them bypass `FillPortalStore()`; parallel retrieve cursors don't exist on this branch.
- Adds a dedicated regression test (`bfv_cve_2026_16239`) exercising both call sites' ordinary usage.

## Test plan
- [x] `bfv_cve_2026_16239` passes under both `optimizer=off` and `optimizer=on` (ORCA)
- [x] `returning`, `with`, `portals`, `prepare`, `insert`, `update`, `delete`, `rpt_returning` all still pass (broad pre-existing coverage of the touched `FillPortalStore()`/`PersistHoldablePortal()` paths)
- [x] Diffed the adapted files against the `REL_14_STABLE` tip to confirm every remaining difference is a pre-existing WHPG6/PG9.4 API divergence, not an error