### PR TITLE
[WHPG6] Use FirstBootstrapObjectId for estimator boundary

### DIFF
--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -260,8 +260,14 @@ DefineOperator(List *names, List *parameters)
 		 * extensions' estimators.)
 		 *
 		 * If it is built-in, only require EXECUTE rights.
+		 *
+		 * "Built-in" here means a hand-assigned bootstrap catalog entry
+		 * (OID < FirstBootstrapObjectId); this is WHPG6's equivalent of
+		 * upstream's FirstGenbkiObjectId boundary.  Functions created later
+		 * during initdb (information_schema, system_views, cdb_schema, ...)
+		 * are not built-in for this purpose and must not skip the gate.
 		 */
-		if (restrictionOid >= FirstNormalObjectId)
+		if (restrictionOid >= FirstBootstrapObjectId)
 		{
 			if (!superuser())
 				ereport(ERROR,
@@ -311,7 +317,7 @@ DefineOperator(List *names, List *parameters)
 					NameListToString(joinName))));
 
 		/* privilege checks are the same as for the restriction estimator */
-		if (joinOid >= FirstNormalObjectId)
+		if (joinOid >= FirstBootstrapObjectId)
 		{
 			if (!superuser())
 				ereport(ERROR,


### PR DESCRIPTION
WHPG6 does not define upstream's FirstGenbkiObjectId, but FirstBootstrapObjectId is the equivalent 10000 boundary.  Use it for the RESTRICT and JOIN estimator checks so initdb-created functions with OIDs 10000-16383 do not skip the superuser gate.

This is a defense-in-depth follow-up to
f4c19e561d8d902bfdc9a80a697a4b02f4810b4f.

Existing create_operator tests still cover the user-created estimator path because their helper functions receive normal OIDs.

Suggested-by: Zhang Mingli <avamingli@gmail.com>

Security: CVE-2026-2004
