### PR TITLE
Fix reversed coordinator/segment CPUSET split in resource groups

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1753,17 +1753,15 @@ getCpuSetByRole(const char *cpuset)
 		splitcpuset = (char *)cpuset;
 	else
 	{
-		char *scpu = first + 1;
-
 		/* Get result cpuset by IS_QUERY_DISPATCHER(), on coordinator or segment */
 		if (IS_QUERY_DISPATCHER())
-			splitcpuset = scpu;
-		else
 		{
 			char *mcpu = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
 			strncpy(mcpu, cpuset, first - cpuset);
 			splitcpuset = mcpu;
 		}
+		else
+			splitcpuset = first + 1;
 	}
 
 	return splitcpuset;

--- a/src/backend/commands/test/Makefile
+++ b/src/backend/commands/test/Makefile
@@ -1,0 +1,11 @@
+subdir=src/backend/commands
+top_builddir=../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=resgroupcmds
+
+include $(top_srcdir)/src/backend/mock.mk
+
+resgroupcmds.t: \
+    $(MOCK_DIR)/backend/access/hash/hash_mock.o \
+    $(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o

--- a/src/backend/commands/test/resgroupcmds_test.c
+++ b/src/backend/commands/test/resgroupcmds_test.c
@@ -1,0 +1,52 @@
+#include "../resgroupcmds.c"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+/*
+ * getCpuSetByRole() splits CPUSET='<coordinator_cores>;<segment_cores>'
+ * by the role of the current node.  These tests pin the direction of the
+ * split, which was silently reversed once before (commit 8588bc98803).
+ */
+
+static void
+test__getCpuSetByRole_coordinator_takes_part_before_semicolon(void **state)
+{
+    GpIdentity.segindex = COORDINATOR_CONTENT_ID;
+    assert_string_equal(getCpuSetByRole("1;4"), "1");
+    assert_string_equal(getCpuSetByRole("0-3;4-7"), "0-3");
+}
+
+static void
+test__getCpuSetByRole_segment_takes_part_after_semicolon(void **state)
+{
+    GpIdentity.segindex = 0;
+    assert_string_equal(getCpuSetByRole("1;4"), "4");
+    assert_string_equal(getCpuSetByRole("0-3;4-7"), "4-7");
+}
+
+static void
+test__getCpuSetByRole_single_part_shared_by_both_roles(void **state)
+{
+    GpIdentity.segindex = COORDINATOR_CONTENT_ID;
+    assert_string_equal(getCpuSetByRole("1"), "1");
+    GpIdentity.segindex = 0;
+    assert_string_equal(getCpuSetByRole("1"), "1");
+}
+
+int
+main(int argc, char *argv[])
+{
+    cmockery_parse_arguments(argc, argv);
+
+    const UnitTest tests[] = {
+        unit_test(test__getCpuSetByRole_coordinator_takes_part_before_semicolon),
+        unit_test(test__getCpuSetByRole_segment_takes_part_after_semicolon),
+        unit_test(test__getCpuSetByRole_single_part_shared_by_both_roles),
+    };
+
+    MemoryContextInit();
+    return run_tests(tests);
+}


### PR DESCRIPTION
`getCpuSetByRole()` gave the coordinator the part after ';' and segments the part before it, the reverse of the documented CPUSET='<coordinator_cores>;<segment_cores>' syntax, since the refactoring in 8588bc98803. 

Swap the branches back so validation and cgroup cpuset binding apply to the right hosts.