### PR TITLE
Fix PGresult leak on every DTX protocol command dispatch

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1412,6 +1412,17 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		}
 	}
 
+	/*
+	 * The PGresults (including any waitGxids arrays libpq attached to them)
+	 * are malloc'ed by libpq and were snatched out of the dispatcher state
+	 * by cdbdisp_returnResults(), so they are not released with any memory
+	 * context: they must be cleared here, or every dtx protocol command
+	 * leaks them for the life of the backend.
+	 */
+	CdbPgResults cdb_pgresults = {results, resultCount, 0};
+
+	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+
 	return (numOfFailed == 0);
 }
 


### PR DESCRIPTION
The PGresults returned by CdbDispatchDtxProtocolCommand() are malloc'ed by libpq and snatched out of the dispatcher state, so the caller must PQclear() them (see cdbdisp_dtx.c). doDispatchDtxProtocolCommand() used to do that at its tail, but commit c7a3b6de59f (#85) moved the block into gatherWaitedGxids(), which is now called only from the normal-query path, leaving the DTX protocol path with no cleanup. Since then every DTX protocol command (PREPARE, COMMIT PREPARED, one-phase commit, abort) leaked one PGresult per participating QE in the QD backend, unbounded for the life of the session.

Restore only the missing ownership cleanup, via the existing cdbdisp_clearCdbPgResults() helper. The current DTX protocol path does not consume waitGxids; this patch preserves that behavior and clears the unconsumed PGresults instead of reintroducing waitGxids collection.
