### PR TITLE
[CVE-2026-14679] parser/executor/pl: guard FUNC_MAX_ARGS-sized arrays against overrun

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1329,7 +1329,7 @@ MatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 	Oid		   *p_argtypes;
 	char	  **p_argnames;
 	char	   *p_argmodes;
-	bool		arggiven[FUNC_MAX_ARGS];
+	bool	   *arggiven;
 	bool		isnull;
 	int			ap;				/* call args position */
 	int			pp;				/* proargs position */
@@ -1351,8 +1351,8 @@ MatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 	Assert(p_argnames != NULL);
 
 	/* initialize state for matching */
-	*argnumbers = (int *) palloc(pronargs * sizeof(int));
-	memset(arggiven, false, pronargs * sizeof(bool));
+	*argnumbers = palloc_array(int, pronargs);
+	arggiven = palloc0_array(bool, pronallargs);
 
 	/* there are numposargs positional args before the named args */
 	for (ap = 0; ap < numposargs; ap++)

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -1293,6 +1293,20 @@ eval_windowfunction(WindowAggState *winstate, WindowStatePerFunc perfuncstate,
 	oldContext = MemoryContextSwitchTo(winstate->ss.ps.ps_ExprContext->ecxt_per_tuple_memory);
 
 	/*
+	 * Protect fixed-size fcinfo.  Ordinarily this would have been checked
+	 * while creating the WindowFunc, but it's possible that we are looking at
+	 * a parsetree from a stored view that was made by a server executable
+	 * with a different value of FUNC_MAX_ARGS.
+	 */
+	if (perfuncstate->numArguments > FUNC_MAX_ARGS)
+		ereport(ERROR,
+				(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+				 errmsg_plural("cannot pass more than %d argument to a function",
+							   "cannot pass more than %d arguments to a function",
+							   FUNC_MAX_ARGS,
+							   FUNC_MAX_ARGS)));
+
+	/*
 	 * We don't pass any normal arguments to a window function, but we do pass
 	 * it the number of arguments, in order to permit window function
 	 * implementations to support varying numbers of arguments.  The real info
@@ -3006,6 +3020,25 @@ initialize_peragg(WindowAggState *winstate, WindowFunc *wfunc,
 	ListCell   *lc;
 
 	numArguments = list_length(wfunc->args);
+
+	/*
+	 * Check the number of arguments, to protect fixed-size arrays here and
+	 * later in node execution.
+	 *
+	 * Aggregates can have at most FUNC_MAX_ARGS-1 args (compare
+	 * AggregateCreate, whose error message we want to match).  Ordinarily
+	 * this would have been checked while creating the WindowFunc, but it's
+	 * possible that we are looking at a parsetree from a stored view that was
+	 * made by a server executable with a different value of FUNC_MAX_ARGS, or
+	 * an executable in which parse_func.c didn't enforce the correct limit.
+	 */
+	if (numArguments > FUNC_MAX_ARGS - 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+				 errmsg_plural("aggregates cannot have more than %d argument",
+							   "aggregates cannot have more than %d arguments",
+							   FUNC_MAX_ARGS - 1,
+							   FUNC_MAX_ARGS - 1)));
 
 	i = 0;
 	foreach(lc, wfunc->args)

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -1927,7 +1927,23 @@ get_aggregate_argtypes(Aggref *aggref, Oid *inputTypes)
 	int			numArguments = 0;
 	ListCell   *lc;
 
-	Assert(list_length(aggref->aggargtypes) <= FUNC_MAX_ARGS);
+	/*
+	 * Check the number of arguments to protect fixed-size arrays in callers.
+	 *
+	 * Aggregates can have at most FUNC_MAX_ARGS-1 args (compare
+	 * AggregateCreate, whose error message we want to match).  Ordinarily
+	 * this would have been checked while creating the Aggref, but it's
+	 * possible that we are looking at a parsetree from a stored view that was
+	 * made by a server executable with a different value of FUNC_MAX_ARGS, or
+	 * an executable in which parse_func.c didn't enforce the correct limit.
+	 */
+	if (list_length(aggref->aggargtypes) > FUNC_MAX_ARGS - 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+				 errmsg_plural("aggregates cannot have more than %d argument",
+							   "aggregates cannot have more than %d arguments",
+							   FUNC_MAX_ARGS - 1,
+							   FUNC_MAX_ARGS - 1)));
 
 	foreach(lc, aggref->aggargtypes)
 	{

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -782,6 +782,22 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		aggref->location = location;
 
 		/*
+		 * The argument-count limit for aggregates is one less than for other
+		 * kinds of functions (cf. AggregateCreate).  Now that we know it's an
+		 * aggregate, apply the stricter limit.  We need an explicit check
+		 * because hypothetical-set aggregates don't have a fixed number of
+		 * arguments, so having matched the pg_proc entry proves nothing.
+		 */
+		if (list_length(fargs) > FUNC_MAX_ARGS - 1)
+			ereport(ERROR,
+					(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+					 errmsg_plural("aggregates cannot have more than %d argument",
+								   "aggregates cannot have more than %d arguments",
+								   FUNC_MAX_ARGS - 1,
+								   FUNC_MAX_ARGS - 1),
+					 parser_errposition(pstate, location)));
+
+		/*
 		 * Reject attempt to call a parameterless aggregate without (*)
 		 * syntax.  This is mere pedantry but some folks insisted ...
 		 *
@@ -860,6 +876,19 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("DISTINCT is supported only for single-argument window aggregates")));
 		}
+
+		/*
+		 * As above, enforce the correct argument-count limit if it's really
+		 * an aggregate.
+		 */
+		if (wfunc->winagg && list_length(fargs) > FUNC_MAX_ARGS - 1)
+			ereport(ERROR,
+					(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+					 errmsg_plural("aggregates cannot have more than %d argument",
+								   "aggregates cannot have more than %d arguments",
+								   FUNC_MAX_ARGS - 1,
+								   FUNC_MAX_ARGS - 1),
+					 parser_errposition(pstate, location)));
 
 		/*
 		 * Reject attempt to call a parameterless aggregate without (*)

--- a/src/backend/utils/fmgr/funcapi.c
+++ b/src/backend/utils/fmgr/funcapi.c
@@ -951,7 +951,7 @@ get_func_arg_info(HeapTuple procTup,
 			ARR_ELEMTYPE(arr) != OIDOID)
 			elog(ERROR, "proallargtypes is not a 1-D Oid array");
 		Assert(numargs >= procStruct->pronargs);
-		*p_argtypes = (Oid *) palloc(numargs * sizeof(Oid));
+		*p_argtypes = palloc_array(Oid, numargs);
 		memcpy(*p_argtypes, ARR_DATA_PTR(arr),
 			   numargs * sizeof(Oid));
 	}
@@ -960,7 +960,7 @@ get_func_arg_info(HeapTuple procTup,
 		/* If no proallargtypes, use proargtypes */
 		numargs = procStruct->proargtypes.dim1;
 		Assert(numargs == procStruct->pronargs);
-		*p_argtypes = (Oid *) palloc(numargs * sizeof(Oid));
+		*p_argtypes = palloc_array(Oid, numargs);
 		memcpy(*p_argtypes, procStruct->proargtypes.values,
 			   numargs * sizeof(Oid));
 	}
@@ -1038,8 +1038,8 @@ get_func_trftypes(HeapTuple procTup,
 			nelems < 0 ||
 			ARR_HASNULL(arr) ||
 			ARR_ELEMTYPE(arr) != OIDOID)
-			elog(ERROR, "protrftypes is not a 1-D Oid array");
-		*p_trftypes = (Oid *) palloc(nelems * sizeof(Oid));
+			elog(ERROR, "protrftypes is not a 1-D Oid array or it contains nulls");
+		*p_trftypes = palloc_array(Oid, nelems);
 		memcpy(*p_trftypes, ARR_DATA_PTR(arr),
 			   nelems * sizeof(Oid));
 

--- a/src/pl/plpgsql/src/pl_comp.c
+++ b/src/pl/plpgsql/src/pl_comp.c
@@ -2485,6 +2485,20 @@ compute_function_hashkey(FunctionCallInfo fcinfo,
 
 	if (procStruct->pronargs > 0)
 	{
+		/*
+		 * Protect against overrun of fixed-size hashkey->argtypes array.
+		 * Ordinarily the parser would have checked this long since, but it's
+		 * possible that we are looking at a pg_proc entry that was made by a
+		 * server executable with a different value of FUNC_MAX_ARGS.
+		 */
+		if (procStruct->pronargs > FUNC_MAX_ARGS)
+			ereport(ERROR,
+					(errcode(ERRCODE_TOO_MANY_ARGUMENTS),
+					 errmsg_plural("cannot pass more than %d argument to a function",
+								   "cannot pass more than %d arguments to a function",
+								   FUNC_MAX_ARGS,
+								   FUNC_MAX_ARGS)));
+
 		/* get the argument types */
 		memcpy(hashkey->argtypes, procStruct->proargtypes.values,
 			   procStruct->pronargs * sizeof(Oid));

--- a/src/pl/tcl/pltcl.c
+++ b/src/pl/tcl/pltcl.c
@@ -1401,6 +1401,7 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 	volatile MemoryContext proc_cxt = NULL;
 	Tcl_DString proc_internal_def;
 	Tcl_DString proc_internal_body;
+	Tcl_DString proc_internal_args;
 
 	/* We'll need the pg_proc tuple in any case... */
 	procTup = SearchSysCache1(PROCOID, ObjectIdGetDatum(fn_oid));
@@ -1448,17 +1449,17 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 	 ************************************************************/
 	Tcl_DStringInit(&proc_internal_def);
 	Tcl_DStringInit(&proc_internal_body);
+	Tcl_DStringInit(&proc_internal_args);
 	PG_TRY();
 	{
 		bool		is_trigger = OidIsValid(tgreloid);
 		char		internal_proname[128];
 		HeapTuple	typeTup;
 		Form_pg_type typeStruct;
-		char		proc_internal_args[33 * FUNC_MAX_ARGS];
 		Datum		prosrcdatum;
 		bool		isnull;
 		char	   *proc_source;
-		char		buf[48];
+		char		buf[64];
 		Tcl_Interp *interp;
 		int			i;
 		int			tcl_rc;
@@ -1568,7 +1569,6 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 		 ************************************************************/
 		if (!is_trigger && !is_event_trigger)
 		{
-			proc_internal_args[0] = '\0';
 			for (i = 0; i < prodesc->nargs; i++)
 			{
 				Oid			argtype = procStruct->proargtypes.values[i];
@@ -1601,8 +1601,8 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 				}
 
 				if (i > 0)
-					strcat(proc_internal_args, " ");
-				strcat(proc_internal_args, buf);
+					Tcl_DStringAppend(&proc_internal_args, " ", -1);
+				Tcl_DStringAppend(&proc_internal_args, buf, -1);
 
 				ReleaseSysCache(typeTup);
 			}
@@ -1610,13 +1610,14 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 		else if (is_trigger)
 		{
 			/* trigger procedure has fixed args */
-			strcpy(proc_internal_args,
-				   "TG_name TG_relid TG_table_name TG_table_schema TG_relatts TG_when TG_level TG_op __PLTcl_Tup_NEW __PLTcl_Tup_OLD args");
+			Tcl_DStringAppend(&proc_internal_args,
+							  "TG_name TG_relid TG_table_name TG_table_schema TG_relatts TG_when TG_level TG_op __PLTcl_Tup_NEW __PLTcl_Tup_OLD args",
+							  -1);
 		}
 		else if (is_event_trigger)
 		{
 			/* event trigger procedure has fixed args */
-			strcpy(proc_internal_args, "TG_event TG_tag");
+			Tcl_DStringAppend(&proc_internal_args, "TG_event TG_tag", -1);
 		}
 
 		/************************************************************
@@ -1629,7 +1630,8 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 		 ************************************************************/
 		Tcl_DStringAppendElement(&proc_internal_def, "proc");
 		Tcl_DStringAppendElement(&proc_internal_def, internal_proname);
-		Tcl_DStringAppendElement(&proc_internal_def, proc_internal_args);
+		Tcl_DStringAppendElement(&proc_internal_def,
+								 Tcl_DStringValue(&proc_internal_args));
 
 		/************************************************************
 		 * prefix procedure body with
@@ -1711,6 +1713,7 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 			MemoryContextDelete(proc_cxt);
 		Tcl_DStringFree(&proc_internal_def);
 		Tcl_DStringFree(&proc_internal_body);
+		Tcl_DStringFree(&proc_internal_args);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -1739,6 +1742,7 @@ compile_pltcl_function(Oid fn_oid, Oid tgreloid,
 
 	Tcl_DStringFree(&proc_internal_def);
 	Tcl_DStringFree(&proc_internal_body);
+	Tcl_DStringFree(&proc_internal_args);
 
 	ReleaseSysCache(procTup);
 


### PR DESCRIPTION
## Summary

Backport for WHPG7 / CVE-2026-14679: several fixed-size arrays dimensioned at `FUNC_MAX_ARGS` could be overrun by a function or aggregate declared with an extreme argument count.

The real upstream fix already present in the  history and cherry-picked both of its commits with `-x`, preserving Tom Lane's original authorship and adding `(cherry picked from commit ...)` trailers:

1. `c7f4628382071ef87f5e7fee8939f09db1e5e022` — "Protect some fixed-size arrays that have FUNC_MAX_ARGS elements." — `parse_func.c`, `parse_agg.c`, `nodeWindowAgg.c`, `funcapi.c`, `pl_comp.c`, `pltcl.c`. One conflict (in `funcapi.c`, an incidental `palloc_array()` cleanup unrelated to the security fix itself, caused by this fork's file predating later upstream refactors) — resolved by taking upstream's side, documented as a `WarehousePG adaptation:` note in that commit.
2. `cf44ff5e66353264451ac239b39e9053e8d138e6` — "Replace fixed-size, too-short array with a palloc'd one." — `namespace.c`'s `MatchNamedCall()`: `arggiven[]` needs `pronallargs` entries (which can exceed `FUNC_MAX_ARGS` when a function has OUT parameters), not a fixed `FUNC_MAX_ARGS` array. Applied cleanly, no adaptation needed.