### PR TITLE
[WHPG6] Require superuser to install non-built-in selectivity estimators

### DIFF
--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -250,11 +250,32 @@ DefineOperator(List *names, List *parameters)
 					 errmsg("restriction estimator function %s must return type \"float8\"",
 							NameListToString(restrictionName))));
 
-		/* Require EXECUTE rights for the estimator */
-		aclresult = pg_proc_aclcheck(restrictionOid, GetUserId(), ACL_EXECUTE);
-		if (aclresult != ACLCHECK_OK)
-			aclcheck_error(aclresult, ACL_KIND_PROC,
-						   NameListToString(restrictionName));
+		/*
+		 * If the estimator is not a built-in function, require superuser
+		 * privilege to install it.  This protects against using something
+		 * that is not a restriction estimator or has hard-wired assumptions
+		 * about what data types it is working with.  (Built-in estimators are
+		 * required to defend themselves adequately against unexpected data
+		 * type choices, but it seems impractical to expect that of
+		 * extensions' estimators.)
+		 *
+		 * If it is built-in, only require EXECUTE rights.
+		 */
+		if (restrictionOid >= FirstNormalObjectId)
+		{
+			if (!superuser())
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("must be superuser to specify a non-built-in restriction estimator function")));
+		}
+		else
+		{
+			/* Require EXECUTE rights for the estimator */
+			aclresult = pg_proc_aclcheck(restrictionOid, GetUserId(), ACL_EXECUTE);
+			if (aclresult != ACLCHECK_OK)
+				aclcheck_error(aclresult, ACL_KIND_PROC,
+							   NameListToString(restrictionName));
+		}
 	}
 	else
 		restrictionOid = InvalidOid;
@@ -289,11 +310,22 @@ DefineOperator(List *names, List *parameters)
 			 errmsg("join estimator function %s must return type \"float8\"",
 					NameListToString(joinName))));
 
-		/* Require EXECUTE rights for the estimator */
-		aclresult = pg_proc_aclcheck(joinOid, GetUserId(), ACL_EXECUTE);
-		if (aclresult != ACLCHECK_OK)
-			aclcheck_error(aclresult, ACL_KIND_PROC,
-						   NameListToString(joinName));
+		/* privilege checks are the same as for the restriction estimator */
+		if (joinOid >= FirstNormalObjectId)
+		{
+			if (!superuser())
+				ereport(ERROR,
+						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						 errmsg("must be superuser to specify a non-built-in join estimator function")));
+		}
+		else
+		{
+			/* Require EXECUTE rights for the estimator */
+			aclresult = pg_proc_aclcheck(joinOid, GetUserId(), ACL_EXECUTE);
+			if (aclresult != ACLCHECK_OK)
+				aclcheck_error(aclresult, ACL_KIND_PROC,
+							   NameListToString(joinName));
+		}
 	}
 	else
 		joinOid = InvalidOid;

--- a/src/backend/tsearch/ts_selfuncs.c
+++ b/src/backend/tsearch/ts_selfuncs.c
@@ -108,12 +108,14 @@ tsmatchsel(PG_FUNCTION_ARGS)
 	 * OK, there's a Var and a Const we're dealing with here.  We need the
 	 * Const to be a TSQuery, else we can't do anything useful.  We have to
 	 * check this because the Var might be the TSQuery not the TSVector.
+	 *
+	 * Also check that the Var really is a TSVector, in case this estimator is
+	 * mistakenly attached to some other operator.
 	 */
-	if (((Const *) other)->consttype == TSQUERYOID)
+	if (((Const *) other)->consttype == TSQUERYOID &&
+		vardata.vartype == TSVECTOROID)
 	{
 		/* tsvector @@ tsquery or the other way around */
-		Assert(vardata.vartype == TSVECTOROID);
-
 		selec = tsquerysel(&vardata, ((Const *) other)->constvalue);
 	}
 	else

--- a/src/test/regress/expected/create_operator.out
+++ b/src/test/regress/expected/create_operator.out
@@ -176,3 +176,37 @@ CREATE OPERATOR #*# (
 );
 ERROR:  permission denied for type type_op6
 ROLLBACK;
+-- Should fail. Only superuser may install a non-built-in restriction estimator
+-- (CVE-2026-2004).  fn_restrict_op7 gets a normal, user-space OID, so a
+-- non-superuser must be refused even though the estimator is otherwise valid.
+BEGIN TRANSACTION;
+CREATE ROLE regress_rol_op7;
+CREATE FUNCTION fn_restrict_op7(internal, oid, internal, integer)
+RETURNS float8 LANGUAGE internal AS 'eqsel';
+SET ROLE regress_rol_op7;
+CREATE OPERATOR #!# (
+   leftarg = int4,
+   rightarg = int4,
+   procedure = int4eq,
+   RESTRICT = fn_restrict_op7,
+   JOIN = eqjoinsel
+);
+ERROR:  must be superuser to specify a non-built-in restriction estimator function
+ROLLBACK;
+-- Should fail. Only superuser may install a non-built-in join estimator
+-- (CVE-2026-2004).  A built-in restriction estimator is accepted, but the
+-- non-built-in join estimator is refused.
+BEGIN TRANSACTION;
+CREATE ROLE regress_rol_op8;
+CREATE FUNCTION fn_join_op8(internal, oid, internal, int2, internal)
+RETURNS float8 LANGUAGE internal AS 'eqjoinsel';
+SET ROLE regress_rol_op8;
+CREATE OPERATOR @!@ (
+   leftarg = int4,
+   rightarg = int4,
+   procedure = int4eq,
+   RESTRICT = eqsel,
+   JOIN = fn_join_op8
+);
+ERROR:  must be superuser to specify a non-built-in join estimator function
+ROLLBACK;

--- a/src/test/regress/sql/create_operator.sql
+++ b/src/test/regress/sql/create_operator.sql
@@ -179,3 +179,37 @@ CREATE OPERATOR #*# (
    procedure = fn_op6
 );
 ROLLBACK;
+
+-- Should fail. Only superuser may install a non-built-in restriction estimator
+-- (CVE-2026-2004).  fn_restrict_op7 gets a normal, user-space OID, so a
+-- non-superuser must be refused even though the estimator is otherwise valid.
+BEGIN TRANSACTION;
+CREATE ROLE regress_rol_op7;
+CREATE FUNCTION fn_restrict_op7(internal, oid, internal, integer)
+RETURNS float8 LANGUAGE internal AS 'eqsel';
+SET ROLE regress_rol_op7;
+CREATE OPERATOR #!# (
+   leftarg = int4,
+   rightarg = int4,
+   procedure = int4eq,
+   RESTRICT = fn_restrict_op7,
+   JOIN = eqjoinsel
+);
+ROLLBACK;
+
+-- Should fail. Only superuser may install a non-built-in join estimator
+-- (CVE-2026-2004).  A built-in restriction estimator is accepted, but the
+-- non-built-in join estimator is refused.
+BEGIN TRANSACTION;
+CREATE ROLE regress_rol_op8;
+CREATE FUNCTION fn_join_op8(internal, oid, internal, int2, internal)
+RETURNS float8 LANGUAGE internal AS 'eqjoinsel';
+SET ROLE regress_rol_op8;
+CREATE OPERATOR @!@ (
+   leftarg = int4,
+   rightarg = int4,
+   procedure = int4eq,
+   RESTRICT = eqsel,
+   JOIN = fn_join_op8
+);
+ROLLBACK;


### PR DESCRIPTION
In WHPG6/PostgreSQL 9.4, CREATE OPERATOR is the only path that can attach restriction and join selectivity estimators to an operator. Reject non-superusers when they specify a non-built-in estimator function for either RESTRICT or JOIN.  Built-in estimators keep the existing EXECUTE privilege check.

Also harden tsmatchsel() so it verifies that the variable side is a tsvector before using tsvector statistics.  If the estimator is attached to an unexpected operator, fall back to the default selectivity instead.

Only the portions applicable to the WHPG6 code base are included: network_selfuncs remains unchanged because WHPG6's network estimators are constant-returning stubs; intarray _int_matchsel and the related pg_extension syscache changes do not exist in this branch; and ALTER OPERATOR cannot change estimator functions in WHPG6.

Add regression coverage for the CREATE OPERATOR superuser gate for both restriction and join estimators.

Based on upstream commit ea3bf34986032ba2760538dacbc144b1f6e300fd (CVE-2026-2004), by Tom Lane. Because the surrounding 9.4 code has diverged from upstream, this was reimplemented rather than cherry-picked directly.

Reported-by: Daniel Firer as part of zeroday.cloud
Security: CVE-2026-2004

## Here are some reminders before you submit the pull request
- [ ✅] Add tests for the change
- [ ✅ ] Pass `make installcheck`
