### PR TITLE
Backport CVE-2026-14680: reject SQL calls to internal-typed functions; honest nulls in combine functions

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -594,6 +594,10 @@ can_coerce_type(int nargs, const Oid *input_typeids, const Oid *target_typeids,
 		if (inputTypeId == targetTypeId)
 			continue;
 
+		/* reject all cases of casting something else to/from "internal" */
+		if (inputTypeId == INTERNALOID || targetTypeId == INTERNALOID)
+			return false;
+
 		/* 
 		 * ANYTABLE is a special case that can occur when a function is 
 		 * called with a TableValue expression.  A table value expression
@@ -2210,6 +2214,10 @@ find_coercion_pathway(Oid targetTypeId, Oid sourceTypeId,
 	/* Domains are always coercible to and from their base type */
 	if (sourceTypeId == targetTypeId)
 		return COERCION_PATH_RELABELTYPE;
+
+	/* Reject all cases of casting something else to/from "internal" */
+	if (sourceTypeId == INTERNALOID || targetTypeId == INTERNALOID)
+		return COERCION_PATH_NONE;
 
 	/* Look in pg_cast */
 	tuple = SearchSysCache2(CASTSOURCETARGET,

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -675,6 +675,32 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 											   rettype,
 											   false);
 
+	/*
+	 * Reject any attempt to call a function that takes or returns type
+	 * internal from SQL.  (The FUNCDETAIL_COERCION case does not reach this
+	 * check because of the early return above, but that's okay because we
+	 * disallow coercions to or from type internal.)  Note that we are
+	 * checking the resolved argument and result types, so this will reject
+	 * calls to polymorphic functions that pass internal-type arguments.  The
+	 * casting rules should prevent that anyway, since we won't cast internal
+	 * to any polymorphic type, but no harm in being doubly sure.
+	 */
+	for (int i = 0; i < nargsplusdefs; i++)
+	{
+		if (declared_arg_types[i] == INTERNALOID)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("functions accepting type \"%s\" cannot be called explicitly",
+							"internal"),
+					 parser_errposition(pstate, location)));
+	}
+	if (rettype == INTERNALOID)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("functions returning type \"%s\" cannot be called explicitly",
+						"internal"),
+				 parser_errposition(pstate, location)));
+
 	/* perform the necessary typecasting of arguments */
 	make_fn_arguments(pstate, fargs, actual_arg_types, declared_arg_types);
 

--- a/src/backend/parser/parse_oper.c
+++ b/src/backend/parser/parse_oper.c
@@ -833,6 +833,28 @@ make_op(ParseState *pstate, List *opname, Node *ltree, Node *rtree,
 											   opform->oprresult,
 											   false);
 
+	/*
+	 * Reject any attempt to call a function that takes or returns type
+	 * internal from SQL.  This is just like the check in ParseFuncOrColumn,
+	 * but for operator syntax.  (Despite that, we say "function" in the error
+	 * messages; doesn't seem worth having two sets of translatable strings.)
+	 */
+	for (int i = 0; i < nargs; i++)
+	{
+		if (declared_arg_types[i] == INTERNALOID)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("functions accepting type \"%s\" cannot be called explicitly",
+							"internal"),
+					 parser_errposition(pstate, location)));
+	}
+	if (rettype == INTERNALOID)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("functions returning type \"%s\" cannot be called explicitly",
+						"internal"),
+				 parser_errposition(pstate, location)));
+
 	/* perform the necessary typecasting of arguments */
 	make_fn_arguments(pstate, args, actual_arg_types, declared_arg_types);
 

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -4028,6 +4028,10 @@ numeric_combine(PG_FUNCTION_ARGS)
 
 	if (state2 == NULL)
 	{
+		/*
+		 * NULL state2 is easy, just return state1, which we know is already
+		 * in the agg_context
+		 */
 		if (state1 == NULL)
 			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
@@ -4120,6 +4124,10 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 
 	if (state2 == NULL)
 	{
+		/*
+		 * NULL state2 is easy, just return state1, which we know is already
+		 * in the agg_context
+		 */
 		if (state1 == NULL)
 			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
@@ -4635,6 +4643,10 @@ numeric_poly_combine(PG_FUNCTION_ARGS)
 
 	if (state2 == NULL)
 	{
+		/*
+		 * NULL state2 is easy, just return state1, which we know is already
+		 * in the agg_context
+		 */
 		if (state1 == NULL)
 			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
@@ -4876,6 +4888,10 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 
 	if (state2 == NULL)
 	{
+		/*
+		 * NULL state2 is easy, just return state1, which we know is already
+		 * in the agg_context
+		 */
 		if (state1 == NULL)
 			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -7914,11 +7914,20 @@ get_cast_hashentry(PLpgSQL_execstate *estate,
 		 * If there's no cast path according to the parser, fall back to using
 		 * an I/O coercion; this is semantically dubious but matches plpgsql's
 		 * historical behavior.  We would need something of the sort for
-		 * UNKNOWN literals in any case.
+		 * UNKNOWN literals in any case.  The only case we reject is casting
+		 * to/from INTERNAL.  (Other than that case, this is probably now only
+		 * reachable in the case where srctype is UNKNOWN/RECORD.)
 		 */
 		if (cast_expr == NULL)
 		{
 			CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+
+			if (srctype == INTERNALOID || dsttype == INTERNALOID)
+				ereport(ERROR,
+						(errcode(ERRCODE_CANNOT_COERCE),
+						 errmsg("cannot cast type %s to %s",
+								format_type_be(srctype),
+								format_type_be(dsttype))));
 
 			iocoerce->arg = (Expr *) placeholder;
 			iocoerce->resulttype = dsttype;

--- a/src/test/regress/expected/internal_type_calls.out
+++ b/src/test/regress/expected/internal_type_calls.out
@@ -1,6 +1,8 @@
 --
 -- Test that functions taking or returning type "internal" cannot be
--- called or constructed from SQL.  (CVE-2026-14680)
+-- called or constructed from SQL, and that aggregate combine functions
+-- (which WarehousePG exercises heavily via multi-stage aggregation)
+-- still work correctly.  (CVE-2026-14680)
 --
 -- functions returning type internal must not be callable from SQL
 SELECT internal_in('foo');
@@ -33,3 +35,45 @@ SELECT CAST(123 AS internal);
 ERROR:  cannot cast type integer to internal
 LINE 1: SELECT CAST(123 AS internal);
                ^
+-- multi-stage aggregation still works: the planner and executor invoke
+-- the internal-typed transition/combine functions themselves
+CREATE TABLE internal_calls_t(a int, b numeric) DISTRIBUTED BY (a);
+INSERT INTO internal_calls_t SELECT g, g * 1.5 FROM generate_series(1, 1000) g;
+INSERT INTO internal_calls_t VALUES (1001, NULL);
+-- numeric_combine / numeric_avg_combine paths
+SELECT avg(b), sum(b), count(b), stddev(b), var_samp(b) FROM internal_calls_t;
+         avg          |   sum    | count |      stddev      |      var_samp       
+----------------------+----------+-------+------------------+---------------------
+ 750.7500000000000000 | 750750.0 |  1000 | 433.229154143624 | 187687.500000000000
+(1 row)
+
+-- all-NULL input: combine functions must return honest NULL states
+SELECT avg(b), sum(b) FROM internal_calls_t WHERE b IS NULL;
+ avg | sum 
+-----+-----
+     |    
+(1 row)
+
+SELECT a % 3 AS grp, avg(b), sum(b) FROM internal_calls_t GROUP BY 1 ORDER BY 1;
+ grp |         avg          |   sum    
+-----+----------------------+----------
+   0 | 751.5000000000000000 | 250249.5
+   1 | 750.7500000000000000 | 250750.5
+   2 | 750.0000000000000000 | 249750.0
+(3 rows)
+
+-- int8_avg_combine / numeric_poly_combine paths
+SELECT avg(a::int8), sum(a::int8), avg(a::int2), var_pop(a::int8) FROM internal_calls_t;
+         avg          |  sum   |         avg          |      var_pop       
+----------------------+--------+----------------------+--------------------
+ 501.0000000000000000 | 501501 | 501.0000000000000000 | 83500.000000000000
+(1 row)
+
+-- array_agg_combine path
+SELECT array_agg(a ORDER BY a) FROM internal_calls_t WHERE a <= 3;
+ array_agg 
+-----------
+ {1,2,3}
+(1 row)
+
+DROP TABLE internal_calls_t;

--- a/src/test/regress/expected/internal_type_calls.out
+++ b/src/test/regress/expected/internal_type_calls.out
@@ -1,0 +1,35 @@
+--
+-- Test that functions taking or returning type "internal" cannot be
+-- called or constructed from SQL.  (CVE-2026-14680)
+--
+-- functions returning type internal must not be callable from SQL
+SELECT internal_in('foo');
+ERROR:  functions returning type "internal" cannot be called explicitly
+LINE 1: SELECT internal_in('foo');
+               ^
+-- functions accepting type internal must not be callable from SQL,
+-- even when the argument is an internal-typed parameter
+PREPARE p_internal(internal) AS SELECT numeric_avg_serialize($1);
+ERROR:  functions accepting type "internal" cannot be called explicitly
+LINE 1: PREPARE p_internal(internal) AS SELECT numeric_avg_serialize...
+                                               ^
+-- unknown literals must not be coercible to internal, so this must not
+-- match any function
+SELECT numeric_avg_combine('abc', 'def');
+ERROR:  function numeric_avg_combine(unknown, unknown) does not exist
+LINE 1: SELECT numeric_avg_combine('abc', 'def');
+               ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- casts to or from internal are rejected
+SELECT 'foo'::internal;
+ERROR:  cannot cast type unknown to internal
+LINE 1: SELECT 'foo'::internal;
+                    ^
+SELECT NULL::internal;
+ERROR:  cannot cast type unknown to internal
+LINE 1: SELECT NULL::internal;
+                   ^
+SELECT CAST(123 AS internal);
+ERROR:  cannot cast type integer to internal
+LINE 1: SELECT CAST(123 AS internal);
+               ^

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -109,7 +109,7 @@ test: cursor
 # so it needs to be in a group by itself
 test: query_finish_pending
 
-test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan_gp co_nestloop_idxscan dml_in_udf gpdtm_plpgsql gp_array_agg gp_hyperloglog
+test: gpdiffcheck gptokencheck gp_hashagg sequence_gp tidscan_gp co_nestloop_idxscan dml_in_udf gpdtm_plpgsql gp_array_agg gp_hyperloglog internal_type_calls
 
 # The test must be run by itself as it injects a fault on QE to fail
 # at the 2nd phase of 2PC.

--- a/src/test/regress/sql/internal_type_calls.sql
+++ b/src/test/regress/sql/internal_type_calls.sql
@@ -1,6 +1,8 @@
 --
 -- Test that functions taking or returning type "internal" cannot be
--- called or constructed from SQL.  (CVE-2026-14680)
+-- called or constructed from SQL, and that aggregate combine functions
+-- (which WarehousePG exercises heavily via multi-stage aggregation)
+-- still work correctly.  (CVE-2026-14680)
 --
 
 -- functions returning type internal must not be callable from SQL
@@ -18,3 +20,21 @@ SELECT numeric_avg_combine('abc', 'def');
 SELECT 'foo'::internal;
 SELECT NULL::internal;
 SELECT CAST(123 AS internal);
+
+-- multi-stage aggregation still works: the planner and executor invoke
+-- the internal-typed transition/combine functions themselves
+CREATE TABLE internal_calls_t(a int, b numeric) DISTRIBUTED BY (a);
+INSERT INTO internal_calls_t SELECT g, g * 1.5 FROM generate_series(1, 1000) g;
+INSERT INTO internal_calls_t VALUES (1001, NULL);
+
+-- numeric_combine / numeric_avg_combine paths
+SELECT avg(b), sum(b), count(b), stddev(b), var_samp(b) FROM internal_calls_t;
+-- all-NULL input: combine functions must return honest NULL states
+SELECT avg(b), sum(b) FROM internal_calls_t WHERE b IS NULL;
+SELECT a % 3 AS grp, avg(b), sum(b) FROM internal_calls_t GROUP BY 1 ORDER BY 1;
+-- int8_avg_combine / numeric_poly_combine paths
+SELECT avg(a::int8), sum(a::int8), avg(a::int2), var_pop(a::int8) FROM internal_calls_t;
+-- array_agg_combine path
+SELECT array_agg(a ORDER BY a) FROM internal_calls_t WHERE a <= 3;
+
+DROP TABLE internal_calls_t;

--- a/src/test/regress/sql/internal_type_calls.sql
+++ b/src/test/regress/sql/internal_type_calls.sql
@@ -1,0 +1,20 @@
+--
+-- Test that functions taking or returning type "internal" cannot be
+-- called or constructed from SQL.  (CVE-2026-14680)
+--
+
+-- functions returning type internal must not be callable from SQL
+SELECT internal_in('foo');
+
+-- functions accepting type internal must not be callable from SQL,
+-- even when the argument is an internal-typed parameter
+PREPARE p_internal(internal) AS SELECT numeric_avg_serialize($1);
+
+-- unknown literals must not be coercible to internal, so this must not
+-- match any function
+SELECT numeric_avg_combine('abc', 'def');
+
+-- casts to or from internal are rejected
+SELECT 'foo'::internal;
+SELECT NULL::internal;
+SELECT CAST(123 AS internal);


### PR DESCRIPTION
## Summary

Backport of the upstream PostgreSQL fix for **CVE-2026-14680** (CVSS 8.8) to WHPG7, per [PTT-1578](https://enterprisedb.atlassian.net/browse/PTT-1578).

Two upstream commits cherry-picked (`git cherry-pick -x`) from `REL_14_STABLE`, with the original commit messages unchanged. Since this repo merges with rebase-and-merge, the WHPG regression test coverage is folded into the corresponding cherry-picked commit so each commit is self-contained (upstream ships no regression tests for this CVE on any branch — verified on `REL_14_STABLE` and `master`):

1. **Reject calls from SQL to functions that take or return type internal** (upstream `155dacbc5479a9bfbcb47e88ff68a758c73b6a8c`)
   - Locks down function syntax, operator syntax, casts (`can_coerce_type` / `find_coercion_pathway`), and plpgsql's I/O-coercion fallback.
   - Conflict resolution: in `can_coerce_type()` the GPDB-specific ANYTABLE special case occupies the same spot as the new INTERNALOID check; both are kept (INTERNALOID check first, matching upstream placement right after the same-type short-circuit). In `pl_exec.c` the conflict was comment-text only; upstream's new comment is taken.
   - Adds the `internal_type_calls` regression test (greenplum schedule): rejection of internal-returning and internal-accepting function calls (the latter via `PREPARE p(internal)`), and rejection of casts to/from internal.
2. **Return nulls honestly in aggregate "combine" functions** (upstream `913fe0c316a6d024434e66f084acbb605293265a`)
   - WarehousePG's `numeric_combine`, `numeric_avg_combine`, `numeric_poly_combine` and `int8_avg_combine` already contain the `state1 == NULL -> PG_RETURN_NULL()` logic, so the backend part of this commit lands as the upstream comments only. Kept for traceability of the CVE fix.
   - Extends `internal_type_calls` with multi-stage aggregation coverage (the internal-typed combine-function path GPDB depends on): numeric/int8/int2 avg/sum/stddev/var over a distributed table, honest NULL states for all-NULL inputs, and the array_agg combine path.