### PR TITLE
Fix potential buffer overrun in regexp match/split functions.

### DIFF
--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -1052,7 +1052,7 @@ setup_regexp_matches(text *orig_str, text *pattern, pg_re_flags *re_flags,
 
 	/* convert string to pg_wchar form for matching */
 	orig_len = VARSIZE_ANY_EXHDR(orig_str);
-	wide_str = (pg_wchar *) palloc(sizeof(pg_wchar) * (orig_len + 1));
+	wide_str = palloc_array(pg_wchar, orig_len + 1);
 	wide_len = pg_mb2wchar_with_len(VARDATA_ANY(orig_str), wide_str, orig_len);
 
 	/* set up the compiled pattern */
@@ -1186,23 +1186,24 @@ setup_regexp_matches(text *orig_str, text *pattern, pg_re_flags *re_flags,
 
 	if (eml > 1)
 	{
-		int64		maxsiz = eml * (int64) maxlen;
 		int			conv_bufsiz;
 
 		/*
 		 * Make the conversion buffer large enough for any substring of
-		 * interest.
+		 * interest. We can't use the original string's byte length as a
+		 * tighter bound, because that assumes the input is validly encoded;
+		 * but pg_mb2wchar_with_len() can accept strings that are invalid in
+		 * the database encoding, and converting such a character back to
+		 * multibyte form can take more bytes than it did in the input.
 		 *
-		 * Worst case: assume we need the maximum size (maxlen*eml), but take
-		 * advantage of the fact that the original string length in bytes is
-		 * an upper bound on the byte length of any fetched substring (and we
-		 * know that len+1 is safe to allocate because the varlena header is
-		 * longer than 1 byte).
+		 * This can't overflow, nor exceed what palloc will accept: maxlen is
+		 * at most wide_len, which is at most orig_len, and we have already
+		 * successfully allocated (orig_len + 1) * sizeof(pg_wchar) bytes for
+		 * wide_str. That relies on eml being no more than sizeof(pg_wchar),
+		 * which is true of all supported encodings.
 		 */
-		if (maxsiz > orig_len)
-			conv_bufsiz = orig_len + 1;
-		else
-			conv_bufsiz = maxsiz + 1;	/* safe since maxsiz < 2^30 */
+		Assert(eml <= sizeof(pg_wchar));
+		conv_bufsiz = maxlen * eml + 1;
 
 		matchctx->conv_buf = palloc(conv_bufsiz);
 		matchctx->conv_bufsiz = conv_bufsiz;


### PR DESCRIPTION
Backport of upstream PostgreSQL commit 890327639962a0ebbb2cc2b81ba747cc381876c3 (REL_14_STABLE) fixing CVE-2026-14664.

Problem: setup_regexp_matches() sizes the buffer used to convert matched substrings back from pg_wchar form at the smaller of maxlen*eml and the original string's byte length, assuming a conversion cannot produce more bytes than the string it came from. That holds only for validly encoded input: pg_mb2wchar_with_len() silently accepts bytes that are invalid in the database encoding, turning each such byte into one pg_wchar, and converting that back can take more bytes than the input did. A string of such bytes overruns the conversion buffer by up to its own length, corrupting adjacent memory. regexp_match(), regexp_matches(), regexp_split_to_table() and regexp_split_to_array() are all affected, reachable from unprivileged SQL.

Fix: drop the tighter bound and always allocate maxlen*eml + 1 bytes.

The upstream commit applies verbatim: the palloc_array() macros it uses are already on main (bd516f4c6e8, 01ec5cea3f1). After this commit setup_regexp_matches() is byte-identical to the REL_14_STABLE tip.

Tests: upstream ships no test change — the overrun requires invalidly-encoded input that cannot be portably injected from SQL. Locally ran char, varchar, text, strings, regex, regex_gp against a rebuilt 3-segment demo cluster (arm64): all pass. CI (amd64) is authoritative.
