### PR TITLE
Cross-check the type of a portal running EXECUTE or FETCH

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -13,3 +13,4 @@ MainLWLockNames
 choose_setop_type
 gp_resgroup_print_operator_memory_limits
 pqFunctionCall3
+SetTuplestoreDestReceiverParams

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2313,7 +2313,9 @@ static QueryDesc *build_querydesc(Portal portal, char *sql)
 	SetTuplestoreDestReceiverParams(destReceiver,
 									portal->holdStore,
 									portal->holdContext,
-									false);
+									false,
+									NULL,
+									NULL);
 
 	/*
 	 * Parse the SQL string into a list of raw parse trees.

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -533,7 +533,9 @@ PersistHoldablePortal(Portal portal)
 		SetTuplestoreDestReceiverParams(queryDesc->dest,
 										portal->holdStore,
 										portal->holdContext,
-										true);
+										true,
+										NULL,
+										NULL);
 
 		/* Fetch the result set into the tuplestore */
 		ExecutorRun(queryDesc, direction, 0L, false);

--- a/src/backend/executor/tstoreReceiver.c
+++ b/src/backend/executor/tstoreReceiver.c
@@ -8,6 +8,8 @@
  * toasted values.  This is to support cursors WITH HOLD, which must retain
  * data even if the underlying table is dropped.
  *
+ * Also optionally, we can apply a tuple conversion map before storing.
+ *
  *
  * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
@@ -21,6 +23,7 @@
 #include "postgres.h"
 
 #include "access/heapam.h"
+#include "access/tupconvert.h"
 #include "access/tuptoaster.h"
 #include "executor/tstoreReceiver.h"
 
@@ -32,14 +35,19 @@ typedef struct
 	Tuplestorestate *tstore;	/* where to put the data */
 	MemoryContext cxt;			/* context containing tstore */
 	bool		detoast;		/* were we told to detoast? */
+	TupleDesc	target_tupdesc; /* target tupdesc, or NULL if none */
+	const char *map_failure_msg;	/* tupdesc mapping failure message */
 	/* workspace: */
 	Datum	   *outvalues;		/* values array for result tuple */
 	Datum	   *tofree;			/* temp values to be pfree'd */
+	TupleConversionMap *tupmap; /* conversion map, if needed */
+	TupleTableSlot *mapslot;	/* slot for mapped tuples */
 } TStoreState;
 
 
 static bool tstoreReceiveSlot_notoast(TupleTableSlot *slot, DestReceiver *self);
 static bool tstoreReceiveSlot_detoast(TupleTableSlot *slot, DestReceiver *self);
+static bool tstoreReceiveSlot_tupmap(TupleTableSlot *slot, DestReceiver *self);
 
 
 /*
@@ -70,27 +78,46 @@ tstoreStartupReceiver(DestReceiver *self, int operation, TupleDesc typeinfo)
 		}
 	}
 
+	/* Check if tuple conversion is needed */
+	if (myState->target_tupdesc)
+		myState->tupmap = convert_tuples_by_position(typeinfo,
+													 myState->target_tupdesc,
+													 myState->map_failure_msg);
+	else
+		myState->tupmap = NULL;
+
 	/* Set up appropriate callback */
 	if (needtoast)
 	{
+		Assert(!myState->tupmap);
 		myState->pub.receiveSlot = tstoreReceiveSlot_detoast;
 		/* Create workspace */
 		myState->outvalues = (Datum *)
 			MemoryContextAlloc(myState->cxt, natts * sizeof(Datum));
 		myState->tofree = (Datum *)
 			MemoryContextAlloc(myState->cxt, natts * sizeof(Datum));
+		myState->mapslot = NULL;
+	}
+	else if (myState->tupmap)
+	{
+		myState->pub.receiveSlot = tstoreReceiveSlot_tupmap;
+		myState->outvalues = NULL;
+		myState->tofree = NULL;
+		myState->mapslot = MakeSingleTupleTableSlot(myState->target_tupdesc,
+													&TTSOpsVirtual);
 	}
 	else
 	{
 		myState->pub.receiveSlot = tstoreReceiveSlot_notoast;
 		myState->outvalues = NULL;
 		myState->tofree = NULL;
+		myState->mapslot = NULL;
 	}
 }
 
 /*
  * Receive a tuple from the executor and store it in the tuplestore.
- * This is for the easy case where we don't have to detoast.
+ * This is for the easy case where we don't have to detoast nor map anything.
  */
 static bool
 tstoreReceiveSlot_notoast(TupleTableSlot *slot, DestReceiver *self)
@@ -159,6 +186,21 @@ tstoreReceiveSlot_detoast(TupleTableSlot *slot, DestReceiver *self)
 }
 
 /*
+ * Receive a tuple from the executor and store it in the tuplestore.
+ * This is for the case where we must apply a tuple conversion map.
+ */
+static bool
+tstoreReceiveSlot_tupmap(TupleTableSlot *slot, DestReceiver *self)
+{
+	TStoreState *myState = (TStoreState *) self;
+
+	execute_attr_map_slot(myState->tupmap->attrMap, slot, myState->mapslot);
+	tuplestore_puttupleslot(myState->tstore, myState->mapslot);
+
+	return true;
+}
+
+/*
  * Clean up at end of an executor run
  */
 static void
@@ -173,6 +215,12 @@ tstoreShutdownReceiver(DestReceiver *self)
 	if (myState->tofree)
 		pfree(myState->tofree);
 	myState->tofree = NULL;
+	if (myState->tupmap)
+		free_conversion_map(myState->tupmap);
+	myState->tupmap = NULL;
+	if (myState->mapslot)
+		ExecDropSingleTupleTableSlot(myState->mapslot);
+	myState->mapslot = NULL;
 }
 
 /*
@@ -205,17 +253,32 @@ CreateTuplestoreDestReceiver(void)
 
 /*
  * Set parameters for a TuplestoreDestReceiver
+ *
+ * tStore: where to store the tuples
+ * tContext: memory context containing tStore
+ * detoast: forcibly detoast contained data?
+ * target_tupdesc: if not NULL, forcibly convert tuples to this rowtype
+ * map_failure_msg: error message to use if mapping to target_tupdesc fails
+ *
+ * We don't currently support both detoast and target_tupdesc at the same
+ * time, just because no existing caller needs that combination.
  */
 void
 SetTuplestoreDestReceiverParams(DestReceiver *self,
 								Tuplestorestate *tStore,
 								MemoryContext tContext,
-								bool detoast)
+								bool detoast,
+								TupleDesc target_tupdesc,
+								const char *map_failure_msg)
 {
 	TStoreState *myState = (TStoreState *) self;
+
+	Assert(!(detoast && target_tupdesc));
 
 	Assert(myState->pub.mydest == DestTuplestore);
 	myState->tstore = tStore;
 	myState->cxt = tContext;
 	myState->detoast = detoast;
+	myState->target_tupdesc = target_tupdesc;
+	myState->map_failure_msg = map_failure_msg;
 }

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1234,7 +1234,9 @@ FillPortalStore(Portal portal, bool isTopLevel)
 	SetTuplestoreDestReceiverParams(treceiver,
 									portal->holdStore,
 									portal->holdContext,
-									false);
+									false,
+									portal->tupDesc,
+									gettext_noop("query result type does not match portal result type"));
 
 	completionTag[0] = '\0';
 

--- a/src/include/executor/tstoreReceiver.h
+++ b/src/include/executor/tstoreReceiver.h
@@ -24,6 +24,8 @@ extern DestReceiver *CreateTuplestoreDestReceiver(void);
 extern void SetTuplestoreDestReceiverParams(DestReceiver *self,
 											Tuplestorestate *tStore,
 											MemoryContext tContext,
-											bool detoast);
+											bool detoast,
+											TupleDesc target_tupdesc,
+											const char *map_failure_msg);
 
 #endif							/* TSTORE_RECEIVER_H */

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -186,3 +186,30 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
 ------+-----------+-----------------
 (0 rows)
 
+--
+-- Cross-check the result type of a portal running EXECUTE or FETCH
+-- (CVE-2026-16239).  A cursor OPENed FOR EXECUTE of a prepared statement
+-- captures the expected result tupdesc when the cursor is opened; if the
+-- prepared statement is deallocated and re-prepared with a different
+-- result type before the cursor is fetched, the FETCH must error out
+-- instead of silently reinterpreting the new tuple's bytes as the old
+-- type.
+CREATE FUNCTION portal_result_type_check() RETURNS void AS $$
+DECLARE
+    cur refcursor;
+    rec record;
+BEGIN
+    PREPARE portal_type_check_p AS SELECT 1::int AS a;
+    OPEN cur FOR EXECUTE 'EXECUTE portal_type_check_p';
+    DEALLOCATE portal_type_check_p;
+    PREPARE portal_type_check_p AS SELECT 'mismatch'::text AS a;
+    FETCH cur INTO rec;
+    RAISE NOTICE 'got: %', rec.a;
+    DEALLOCATE portal_type_check_p;
+END;
+$$ LANGUAGE plpgsql;
+SELECT portal_result_type_check();
+ERROR:  query result type does not match portal result type
+DETAIL:  Returned type text does not match expected type integer in column 1.
+CONTEXT:  PL/pgSQL function portal_result_type_check() line 10 at FETCH
+DROP FUNCTION portal_result_type_check();

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -188,3 +188,32 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
 ------+-----------+-----------------
 (0 rows)
 
+--
+-- Cross-check the result type of a portal running EXECUTE or FETCH
+-- (CVE-2026-16239).  A cursor OPENed FOR EXECUTE of a prepared statement
+-- captures the expected result tupdesc when the cursor is opened; if the
+-- prepared statement is deallocated and re-prepared with a different
+-- result type before the cursor is fetched, the FETCH must error out
+-- instead of silently reinterpreting the new tuple's bytes as the old
+-- type.
+CREATE FUNCTION portal_result_type_check() RETURNS void AS $$
+DECLARE
+    cur refcursor;
+    rec record;
+BEGIN
+    PREPARE portal_type_check_p AS SELECT 1::int AS a;
+    OPEN cur FOR EXECUTE 'EXECUTE portal_type_check_p';
+    DEALLOCATE portal_type_check_p;
+    PREPARE portal_type_check_p AS SELECT 'mismatch'::text AS a;
+    FETCH cur INTO rec;
+    RAISE NOTICE 'got: %', rec.a;
+    DEALLOCATE portal_type_check_p;
+END;
+$$ LANGUAGE plpgsql;
+SELECT portal_result_type_check();
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+ERROR:  query result type does not match portal result type
+DETAIL:  Returned type text does not match expected type integer in column 1.
+CONTEXT:  PL/pgSQL function portal_result_type_check() line 10 at FETCH
+DROP FUNCTION portal_result_type_check();

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -79,3 +79,30 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
+
+--
+-- Cross-check the result type of a portal running EXECUTE or FETCH
+-- (CVE-2026-16239).  A cursor OPENed FOR EXECUTE of a prepared statement
+-- captures the expected result tupdesc when the cursor is opened; if the
+-- prepared statement is deallocated and re-prepared with a different
+-- result type before the cursor is fetched, the FETCH must error out
+-- instead of silently reinterpreting the new tuple's bytes as the old
+-- type.
+CREATE FUNCTION portal_result_type_check() RETURNS void AS $$
+DECLARE
+    cur refcursor;
+    rec record;
+BEGIN
+    PREPARE portal_type_check_p AS SELECT 1::int AS a;
+    OPEN cur FOR EXECUTE 'EXECUTE portal_type_check_p';
+    DEALLOCATE portal_type_check_p;
+    PREPARE portal_type_check_p AS SELECT 'mismatch'::text AS a;
+    FETCH cur INTO rec;
+    RAISE NOTICE 'got: %', rec.a;
+    DEALLOCATE portal_type_check_p;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT portal_result_type_check();
+
+DROP FUNCTION portal_result_type_check();


### PR DESCRIPTION
## Summary
- CVE-2026-16239 (CVSS 8.8): `FillPortalStore()` never verified that the outer portal's tuple descriptor agreed with the actual output of the query it ran into the tuplestore. Upstream says this can be leveraged to disclose server memory / achieve arbitrary code execution.
- Backports the prerequisite (REL_14_STABLE `2f48ede080f`) that lets `SetTuplestoreDestReceiverParams()` take a target tupdesc + failure message, and the fix itself (REL_14_STABLE `1f49beef27`), applied to `pquery.c`'s `FillPortalStore()`.
- Updates the two other WHPG7-only callers of `SetTuplestoreDestReceiverParams()` (`PersistHoldablePortal` in `portalcmds.c`, and the ANALYZE sample-rows dispatcher in `analyze.c`) for the new signature, passing `NULL, NULL` to match upstream's own non-security callers.
- Checked GPDB's other portal paths: RETRIEVE (parallel retrieve cursor) goes through `UtilityTupleDescriptor()` → the same `FillPortalStore()` code path, so it's covered without any separate change.
- Adds a regression test to `prepare.sql` reproducing the vulnerability class via a PL/pgSQL cursor `OPEN ... FOR EXECUTE` of a prepared statement that's deallocated and re-prepared with a mismatched type before the cursor is fetched.
- See also the sibling WHPG6 backport in #242.

## Test plan
- [x] Reproduced the vulnerability live on the unpatched build: fetching a `text` value through a portal that expects `int4` returns the value's raw bytes reinterpreted as an integer. Confirmed the patched build raises `query result type does not match portal result type` instead.
- [x] New `prepare` test passes cleanly (both `prepare.out` and the ORCA-enabled `prepare_optimizer.out`) through the real `pg_regress` harness.
- [x] Manually exercised every `FillPortalStore()`-driven strategy (EXECUTE, FETCH, modifying-CTE) to confirm no behavior change on non-mismatched input.
- [x] Diffed the adapted files against the `REL_14_STABLE` tip to confirm every remaining difference is a pre-existing WHPG7/PG12 API divergence, not an error.