### PR TITLE
[WHPG6] Restrict accesses to non-system views and foreign tables during pg_dump

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw.out
@@ -2390,6 +2390,15 @@ DELETE FROM ft2 WHERE c1 = 9999 RETURNING tableoid::regclass;
  ft2
 (1 row)
 
+-- test restriction on non-system foreign tables (CVE-2024-7348).
+SET restrict_nonsystem_relation_kind TO 'foreign-table';
+SELECT * from ft1 where c1 < 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+INSERT INTO ft1 (c1) VALUES (1); -- ERROR
+ERROR:  access to non-system foreign table is restricted
+DELETE FROM ft1 WHERE c1 = 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+RESET restrict_nonsystem_relation_kind;
 -- Test that trigger on remote table works as expected
  \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -f sql/postgres_sql/gp2pg_postgres_create_trigger.sql
 CREATE FUNCTION

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -2390,6 +2390,15 @@ DELETE FROM ft2 WHERE c1 = 9999 RETURNING tableoid::regclass;
  ft2
 (1 row)
 
+-- test restriction on non-system foreign tables (CVE-2024-7348).
+SET restrict_nonsystem_relation_kind TO 'foreign-table';
+SELECT * from ft1 where c1 < 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+INSERT INTO ft1 (c1) VALUES (1); -- ERROR
+ERROR:  access to non-system foreign table is restricted
+DELETE FROM ft1 WHERE c1 = 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+RESET restrict_nonsystem_relation_kind;
 -- Test that trigger on remote table works as expected
  \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -f sql/postgres_sql/gp2pg_postgres_create_trigger.sql
 CREATE FUNCTION

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -611,6 +611,15 @@ TRUNCATE TABLE "S 1"."GP 1";
 -- validate writes on master (mpp_execute set to master)
 -- ===================================================================
 ALTER FOREIGN TABLE gp_ft1 OPTIONS ( SET mpp_execute 'master' );
+-- test restriction on non-system foreign tables.
+SET restrict_nonsystem_relation_kind TO 'foreign-table';
+SELECT * from gp_ft1 where f1 < 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+INSERT INTO gp_ft1 (f1) VALUES (1); -- ERROR
+ERROR:  access to non-system foreign table is restricted
+DELETE FROM gp_ft1 WHERE f1 = 1; -- ERROR
+ERROR:  access to non-system foreign table is restricted
+RESET restrict_nonsystem_relation_kind;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                    QUERY PLAN                   
 ------------------------------------------------

--- a/contrib/postgres_fdw/sql/gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp2pg_postgres_fdw.sql
@@ -396,6 +396,13 @@ EXPLAIN (verbose, costs off)
 DELETE FROM ft2 WHERE c1 = 9999 RETURNING tableoid::regclass;
 DELETE FROM ft2 WHERE c1 = 9999 RETURNING tableoid::regclass;
 
+-- test restriction on non-system foreign tables (CVE-2024-7348).
+SET restrict_nonsystem_relation_kind TO 'foreign-table';
+SELECT * from ft1 where c1 < 1; -- ERROR
+INSERT INTO ft1 (c1) VALUES (1); -- ERROR
+DELETE FROM ft1 WHERE c1 = 1; -- ERROR
+RESET restrict_nonsystem_relation_kind;
+
 -- Test that trigger on remote table works as expected
  \! env PGOPTIONS='' psql -p ${PG_PORT} contrib_regression -f sql/postgres_sql/gp2pg_postgres_create_trigger.sql
 

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -176,6 +176,13 @@ TRUNCATE TABLE "S 1"."GP 1";
 
 ALTER FOREIGN TABLE gp_ft1 OPTIONS ( SET mpp_execute 'master' );
 
+-- test restriction on non-system foreign tables.
+SET restrict_nonsystem_relation_kind TO 'foreign-table';
+SELECT * from gp_ft1 where f1 < 1; -- ERROR
+INSERT INTO gp_ft1 (f1) VALUES (1); -- ERROR
+DELETE FROM gp_ft1 WHERE f1 = 1; -- ERROR
+RESET restrict_nonsystem_relation_kind;
+
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 SELECT * FROM "S 1"."GP 1" ORDER BY f1;

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5986,6 +5986,23 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </listitem>
      </varlistentry>
 
+     <varlistentry id="guc-restrict-nonsystem-relation-kind" xreflabel="restrict_nonsystem_relation_kind">
+      <term><varname>restrict_nonsystem_relation_kind</varname> (<type>string</type>)
+      <indexterm>
+       <primary><varname>restrict_nonsystem_relation_kind</varname></primary>
+       <secondary>configuration parameter</secondary>
+     </indexterm>
+     </term>
+     <listitem>
+      <para>
+       This variable specifies relation kind to which access is restricted.
+       It contains a comma-separated list of relation kind.  Currently, the
+       supported relation kinds are <literal>view</literal> and
+       <literal>foreign-table</literal>.
+      </para>
+     </listitem>
+     </varlistentry>
+
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-client-format">

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -24,6 +24,7 @@
 #include "foreign/foreign.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
+#include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
@@ -391,6 +392,15 @@ GetFdwRoutine(Oid fdwhandler)
 {
 	Datum		datum;
 	FdwRoutine *routine;
+
+	/* Check if the access to foreign tables is restricted */
+	if (unlikely((restrict_nonsystem_relation_kind & RESTRICT_RELKIND_FOREIGN_TABLE) != 0))
+	{
+		/* there must not be built-in FDW handler  */
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("access to non-system foreign table is restricted")));
+	}
 
 	datum = OidFunctionCall0(fdwhandler);
 	routine = (FdwRoutine *) DatumGetPointer(datum);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -51,6 +51,7 @@
 #include "parser/parsetree.h"
 #include "parser/parse_oper.h"	/* ordering_oper_opid */
 #include "rewrite/rewriteManip.h"
+#include "tcop/tcopprot.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/uri.h"
@@ -6461,7 +6462,19 @@ make_modifytable(PlannerInfo *root,
 
 			Assert(rte->rtekind == RTE_RELATION);
 			if (rte->relkind == RELKIND_FOREIGN_TABLE)
+			{
+				/* Check if the access to foreign tables is restricted */
+				if (unlikely((restrict_nonsystem_relation_kind & RESTRICT_RELKIND_FOREIGN_TABLE) != 0))
+				{
+					/* there must not be built-in foreign tables */
+					Assert(rte->relid >= FirstNormalObjectId);
+					ereport(ERROR,
+							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+							 errmsg("access to non-system foreign table is restricted")));
+				}
+
 				fdwroutine = GetFdwRoutineByRelId(rte->relid);
+			}
 			else
 				fdwroutine = NULL;
 		}

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -41,6 +41,7 @@
 #include "parser/parsetree.h"
 #include "rewrite/rewriteManip.h"
 #include "storage/bufmgr.h"
+#include "tcop/tcopprot.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -413,6 +414,17 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	/* Grab the fdwroutine info using the relcache, while we have it */
 	if (relation->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 	{
+		/* Check if the access to foreign tables is restricted */
+		if (unlikely((restrict_nonsystem_relation_kind & RESTRICT_RELKIND_FOREIGN_TABLE) != 0))
+		{
+			/* there must not be built-in foreign tables */
+			Assert(RelationGetRelid(relation) >= FirstNormalObjectId);
+
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("access to non-system foreign table is restricted")));
+		}
+
 		rel->fdwroutine = GetFdwRoutineForRelation(relation, true);
 		rel->ftEntry->exec_location = GetForeignTable(RelationGetRelid(relation))->exec_location;
 	}

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -28,6 +28,7 @@
 #include "rewrite/rewriteDefine.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rewriteManip.h"
+#include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -1566,6 +1567,14 @@ ApplyRetrieveRule(Query *parsetree,
 	if (rule->qual != NULL)
 		elog(ERROR, "cannot handle qualified ON SELECT rule");
 
+	/* Check if the expansion of non-system views are restricted */
+	if (unlikely((restrict_nonsystem_relation_kind & RESTRICT_RELKIND_VIEW) != 0 &&
+				 RelationGetRelid(relation) >= FirstNormalObjectId))
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("access to non-system view \"%s\" is restricted",
+						RelationGetRelationName(relation))));
+
 	if (rt_index == parsetree->resultRelation)
 	{
 		/*
@@ -2800,6 +2809,14 @@ rewriteTargetView(Query *parsetree, Relation view)
 				break;
 		}
 	}
+
+	/* Check if the expansion of non-system views are restricted */
+	if (unlikely((restrict_nonsystem_relation_kind & RESTRICT_RELKIND_VIEW) != 0 &&
+				 RelationGetRelid(view) >= FirstNormalObjectId))
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("access to non-system view \"%s\" is restricted",
+						RelationGetRelationName(view))));
 
 	/*
 	 * For INSERT/UPDATE the modified columns must all be updatable. Note that

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -83,6 +83,7 @@
 #include "utils/timeout.h"
 #include "utils/timestamp.h"
 #include "mb/pg_wchar.h"
+#include "utils/builtins.h"
 
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
@@ -126,6 +127,8 @@ int			PostAuthDelay = 0;
 /* Time between checks that the client is still connected. */
 int         client_connection_check_interval = 0;
 
+/* flags for non-system relation kinds to restrict use */
+int			restrict_nonsystem_relation_kind;
 
 /*
  * Hook for extensions, to get notified when query cancel or DIE signal is
@@ -4204,6 +4207,66 @@ assign_max_stack_depth(int newval, void *extra)
 	max_stack_depth_bytes = newval_bytes;
 }
 
+/*
+ * GUC check_hook for restrict_nonsystem_relation_kind
+ */
+bool
+check_restrict_nonsystem_relation_kind(char **newval, void **extra, GucSource source)
+{
+	char	   *rawstring;
+	List	   *elemlist;
+	ListCell   *l;
+	int			flags = 0;
+
+	/* Need a modifiable copy of string */
+	rawstring = pstrdup(*newval);
+
+	if (!SplitIdentifierString(rawstring, ',', &elemlist))
+	{
+		/* syntax error in list */
+		GUC_check_errdetail("List syntax is invalid.");
+		pfree(rawstring);
+		list_free(elemlist);
+		return false;
+	}
+
+	foreach(l, elemlist)
+	{
+		char	   *tok = (char *) lfirst(l);
+
+		if (pg_strcasecmp(tok, "view") == 0)
+			flags |= RESTRICT_RELKIND_VIEW;
+		else if (pg_strcasecmp(tok, "foreign-table") == 0)
+			flags |= RESTRICT_RELKIND_FOREIGN_TABLE;
+		else
+		{
+			GUC_check_errdetail("Unrecognized key word: \"%s\".", tok);
+			pfree(rawstring);
+			list_free(elemlist);
+			return false;
+		}
+	}
+
+	pfree(rawstring);
+	list_free(elemlist);
+
+	/* Save the flags in *extra, for use by the assign function */
+	*extra = malloc(sizeof(int));
+	*((int *) *extra) = flags;
+
+	return true;
+}
+
+/*
+ * GUC assign_hook for restrict_nonsystem_relation_kind
+ */
+void
+assign_restrict_nonsystem_relation_kind(const char *newval, void *extra)
+{
+	int		   *flags = (int *) extra;
+
+	restrict_nonsystem_relation_kind = *flags;
+}
 
 /*
  * set_debug_options --- apply "-d N" command line option

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -517,6 +517,7 @@ static int	wal_segment_size;
 static bool	data_checksums;
 static bool integer_datetimes;
 static int	effective_io_concurrency;
+static char *restrict_nonsystem_relation_kind_string;
 
 /* should be static, but commands/variable.c needs to get at this */
 char	   *role_string;
@@ -3369,6 +3370,17 @@ static struct config_string ConfigureNamesString[] =
 		&external_pid_file,
 		NULL,
 		check_canonical_path, NULL, NULL
+	},
+
+	{
+		{"restrict_nonsystem_relation_kind", PGC_USERSET, CLIENT_CONN_STATEMENT,
+			gettext_noop("Sets relation kinds of non-system relation to restrict use"),
+			NULL,
+			GUC_LIST_INPUT | GUC_NOT_IN_SAMPLE
+		},
+		&restrict_nonsystem_relation_kind_string,
+		"",
+		check_restrict_nonsystem_relation_kind, assign_restrict_nonsystem_relation_kind, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -317,6 +317,7 @@ static void fmtReloptionsArray(Archive *fout, PQExpBuffer buffer,
 				   const char *reloptions, const char *prefix);
 static char *get_synchronized_snapshot(Archive *fout);
 static void setupDumpWorker(Archive *AHX, RestoreOptions *ropt);
+static void set_restrict_relation_kind(Archive *AH, const char *value);
 
 
 /* START MPP ADDITION */
@@ -1189,6 +1190,15 @@ setup_connection(Archive *AH, const char *dumpencoding, char *use_role)
 		ExecuteSqlStatement(AH, "SET quote_all_identifiers = true");
 
 	/*
+	 * For security reasons, we restrict the expansion of non-system views and
+	 * access to foreign tables during the pg_dump process.  The relaxation to
+	 * "view" in the dumpTableData_* paths mirrors upstream, but is inert on
+	 * this 9.4 base where makeTableDataInfo() builds no data job for foreign
+	 * tables, so that relaxation is never reached here.
+	 */
+	set_restrict_relation_kind(AH, "view, foreign-table");
+
+	/*
 	 * Initialize prepared-query state to "nothing prepared".  We do this here
 	 * so that a parallel dump worker will have its own state.
 	 */
@@ -1802,6 +1812,14 @@ dumpTableData_copy(Archive *fout, void *dcontext)
 	}
 	else if (tdinfo->filtercond)
 	{
+		/*
+		 * Temporarily relax the restriction to "view" so we can read a
+		 * foreign table's own data.  Inert on this 9.4 base (makeTableDataInfo()
+		 * builds no data job for foreign tables); kept for parity with upstream.
+		 */
+		if (tbinfo->relkind == RELKIND_FOREIGN_TABLE)
+			set_restrict_relation_kind(fout, "view");
+
 		appendPQExpBufferStr(q, "COPY (SELECT ");
 		/* klugery to get rid of parens in column list */
 		if (strlen(column_list) > 2)
@@ -1912,6 +1930,11 @@ dumpTableData_copy(Archive *fout, void *dcontext)
 				  classname);
 
 	destroyPQExpBuffer(q);
+
+	/* Revert back the setting */
+	if (tbinfo->relkind == RELKIND_FOREIGN_TABLE)
+		set_restrict_relation_kind(fout, "view, foreign-table");
+
 	return 1;
 }
 
@@ -1939,6 +1962,14 @@ dumpTableData_insert(Archive *fout, void *dcontext)
 	appendPQExpBuffer(q, "DECLARE _pg_dump_cursor CURSOR FOR "
 						"SELECT * FROM ONLY %s",
 						fmtQualifiedDumpable(tbinfo));
+
+	/*
+	 * Temporarily relax the restriction to "view" so we can read a foreign
+	 * table's own data.  Inert on this 9.4 base (makeTableDataInfo() builds no
+	 * data job for foreign tables); kept for parity with upstream.
+	 */
+	if (tbinfo->relkind == RELKIND_FOREIGN_TABLE)
+		set_restrict_relation_kind(fout, "view");
 
 	if (tdinfo->filtercond)
 		appendPQExpBuffer(q, " %s", tdinfo->filtercond);
@@ -2078,6 +2109,10 @@ dumpTableData_insert(Archive *fout, void *dcontext)
 	destroyPQExpBuffer(q);
 	if (insertStmt != NULL)
 		destroyPQExpBuffer(insertStmt);
+
+	/* Revert back the setting */
+	if (tbinfo->relkind == RELKIND_FOREIGN_TABLE)
+		set_restrict_relation_kind(fout, "view, foreign-table");
 
 	return 1;
 }
@@ -3188,6 +3223,28 @@ dumpBlobs(Archive *fout, void *arg __attribute__((unused)))
 	} while (ntups > 0);
 
 	return 1;
+}
+
+/*
+ * Set the given value to restrict_nonsystem_relation_kind value. Since
+ * restrict_nonsystem_relation_kind is introduced in minor version releases,
+ * the setting query is effective only where available.
+ */
+static void
+set_restrict_relation_kind(Archive *AH, const char *value)
+{
+	PQExpBuffer query = createPQExpBuffer();
+	PGresult   *res;
+
+	appendPQExpBuffer(query,
+					  "SELECT set_config(name, '%s', false) "
+					  "FROM pg_settings "
+					  "WHERE name = 'restrict_nonsystem_relation_kind'",
+					  value);
+	res = ExecuteSqlQuery(AH, query->data, PGRES_TUPLES_OK);
+
+	PQclear(res);
+	destroyPQExpBuffer(query);
 }
 
 static void

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -47,6 +47,12 @@ typedef enum
 
 extern PGDLLIMPORT int log_statement;
 
+/* Flags for restrict_nonsystem_relation_kind value */
+#define RESTRICT_RELKIND_VIEW			0x01
+#define RESTRICT_RELKIND_FOREIGN_TABLE	0x02
+
+extern PGDLLIMPORT int restrict_nonsystem_relation_kind;
+
 extern List *pg_parse_query(const char *query_string);
 extern List *pg_rewrite_query(Query *query);
 extern List *pg_analyze_and_rewrite(Node *parsetree, const char *query_string,
@@ -62,6 +68,9 @@ extern List *pg_plan_queries(List *querytrees, int cursorOptions,
 
 extern bool check_max_stack_depth(int *newval, void **extra, GucSource source);
 extern void assign_max_stack_depth(int newval, void *extra);
+extern bool check_restrict_nonsystem_relation_kind(char **newval, void **extra,
+												   GucSource source);
+extern void assign_restrict_nonsystem_relation_kind(const char *newval, void *extra);
 
 extern void die(SIGNAL_ARGS);
 extern void quickdie(SIGNAL_ARGS) __attribute__((noreturn));

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -472,6 +472,7 @@
 		"resource_scheduler",
 		"resource_select_only",
 		"restart_after_crash",
+		"restrict_nonsystem_relation_kind",
 		"role",
 		"runaway_detector_activation_percent",
 		"seed",

--- a/src/test/regress/expected/create_view.out
+++ b/src/test/regress/expected/create_view.out
@@ -1719,6 +1719,23 @@ select pg_get_viewdef('tdis_v1', true);
    GROUP BY tdis.a, tdis.b, tdis.c, '-1'::integer;
 (1 row)
 
+-- test restriction on non-system view expansion.
+create table tt27v_tbl (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tt27v as select a from tt27v_tbl;
+set restrict_nonsystem_relation_kind to 'view';
+select a from tt27v where a > 0; -- Error
+ERROR:  access to non-system view "tt27v" is restricted
+insert into tt27v values (1); -- Error
+ERROR:  access to non-system view "tt27v" is restricted
+select viewname from pg_views where viewname = 'tt27v'; -- Ok to access a system view.
+ viewname 
+----------
+ tt27v
+(1 row)
+
+reset restrict_nonsystem_relation_kind;
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/expected/create_view_optimizer.out
+++ b/src/test/regress/expected/create_view_optimizer.out
@@ -1719,6 +1719,23 @@ select pg_get_viewdef('tdis_v1', true);
    GROUP BY tdis.a, tdis.b, tdis.c, '-1'::integer;
 (1 row)
 
+-- test restriction on non-system view expansion.
+create table tt27v_tbl (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view tt27v as select a from tt27v_tbl;
+set restrict_nonsystem_relation_kind to 'view';
+select a from tt27v where a > 0; -- Error
+ERROR:  access to non-system view "tt27v" is restricted
+insert into tt27v values (1); -- Error
+ERROR:  access to non-system view "tt27v" is restricted
+select viewname from pg_views where viewname = 'tt27v'; -- Ok to access a system view.
+ viewname 
+----------
+ tt27v
+(1 row)
+
+reset restrict_nonsystem_relation_kind;
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;

--- a/src/test/regress/sql/create_view.sql
+++ b/src/test/regress/sql/create_view.sql
@@ -590,6 +590,15 @@ create table tdis(a int, b int, c int);
 create view tdis_v1 as select distinct a, b, c, -1::int from tdis;
 select pg_get_viewdef('tdis_v1', true);
 
+-- test restriction on non-system view expansion.
+create table tt27v_tbl (a int);
+create view tt27v as select a from tt27v_tbl;
+set restrict_nonsystem_relation_kind to 'view';
+select a from tt27v where a > 0; -- Error
+insert into tt27v values (1); -- Error
+select viewname from pg_views where viewname = 'tt27v'; -- Ok to access a system view.
+reset restrict_nonsystem_relation_kind;
+
 -- clean up all the random objects we made above
 set client_min_messages = warning;
 DROP SCHEMA temp_view_test CASCADE;


### PR DESCRIPTION
pg_dump is vulnerable to a privilege-escalation race: a user could replace a table with a view or foreign table between the time pg_dump acquires its lock and the time it reads the data, so that a query pg_dump issues as the dumping (often superuser) role instead runs attacker-controlled SQL or a foreign-data wrapper of the attacker's choosing.  (CVE-2024-7348)

Add a restrict_nonsystem_relation_kind GUC (values "view" and "foreign-table") that makes the backend refuse to expand a non-system view or access a non-system foreign table.  pg_dump sets it to "view, foreign-table" for the duration of the dump, temporarily relaxing it to "view" only while reading a foreign table's own data.  The GUC is USERSET and defaults to empty, so it changes nothing unless pg_dump (or a user) asks for it; pg_dump sets it via set_config() gated on pg_settings, so it is silently ignored when dumping from a server that predates the GUC.

Based on upstream commit 79c7a7e29695a32fef2e65682be224b8d61ec972 (CVE-2024-7348) and its WHPG7 backport
b3e6063eb7d3f7ba1c47b0e9e8d99cbba2c95a44, reimplemented for the PostgreSQL 9.4 base:

- The view and foreign-table checks land in the same call sites as upstream (ApplyRetrieveRule/rewriteTargetView, get_relation_info, make_modifytable, GetFdwRoutine), all of which exist in 9.4.
- Dropped upstream's incidental non-CVE churn that came bundled in the cherry-pick context: the PG12 row-security SET in setup_connection, the generated-column INSERT handling and getPolicies()/other PG12-only functions in pg_dump.c, and the PG12-only rel->serverid assignment in get_relation_info(); none exist on the 9.4 base.
- restrict_nonsystem_relation_kind is added to unsync_guc_name.h so the dispatcher does not try to sync it to the segments (matching WHPG7); restore_command, which upstream also lists there, is a PG12 GUC absent from 9.4 and was not added.
- WHPG6 native external tables (relstorage 'x') are not foreign tables and do not pass through the FDW path, so they are out of scope here; views, the primary escalation vector, are fully covered.

The new GUC is documented in config.sgml (this doc hunk was present in the upstream commit but missing from the WHPG7 backport).

The view restriction is covered by src/test/regress/sql/create_view.sql. The foreign-table restriction is tested in gp2pg_postgres_fdw.sql.

Reported-by: Noah Misch
Security: CVE-2024-7348