### PR TITLE
Fix ssh error reporting, a ~/.bashrc deletion hazard, and PAM lockout in CI sshd setup

### DIFF
--- a/concourse/scripts/setup_gpadmin_user.bash
+++ b/concourse/scripts/setup_gpadmin_user.bash
@@ -95,6 +95,35 @@ setup_sshd() {
   # Disable password authentication so builds never hang given bad keys
   sed -ri 's/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
 
+  # The two seds above match nothing on EL9-family images: their stock
+  # sshd_config carries neither "UsePAM yes" nor "PasswordAuthentication
+  # yes", only an Include, AuthorizedKeysFile and Subsystem line, so UsePAM
+  # keeps its built-in default of yes.  The container has no usable PAM
+  # account stack, so sshd accepts gpadmin's key and then refuses the
+  # session:
+  #
+  #   Accepted key RSA SHA256:... found at /home/gpadmin/.ssh/authorized_keys:1
+  #   Access denied for user gpadmin by PAM account configuration [preauth]
+  #
+  # Every bare ssh/rsync from test code then exits 255 while gpssh (pty,
+  # different PAM path) works.  State the settings in a drop-in instead of
+  # patching lines that are not there; the Include sits at the top of
+  # sshd_config and sshd takes the first value it finds, so these win.
+  if grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config; then
+    mkdir -p /etc/ssh/sshd_config.d
+    cat > /etc/ssh/sshd_config.d/00-whpg-ci.conf <<-'SSHD_DROPIN'
+	UsePAM no
+	PasswordAuthentication no
+	SSHD_DROPIN
+  else
+    printf 'UsePAM no\nPasswordAuthentication no\n' >> /etc/ssh/sshd_config
+  fi
+
+  # Privilege separation needs these to exist; they are missing on minimal
+  # container images.
+  install -d -m 711 /var/empty/sshd
+  install -d -m 755 /run/sshd
+
   case "$TEST_OS" in
     centos7)
       test -e /etc/ssh/ssh_host_key || ssh-keygen -f /etc/ssh/ssh_host_key -N '' -t rsa1

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -457,13 +457,18 @@ CHK_PARAMS () {
 		LOG_MSG "[INFO]:-Coordinator IP address array = ${COORDINATOR_IP_ADDRESS[@]}"
 		if [ x"" != x"$STANDBY_HOSTNAME" ];then
 			STANDBY_IP_ADDRESS_ALL=( $( REMOTE_EXECUTE_AND_GET_OUTPUT $STANDBY_HOSTNAME "$IPV4_ADDR_LIST_CMD |$GREP inet|$GREP -v \"127.0.0\"|$AWK '{print \$2}'|$CUT -d'/' -f1" 2>>$LOG_FILE ))
+			STANDBY_IPV4_RETVAL=$?
 			STANDBY_IPV6_ADDRESS_ALL=( $( REMOTE_EXECUTE_AND_GET_OUTPUT $STANDBY_HOSTNAME "$IPV6_ADDR_LIST_CMD |$GREP inet6|$AWK '{print \$2}' |$CUT -d'/' -f1" 2>>$LOG_FILE ))
+			STANDBY_IPV6_RETVAL=$?
 			STANDBY_IP_ADDRESS=(`$ECHO ${STANDBY_IP_ADDRESS_ALL[@]} ${STANDBY_IPV6_ADDRESS_ALL[@]}|$TR ' ' '\n'|$SORT -u|$TR '\n' ' '`)
-			ERROR_CHK $? "obtain IP address of standby Coordinator host" 2
+			ERROR_CHK $(( STANDBY_IPV4_RETVAL != 0 || STANDBY_IPV6_RETVAL != 0 )) "obtain IP address of standby Coordinator host" 2
 			LOG_MSG "[INFO]:-Standby IP address array = ${STANDBY_IP_ADDRESS[@]}"
 			#Check open files value
 			STANDBY_COORDINATOR_OPEN=$( REMOTE_EXECUTE_AND_GET_OUTPUT $STANDBY_HOSTNAME "ulimit -n" )
-			if [ $STANDBY_COORDINATOR_OPEN -lt $OS_OPENFILES ];then
+			RETVAL=$?
+			if [ $RETVAL -ne 0 ];then
+				LOG_MSG "[WARN]:-Failed to obtain open file limit on standby Coordinator host $STANDBY_HOSTNAME" 1
+			elif [ $STANDBY_COORDINATOR_OPEN -lt $OS_OPENFILES ];then
 				LOG_MSG "[WARN]:-Standby Coordinator open file limit is $STANDBY_COORDINATOR_OPEN should be >= $OS_OPENFILES" 1
 				ULIMIT_WARN=1
 			fi
@@ -680,7 +685,10 @@ CHK_OPEN_FILES () {
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	LOG_MSG "[INFO]:-Checking $1"
 	OPEN_VALUE=$( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "ulimit -n" )
-	if [ $OPEN_VALUE -lt $OS_OPENFILES ];then
+	RETVAL=$?
+	if [ $RETVAL -ne 0 ];then
+		LOG_MSG "[WARN]:-Failed to obtain open file limit on host $1" 1
+	elif [ $OPEN_VALUE -lt $OS_OPENFILES ];then
 		LOG_MSG "[WARN]:-Host $1 open files limit is $OPEN_VALUE should be >= $OS_OPENFILES" 1
 		ULIMIT_WARN=1
 	fi
@@ -746,7 +754,14 @@ CHK_QES () {
         # Check that the hostname is not associated with local host
         LOG_MSG "[INFO]:-Checking $GP_HOSTADDRESS $HOSTFILE for localhost set as $GP_HOSTADDRESS"
         LOCAL_COUNT=$( REMOTE_EXECUTE_AND_GET_OUTPUT $GP_HOSTADDRESS "$GREP $GP_HOSTADDRESS $HOSTFILE|$GREP -c localhost")
-        if [ $LOCAL_COUNT -ne 0 ];then
+        RETVAL=$?
+        # RETVAL is the exit status of the "grep -c localhost" pipe, so 1 is
+        # the normal, expected result when the host is not localhost-aliased;
+        # only 255 (ssh connection/authentication failure) means the check
+        # itself never ran.
+        if [ $RETVAL -eq 255 ];then
+            LOG_MSG "[WARN]:-Failed to check $HOSTFILE on $GP_HOSTADDRESS for localhost aliasing" 1
+        elif [ $LOCAL_COUNT -ne 0 ];then
             LOG_MSG "[WARN]:-----------------------------------------------------------" 1
             LOG_MSG "[WARN]:-Host $GP_HOSTADDRESS is assigned as localhost in $HOSTFILE"  1
             LOG_MSG "[WARN]:-This will cause segment->coordinator communication failures" 1

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -261,11 +261,23 @@ REMOTE_EXECUTE_AND_GET_OUTPUT () {
   LOG_MSG "[INFO]:-Start Function $FUNCNAME"
   HOST="$1"
   CMD="echo 'GP_DELIMITER_FOR_IGNORING_BASH_BANNER';$2"
-  OUTPUT=$( $TRUSTED_SHELL "$HOST" "$CMD" | $AWK '/^GP_DELIMITER_FOR_IGNORING_BASH_BANNER/ {seen = 1} seen {print}' | $TAIL -n +2 )
+  # Run the remote command on its own so RETVAL is the ssh/remote status;
+  # a pipeline into the banner filter would leave $? holding the filter's
+  # status instead, hiding connection failures.
+  OUTPUT=$( $TRUSTED_SHELL "$HOST" "$CMD" )
   RETVAL=$?
-  if [ $RETVAL -ne 0 ]; then
- 
-     LOG_MSG "[FATAL]:- Command $CMD on $HOST failed with error status $RETVAL" 2
+  OUTPUT=$( $ECHO "$OUTPUT" | $AWK '/^GP_DELIMITER_FOR_IGNORING_BASH_BANNER/ {seen = 1} seen {print}' | $TAIL -n +2 )
+  if [ $RETVAL -eq 255 ]; then
+     # 255 is ssh's own status for a connection or authentication failure:
+     # the remote command never ran.  Display on stderr: this function's
+     # stdout is the remote command's output, captured by every caller.
+     LOG_MSG "[FATAL]:- Command $CMD on $HOST failed with error status $RETVAL" 2 >&2
+  elif [ $RETVAL -ne 0 ]; then
+     # The remote command ran and exited non-zero.  Callers probe with
+     # grep/test commands for which a non-zero status is a legitimate
+     # negative answer, so record it without raising an error; the status
+     # is passed through to the caller below.
+     LOG_MSG "[INFO]:-Command $CMD on $HOST exited with status $RETVAL"
   else
      LOG_MSG "[INFO]:-Completed $TRUSTED_SHELL $HOST $CMD"
   fi
@@ -274,6 +286,7 @@ REMOTE_EXECUTE_AND_GET_OUTPUT () {
   DEBUG_LEVEL=$INITIAL_DEBUG_LEVEL
   #Return output
   echo "$OUTPUT"
+  return $RETVAL
 }
 
 POSTGRES_VERSION_CHK() {

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -533,27 +533,54 @@ def impl(context, logdir):
     if os.path.exists('{}/recovery_progress.file'.format(log_dir)):
         raise Exception('recovery_progress.file is still present under {}'.format(log_dir))
 
-def backup_bashrc():
+# Whether backup_bashrc() ran for the current scenario.  restore_bashrc()
+# acts only when this is set: a missing backup file does not mean "there was
+# no .bashrc before the test" -- the hooks that call backup_bashrc() can fail
+# before reaching it, and deleting ~/.bashrc on that guess would destroy the
+# user's real file.
+_bashrc_backup_taken = False
+
+
+def _bashrc_paths():
     home_dir = os.environ.get('HOME')
-    file = home_dir + '/.bashrc'
-    backup_fle = home_dir + '/.bashrc.backup'
+    return home_dir + '/.bashrc', home_dir + '/.bashrc.backup'
+
+
+def backup_bashrc():
+    global _bashrc_backup_taken
+    file, backup_fle = _bashrc_paths()
+    _bashrc_backup_taken = False
     if (os.path.isfile(file)):
         command = "cp -f %s %s" % (file, backup_fle)
         result = run_cmd(command)
         if (result[0] != 0):
             raise Exception("Error while backing up bashrc file. STDERR:%s" % (result[2]))
+        _bashrc_backup_taken = True
+    else:
+        # No .bashrc to begin with: remember that, so restore removes whatever
+        # the scenario created rather than leaving it behind.
+        _bashrc_backup_taken = True
     return
 
 
 
 def restore_bashrc():
-    home_dir = os.environ.get('HOME')
-    file = home_dir + '/.bashrc'
-    backup_fle = home_dir + '/.bashrc.backup'
+    global _bashrc_backup_taken
+    file, backup_fle = _bashrc_paths()
+
+    if not _bashrc_backup_taken:
+        # backup_bashrc() never ran for this scenario -- the before hook can
+        # raise before reaching it.  Touching ~/.bashrc now would be acting on
+        # a guess about a file this test did not put there.
+        print("behave: skipping .bashrc restore -- no backup was taken for this scenario")
+        return
+
     if (os.path.isfile(backup_fle)):
         command = "mv -f %s %s" % (backup_fle, file)
     else:
+        # Backup ran and found no .bashrc, so anything here is the scenario's.
         command = "rm -f %s" % (file)
+    _bashrc_backup_taken = False
     result = run_cmd(command)
     if (result[0] != 0):
         raise Exception("Error while restoring up bashrc file. STDERR:%s" % (result[2]))


### PR DESCRIPTION
Three independent fixes in the management-utility and CI shell layer, found
while hardening the behave suite. One commit each.

## 1. `gpMgmt: report ssh failures from REMOTE_EXECUTE_AND_GET_OUTPUT`

The function captured `$?` after piping ssh output through the banner filter
(`awk | tail`), so a failed ssh was reported as success with empty output and
every caller proceeded on an empty string. Its exit status was also always 0
(the function ends with `echo "$OUTPUT"`), leaving the rc checks in
`POSTGRES_VERSION_CHK`, `CHK_FILE`, `CHK_DIR` and gpinitsystem's standby-IP
`ERROR_CHK` dead.

Fix: run ssh separately from the filter so the real status is captured and
returned. `[FATAL]` is reserved for rc 255 (ssh itself failed; the remote
command never ran) and displayed on stderr so it cannot leak into callers'
`$( )` capture; other non-zero statuses are legitimate answers from remote
probes (`grep -c` etc.) and are logged as INFO and passed through.

Caller audit: the function is only ever invoked inside `$( )`; no consumer
runs `set -e`; the one `trap RETRY ERR` (SED_PG_CONF) is dismantled before
returning and its call sites are ERR-exempt `if [ ... ]` conditions. The
revived rc checks all take sane paths.

## 2. `behave: never delete ~/.bashrc when no backup was taken`

`restore_bashrc()` inferred "no backup file = there was no `.bashrc` before
the test" and removed `~/.bashrc` on that guess. When the before hook raises
before reaching `backup_bashrc()` (e.g. cluster unreachable), the after hook
still runs restore — deleting the developer's real `~/.bashrc`. A module flag
now records whether the backup actually ran, and restore acts only on that.

## 3. `ci: disable PAM in sshd via a config drop-in`

The `UsePAM yes` / `PasswordAuthentication yes` seds match nothing on
EL9-family images (stock `sshd_config` has only Include / AuthorizedKeysFile /
Subsystem lines), so UsePAM stays at its default of yes and sshd accepts
gpadmin's key but refuses the session ("Access denied for user gpadmin by PAM
account configuration"). Every bare ssh/rsync exits 255 while gpssh (different
PAM path) works. State the settings in an `sshd_config.d` drop-in when the
stock config includes that directory, append otherwise; also create
`/var/empty/sshd` and `/run/sshd` for privilege separation.

## Verification

- Fix 1: function-level matrix — healthy command rc 0 with output intact;
  remote exit 3 passed through without FATAL; unreachable host rc 255 with
  empty stdout and FATAL on stderr and in the log; banner stripping unchanged
  (rc propagated through a banner-printing stub shell).
- Fix 2: isolated harness over a temporary HOME — existing `.bashrc`
  round-trips through backup/edit/restore; a scenario-created `.bashrc` is
  removed when none existed before; with the backup step skipped, a
  pre-existing `.bashrc` survives restore.
- Fix 3: `bash -n` clean; drop-in heredoc content byte-verified; the same
  approach is running green in CI on Rocky Linux 9 images.
