### PR TITLE
pg_dump: avoid assuming how long pg_proc.protrftypes can be.

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -1057,38 +1057,138 @@ findParentsByOid(TableInfo *self,
 
 /*
  * parseOidArray
- *	  parse a string of numbers delimited by spaces into a character array
+ *	  parse a string of unsigned numbers separated by spaces
+ *	  into an array of OIDs
  *
- * Note: actually this is used for both Oids and potentially-signed
- * attribute numbers.  This should cause no trouble, but we could split
- * the function into two functions with different argument types if it does.
+ * The result is a malloc'd array.
+ *
+ * If arraysize >= 0, we insist that the input contain exactly that many
+ * OIDs, and the allocated array is of that length too.  If arraysize < 0,
+ * we dynamically size the array to have one more entry than the input
+ * provides, and fill the extra entry with zero.
  */
-
-void
-parseOidArray(const char *str, Oid *array, int arraysize)
+Oid *
+parseOidArray(const char *str, int arraysize)
 {
-	int			j,
-				argNum;
-	char		temp[100];
-	char		s;
+	Oid		   *array;
+	int			allocsize,
+				argNum,
+				templen;
+	char		temp[32];
 
-	argNum = 0;
-	j = 0;
-	for (;;)
+	if (arraysize >= 0)
+		allocsize = arraysize;
+	else
 	{
-		s = *str++;
+		/*
+		 * Make enough room for input + one extra entry (could be more than
+		 * enough, if there are redundant spaces in the input).
+		 */
+		allocsize = 2;
+		for (const char *s1 = str; *s1; s1++)
+		{
+			if (*s1 == ' ')
+				allocsize++;
+		}
+	}
+	array = pg_malloc_array(Oid, allocsize);
+	argNum = 0;
+	templen = 0;
+	for (const char *s1 = str;; s1++)
+	{
+		char		s = *s1;
+
 		if (s == ' ' || s == '\0')
 		{
-			if (j > 0)
+			if (templen > 0)
 			{
-				if (argNum >= arraysize)
+				if (arraysize >= 0 && argNum >= arraysize)
 				{
 					pg_log_error("could not parse numeric array \"%s\": too many numbers", str);
 					exit_nicely(1);
 				}
-				temp[j] = '\0';
+				temp[templen] = '\0';
 				array[argNum++] = atooid(temp);
-				j = 0;
+				templen = 0;
+			}
+			if (s == '\0')
+				break;
+		}
+		else
+		{
+			if (!isdigit((unsigned char) s) ||
+				templen >= sizeof(temp) - 1)
+			{
+				pg_log_error("could not parse numeric array \"%s\": invalid character in number", str);
+				exit_nicely(1);
+			}
+			temp[templen++] = s;
+		}
+	}
+
+	if (arraysize >= 0 && argNum != arraysize)
+	{
+		pg_log_error("could not parse numeric array \"%s\": too few numbers", str);
+		exit_nicely(1);
+	}
+
+	while (argNum < allocsize)
+		array[argNum++] = InvalidOid;
+
+	return array;
+}
+
+
+/*
+ * parseIntArray
+ *	  parse a string of possibly-signed numbers separated by spaces
+ *	  into an array of ints
+ *
+ * This is exactly like parseOidArray, but for integers.
+ */
+int *
+parseIntArray(const char *str, int arraysize)
+{
+	int		   *array;
+	int			allocsize,
+				argNum,
+				templen;
+	char		temp[32];
+
+	if (arraysize >= 0)
+		allocsize = arraysize;
+	else
+	{
+		/*
+		 * Make enough room for input + one extra entry (could be more than
+		 * enough, if there are redundant spaces in the input).
+		 */
+		allocsize = 2;
+		for (const char *s1 = str; *s1; s1++)
+		{
+			if (*s1 == ' ')
+				allocsize++;
+		}
+	}
+	array = pg_malloc_array(int, allocsize);
+	argNum = 0;
+	templen = 0;
+	for (const char *s1 = str;; s1++)
+	{
+		char		s = *s1;
+
+		if (s == ' ' || s == '\0')
+		{
+			if (templen > 0)
+			{
+				if (arraysize >= 0 && argNum >= arraysize)
+				{
+					pg_log_error("could not parse numeric array \"%s\": too many numbers", str);
+					exit_nicely(1);
+				}
+				temp[templen] = '\0';
+				array[argNum++] = atoi(temp);
+				templen = 0;
 			}
 			if (s == '\0')
 				break;
@@ -1096,17 +1196,25 @@ parseOidArray(const char *str, Oid *array, int arraysize)
 		else
 		{
 			if (!(isdigit((unsigned char) s) || s == '-') ||
-				j >= sizeof(temp) - 1)
+				templen >= sizeof(temp) - 1)
 			{
 				pg_log_error("could not parse numeric array \"%s\": invalid character in number", str);
 				exit_nicely(1);
 			}
-			temp[j++] = s;
+			temp[templen++] = s;
 		}
 	}
 
-	while (argNum < arraysize)
-		array[argNum++] = InvalidOid;
+	if (arraysize >= 0 && argNum != arraysize)
+	{
+		pg_log_error("could not parse numeric array \"%s\": too few numbers", str);
+		exit_nicely(1);
+	}
+
+	while (argNum < allocsize)
+		array[argNum++] = 0;
+
+	return array;
 }
 
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6150,12 +6150,8 @@ getAggregates(Archive *fout, int *numAggs)
 		if (agginfo[i].aggfn.nargs == 0)
 			agginfo[i].aggfn.argtypes = NULL;
 		else
-		{
-			agginfo[i].aggfn.argtypes = (Oid *) pg_malloc(agginfo[i].aggfn.nargs * sizeof(Oid));
-			parseOidArray(PQgetvalue(res, i, i_proargtypes),
-						  agginfo[i].aggfn.argtypes,
-						  agginfo[i].aggfn.nargs);
-		}
+			agginfo[i].aggfn.argtypes = parseOidArray(PQgetvalue(res, i, i_proargtypes),
+													  agginfo[i].aggfn.nargs);
 
 		/* Decide whether we want to dump it */
 		selectDumpableAggregate(&(agginfo[i]), fout);
@@ -6484,11 +6480,8 @@ getFuncs(Archive *fout, int *numFuncs)
 		if (finfo[i].nargs == 0)
 			finfo[i].argtypes = NULL;
 		else
-		{
-			finfo[i].argtypes = (Oid *) pg_malloc(finfo[i].nargs * sizeof(Oid));
-			parseOidArray(PQgetvalue(res, i, i_proargtypes),
-						  finfo[i].argtypes, finfo[i].nargs);
-		}
+			finfo[i].argtypes = parseOidArray(PQgetvalue(res, i, i_proargtypes),
+											  finfo[i].nargs);
 
 		/* Decide whether we want to dump it */
 		selectDumpableFunction(&finfo[i], fout);
@@ -7742,9 +7735,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 			indxinfo[j].indreloptions = pg_strdup(PQgetvalue(res, j, i_indreloptions));
 			indxinfo[j].indstatcols = pg_strdup(PQgetvalue(res, j, i_indstatcols));
 			indxinfo[j].indstatvals = pg_strdup(PQgetvalue(res, j, i_indstatvals));
-			indxinfo[j].indkeys = (Oid *) pg_malloc(indxinfo[j].indnattrs * sizeof(Oid));
-			parseOidArray(PQgetvalue(res, j, i_indkey),
-						  indxinfo[j].indkeys, indxinfo[j].indnattrs);
+			indxinfo[j].indkeys = parseIntArray(PQgetvalue(res, j, i_indkey),
+												indxinfo[j].indnattrs);
 			indxinfo[j].indisclustered = (PQgetvalue(res, j, i_indisclustered)[0] == 't');
 			indxinfo[j].indisreplident = (PQgetvalue(res, j, i_indisreplident)[0] == 't');
 			indxinfo[j].parentidx = atooid(PQgetvalue(res, j, i_parentidx));
@@ -12900,12 +12892,10 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 
 	if (protrftypes != NULL && strcmp(protrftypes, "") != 0)
 	{
-		Oid		   *typeids = palloc(FUNC_MAX_ARGS * sizeof(Oid));
-		int			i;
+		Oid		   *typeids = parseOidArray(protrftypes, -1);
 
 		appendPQExpBufferStr(q, " TRANSFORM ");
-		parseOidArray(protrftypes, typeids, FUNC_MAX_ARGS);
-		for (i = 0; typeids[i]; i++)
+		for (int i = 0; typeids[i]; i++)
 		{
 			if (i != 0)
 				appendPQExpBufferStr(q, ", ");
@@ -18376,7 +18366,7 @@ dumpConstraint(Archive *fout, const ConstraintInfo *coninfo)
 							  coninfo->contype == 'p' ? "PRIMARY KEY" : "UNIQUE");
 			for (k = 0; k < indxinfo->indnkeyattrs; k++)
 			{
-				int			indkey = (int) indxinfo->indkeys[k];
+				int			indkey = indxinfo->indkeys[k];
 				const char *attname;
 
 				if (indkey == InvalidAttrNumber)
@@ -18393,7 +18383,7 @@ dumpConstraint(Archive *fout, const ConstraintInfo *coninfo)
 
 			for (k = indxinfo->indnkeyattrs; k < indxinfo->indnattrs; k++)
 			{
-				int			indkey = (int) indxinfo->indkeys[k];
+				int			indkey = indxinfo->indkeys[k];
 				const char *attname;
 
 				if (indkey == InvalidAttrNumber)

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -452,7 +452,7 @@ typedef struct _indxInfo
 	char	   *indstatvals;	/* statistic values for columns */
 	int			indnkeyattrs;	/* number of index key attributes */
 	int			indnattrs;		/* total number of index attributes */
-	Oid		   *indkeys;		/* In spite of the name 'indkeys' this field
+	int		   *indkeys;		/* In spite of the name 'indkeys' this field
 								 * contains both key and nonkey attributes */
 	bool		indisclustered;
 	bool		indisreplident;
@@ -739,7 +739,8 @@ extern IndxInfo	*findIndexByOid(Oid oid);
 extern void recordExtensionMembership(CatalogId catId, ExtensionInfo *ext);
 extern ExtensionInfo *findOwningExtension(CatalogId catalogId);
 
-extern void parseOidArray(const char *str, Oid *array, int arraysize);
+extern Oid *parseOidArray(const char *str, int arraysize);
+extern int *parseIntArray(const char *str, int arraysize);
 
 extern void sortDumpableObjects(DumpableObject **objs, int numObjs,
 								DumpId preBoundaryId, DumpId postBoundaryId);

--- a/src/test/regress/expected/object_address.out
+++ b/src/test/regress/expected/object_address.out
@@ -42,6 +42,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM
 CREATE TRANSFORM FOR int LANGUAGE SQL (
 	FROM SQL WITH FUNCTION prsd_lextype(internal),
 	TO SQL WITH FUNCTION int4recv(internal));
+-- make a function that uses it too, mainly to exercise pg_dump
+CREATE FUNCTION public.sql_func_with_transform(int) RETURNS int LANGUAGE sql
+AS 'select $1 + 1'
+TRANSFORM FOR TYPE int;
 CREATE PUBLICATION addr_pub FOR TABLE addr_nsp.gentable;
 CREATE SUBSCRIPTION regress_addr_sub CONNECTION '' PUBLICATION bar WITH (connect = false, slot_name = NONE);
 WARNING:  tables were not subscribed, you will have to run ALTER SUBSCRIPTION ... REFRESH PUBLICATION to subscribe the tables

--- a/src/test/regress/sql/object_address.sql
+++ b/src/test/regress/sql/object_address.sql
@@ -45,6 +45,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM
 CREATE TRANSFORM FOR int LANGUAGE SQL (
 	FROM SQL WITH FUNCTION prsd_lextype(internal),
 	TO SQL WITH FUNCTION int4recv(internal));
+-- make a function that uses it too, mainly to exercise pg_dump
+CREATE FUNCTION public.sql_func_with_transform(int) RETURNS int LANGUAGE sql
+AS 'select $1 + 1'
+TRANSFORM FOR TYPE int;
 CREATE PUBLICATION addr_pub FOR TABLE addr_nsp.gentable;
 CREATE SUBSCRIPTION regress_addr_sub CONNECTION '' PUBLICATION bar WITH (connect = false, slot_name = NONE);
 CREATE STATISTICS addr_nsp.gentable_stat ON a, b FROM addr_nsp.gentable;


### PR DESCRIPTION
The backend doesn't impose any particular limit on the length of this array, and since there could be entries for both input and output arguments, it's feasible for the length to exceed FUNC_MAX_ARGS even without funny business.  This could lead to crashes or worse.

Moreover, pg_dump shouldn't rely on hard-coding FUNC_MAX_ARGS in the first place: it has no business assuming that the backend it's dumping from was compiled with the same value of FUNC_MAX_ARGS that it is. So the stanza in dumpFunc() that allocates exactly FUNC_MAX_ARGS space for the parsed OID array is fundamentally misguided.  And it's broken in another way too: if there are exactly FUNC_MAX_ARGS OIDs, then parseOidArray won't zero-fill any entries, allowing the subsequent loop to run off the end of the array.  A crash seems unlikely in this variant, but garbage output is certain.

To fix, redesign parseOidArray's API so that it does the array-mallocing, which simplifies the callers anyway.  While we're here, tighten and modernize it a bit; in particular, split it into separate functions for OIDs and integers, as was foreseen long ago. This lets us get rid of the confusing type-punning involved in having IndxInfo.indkeys be declared as "Oid *" when it's really potentially-signed ints.  Also, most of the callers expect an exact number of array entries, so make it verify that not just check for "too many".

I noted while testing that this dumpFunc() stanza isn't even reached during check-world.  Add a function with transform to the regression tests to rectify that.

Reported-by: Masahiko Sawada <sawada.mshk@gmail.com>
Author: Tom Lane <tgl@sss.pgh.pa.us>
Reviewed-by: Masahiko Sawada <sawada.mshk@gmail.com>
Backpatch-through: 14
Security: CVE-2026-19385
(cherry picked from commit 57aa21f69127d21e284c5db8eb488b1eccbb6a1f)

WarehousePG adaptation:

The bulk of the change (common.c's parseOidArray/parseIntArray rework and pg_dump.h) applied cleanly.  Three files had positional conflicts, all resolved by keeping the upstream security semantics:

- pg_dump.c: the getAggregates() and getFuncs() call sites use the new parseOidArray() signature (it now mallocs and returns the array).  The upstream context also touched FuncInfo.postponed_def, a field WarehousePG's FuncInfo does not have; those two assignments were dropped as unrelated to this fix.  The dumpFunc() core change (parseOidArray(protrftypes, -1), removing the FUNC_MAX_ARGS assumption) and the getIndexes() indkeys->parseIntArray change applied cleanly.
- src/test/regress/{sql,expected}/object_address: added the upstream sql_func_with_transform test that exercises the fixed dumpFunc() stanza. Upstream's hunk also carried a "SET client_min_messages = 'ERROR'" line that pre-exists in the upstream test but not in WarehousePG's; it was dropped, since on this base it would suppress the later test_addresses() WARNINGs that WarehousePG's expected output still shows.

