### PR TITLE
Backport two Aug-2026 CVE fixes: to_char() TZ overflow and PL/Perl tied-value hardening

### DIFF
--- a/contrib/hstore_plperl/hstore_plperl.c
+++ b/contrib/hstore_plperl/hstore_plperl.c
@@ -2,7 +2,6 @@
 
 #include "fmgr.h"
 #include "hstore/hstore.h"
-#include "storage/shmem.h"		/* for mul_size() */
 #include "plperl.h"
 #include "plperl_helpers.h"
 
@@ -120,15 +119,22 @@ plperl_to_hstore(PG_FUNCTION_ARGS)
 				 (errmsg("cannot transform non-hash Perl value to hstore"))));
 	hv = (HV *) in;
 
-	pcount = hv_iterinit(hv);
+	(void) hv_iterinit(hv);
 
-	pairs = (Pairs *) palloc(mul_size(pcount, sizeof(Pairs)));
+	pcount = 64;				/* arbitrary initial guess */
+	pairs = palloc_array(Pairs, pcount);
 
 	i = 0;
 	while ((he = hv_iternext(hv)))
 	{
 		char	   *key = sv2cstr(HeSVKEY_force(he));
 		SV		   *value = HeVAL(he);
+
+		if (i >= pcount)
+		{
+			pcount *= 2;
+			pairs = repalloc_array(pairs, Pairs, pcount);
+		}
 
 		pairs[i].key = pstrdup(key);
 		pairs[i].keylen = hstoreCheckKeyLen(strlen(pairs[i].key));
@@ -150,7 +156,7 @@ plperl_to_hstore(PG_FUNCTION_ARGS)
 		i++;
 	}
 
-	pcount = hstoreUniquePairs(pairs, pcount, &buflen);
+	pcount = hstoreUniquePairs(pairs, i, &buflen);
 	out = hstorePairs(pairs, pcount, buflen);
 	PG_RETURN_POINTER(out);
 }

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -2539,10 +2539,18 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					/* We assume here that timezone names aren't localized */
+					/*
+					 * We assume here that timezone abbreviations aren't
+					 * localized, so ASCII-only downcasing is sufficient.
+					 */
 					char	   *p = asc_tolower_z(tmtcTzn(in));
 
-					strcpy(s, p);
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					pfree(p);
 					s += strlen(s);
 				}
@@ -2551,7 +2559,14 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					strcpy(s, tmtcTzn(in));
+					const char *p = tmtcTzn(in);
+
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					s += strlen(s);
 				}
 				break;

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -1167,6 +1167,10 @@ get_perl_array_ref(SV *sv)
 
 /*
  * helper function for plperl_array_to_datum, recurses for multi-D arrays
+ *
+ * Caller is required to have set dims[cur_depth - 1] to the length of the
+ * input array, i.e., av_len(av) + 1.  We make this requirement so as to
+ * avoid reading av_len() twice, which is hazardous for tied arrays.
  */
 static void
 array_to_datum_internal(AV *av, ArrayBuildState *astate,
@@ -1176,7 +1180,7 @@ array_to_datum_internal(AV *av, ArrayBuildState *astate,
 {
 	dTHX;
 	int			i;
-	int			len = av_len(av) + 1;
+	int			len = dims[cur_depth - 1];
 
 	for (i = 0; i < len; i++)
 	{


### PR DESCRIPTION
## Summary

Backports two independent upstream security fixes from the August 2026 set:

- **CVE-2026-14669** (CVSS 8.8) — `to_char()` copied the time-zone abbreviation
  into its fixed per-item output buffer with an unguarded `strcpy()`. A
  user-supplied overlength zone abbreviation (e.g. via a custom abbreviation
  file / `timezone` setting) could overflow the allocation. Both the `TZ` and
  `tz` format codes now bound the copy by `n->key->len * DCH_MAX_ITEM_SIZ` and
  raise `time zone format value too long` otherwise, matching the style of the
  CVE-2015-0241 fix.

- **CVE-2026-14670** (CVSS 8.8) — PL/Perl did not defend against Perl arrays
  and hashes that have been *tied*, which can run arbitrary Perl at unexpected
  moments and report inconsistent sizes on each inspection.
  `plperl_array_to_datum()` now reads each array's length exactly once (the
  caller passes it in via `dims[]`), and `plperl_to_hstore()` no longer trusts
  `hv_iterinit()`'s return as the hash size, growing the `Pairs` array
  dynamically instead.

## Background

Both are plain `cherry-pick -x` from `REL_14_STABLE` (the upstream branch whose
code structure matches this PG12 base); each commit keeps its original message
and provenance line.

- The `to_char()` fix applied verbatim.
- The PL/Perl fix required trivial conflict resolution: the `hstore_plperl.c`
  hunk adopts upstream's dynamic `Pairs` growth (initial guess 64 +
  `repalloc_array`), which also lets us drop the now-unused
  `#include "storage/shmem.h"` that had been carried only for `mul_size()`.
  `palloc_array()` / `repalloc_array()` are already present on `main`, so no
  incidental revert was needed.

Neither upstream fix ships regression tests. No catalog, ABI or WAL changes.

## Test plan

Verified on a PG12 demo cluster built from this branch:

- **to_char TZ**: normal abbreviations (`PDT`/`pdt`) unchanged; a 40-char zone
  abbreviation raises `time zone format value too long` for `TZ`, `tz` and
  `TZTZ`; a 20-char abbreviation (within the per-item bound) still prints.
- **PL/Perl**: 1-D and 2-D array round-trips correct; an hstore built from a
  200-entry Perl hash (exercising the `repalloc` growth past the initial 64)
  returns all 200 keys with correct values.
- `formatting.o`, `plperl` and `hstore_plperl` all compile warning-clean.
