### PR TITLE
Fix wrong results from the one-item visibility cache for combo CIDs

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -473,11 +473,19 @@ heapgetpage(TableScanDesc sscan, BlockNumber page)
 				 * the xmax too, but the visibility rules get more complicated
 				 * with locked-only tuples and multi-XIDs, so it seems better
 				 * to just give up early.
+				 *
+				 * Don't use the cache for a HEAP_COMBOCID tuple either: its
+				 * raw command id is an index into the backend-local combo-CID
+				 * array, not a real cmin, so it must not be compared with
+				 * another tuple's plain command id. Such a tuple can still
+				 * have HEAP_XMAX_INVALID set: if the deleting subtransaction
+				 * aborted, the combo cid stays behind.
 				 */
 				bool		use_cache;
 
-				if ((theader->t_infomask & HEAP_XMAX_INVALID) != 0 ||
-					HEAP_XMAX_IS_LOCKED_ONLY(theader->t_infomask))
+				if (((theader->t_infomask & HEAP_XMAX_INVALID) != 0 ||
+					 HEAP_XMAX_IS_LOCKED_ONLY(theader->t_infomask)) &&
+					(theader->t_infomask & HEAP_COMBOCID) == 0)
 					use_cache = true;
 				else
 					use_cache = false;

--- a/src/test/regress/expected/combocid_gp.out
+++ b/src/test/regress/expected/combocid_gp.out
@@ -253,3 +253,58 @@ FETCH ALL FROM c;
 (99 rows)
 
 rollback;
+--
+-- Test that the one-item tuple-visibility cache in heapgetpage() ignores
+-- tuples carrying HEAP_COMBOCID.  Such a tuple's raw command id is an index
+-- into the backend-local combo-CID array, not a real cmin, so it must not be
+-- compared against another tuple's plain command id.
+--
+-- The scenario: a tuple whose deleting subtransaction aborted keeps its
+-- combo cid, and a later scan sets the HEAP_XMAX_INVALID hint bit, which
+-- used to make it eligible for the cache.  Combo-CID indexes and command
+-- ids both count from zero, so the combo index easily collides with the
+-- plain cmin of another tuple on the same page.  A cursor whose snapshot
+-- lies between the two real cmins then returned a wrong extra row: the
+-- plain tuple primed the cache and the combo tuple falsely hit it.
+--
+-- All rows use the same distribution key, so they land on the same segment
+-- and the same heap page.  The cursor query scans a big table before the
+-- table of interest (UNION ALL), so that the QE fills the motion send
+-- buffer and blocks at DECLARE time, and only reaches the page of interest
+-- during FETCH, after the hint bit has been set.
+--
+CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
+INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
+BEGIN;
+INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
+DECLARE combocid_vischeck_cur CURSOR FOR
+    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
+INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+-- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
+INSERT INTO combocid_vischeck VALUES (2, 0);
+SAVEPOINT s;
+-- Assigns combo-CID index 0, colliding with the first row's cmin.
+DELETE FROM combocid_vischeck WHERE a = 2;
+ROLLBACK TO s;
+-- This scan sets the HEAP_XMAX_INVALID hint bit (the deleter aborted).
+SELECT count(*) FROM combocid_vischeck;
+ count 
+-------
+     2
+(1 row)
+
+-- Skip past the big table's rows; the segment scans the page of interest
+-- only now.  The cursor's snapshot predates the insertion of (2), so it
+-- must see only (1).
+MOVE 200000 FROM combocid_vischeck_cur;
+FETCH ALL FROM combocid_vischeck_cur;
+ a 
+---
+ 1
+(1 row)
+
+COMMIT;

--- a/src/test/regress/expected/combocid_gp.out
+++ b/src/test/regress/expected/combocid_gp.out
@@ -267,25 +267,37 @@ rollback;
 -- lies between the two real cmins then returned a wrong extra row: the
 -- plain tuple primed the cache and the combo tuple falsely hit it.
 --
--- All rows use the same distribution key, so they land on the same segment
--- and the same heap page.  The cursor query scans a big table before the
--- table of interest (UNION ALL), so that the QE fills the motion send
--- buffer and blocks at DECLARE time, and only reaches the page of interest
--- during FETCH, after the hint bit has been set.
+-- Both rows use the same distribution key (2 hashes to content 0, dbid 2),
+-- so they land on the same segment and the same heap page.  QEs execute a
+-- cursor's plan eagerly at DECLARE, which would scan the page before the
+-- combo state exists; suspend the cursor's reader QE right after it has
+-- acquired its snapshot and set up interconnect, and resume it only after
+-- the combo tuple and the hint bit are in place, so the page is scanned at
+-- FETCH time.  The fault is armed for a single occurrence: the count(*)
+-- below passes the same fault point and must go through.
 --
 CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
 CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
-CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
-INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
 BEGIN;
-INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
-INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
-INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
-DECLARE combocid_vischeck_cur CURSOR FOR
-    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
-INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+INSERT INTO combocid_vischeck VALUES (1, 2);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 2);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 2);   -- burn a command id
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+DECLARE combocid_vischeck_cur CURSOR FOR SELECT a FROM combocid_vischeck;
+SELECT gp_wait_until_triggered_fault('qe_got_snapshot_and_interconnect', 1, 2);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+INSERT INTO combocid_vischeck_filler VALUES (3, 2);   -- burn a command id
 -- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
-INSERT INTO combocid_vischeck VALUES (2, 0);
+INSERT INTO combocid_vischeck VALUES (2, 2);
 SAVEPOINT s;
 -- Assigns combo-CID index 0, colliding with the first row's cmin.
 DELETE FROM combocid_vischeck WHERE a = 2;
@@ -297,10 +309,14 @@ SELECT count(*) FROM combocid_vischeck;
      2
 (1 row)
 
--- Skip past the big table's rows; the segment scans the page of interest
--- only now.  The cursor's snapshot predates the insertion of (2), so it
--- must see only (1).
-MOVE 200000 FROM combocid_vischeck_cur;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- The cursor's snapshot predates the insertion of (2), so it must see
+-- only (1).
 FETCH ALL FROM combocid_vischeck_cur;
  a 
 ---
@@ -308,3 +324,9 @@ FETCH ALL FROM combocid_vischeck_cur;
 (1 row)
 
 COMMIT;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/expected/combocid_gp_optimizer.out
+++ b/src/test/regress/expected/combocid_gp_optimizer.out
@@ -255,3 +255,58 @@ FETCH ALL FROM c;
 (99 rows)
 
 rollback;
+--
+-- Test that the one-item tuple-visibility cache in heapgetpage() ignores
+-- tuples carrying HEAP_COMBOCID.  Such a tuple's raw command id is an index
+-- into the backend-local combo-CID array, not a real cmin, so it must not be
+-- compared against another tuple's plain command id.
+--
+-- The scenario: a tuple whose deleting subtransaction aborted keeps its
+-- combo cid, and a later scan sets the HEAP_XMAX_INVALID hint bit, which
+-- used to make it eligible for the cache.  Combo-CID indexes and command
+-- ids both count from zero, so the combo index easily collides with the
+-- plain cmin of another tuple on the same page.  A cursor whose snapshot
+-- lies between the two real cmins then returned a wrong extra row: the
+-- plain tuple primed the cache and the combo tuple falsely hit it.
+--
+-- All rows use the same distribution key, so they land on the same segment
+-- and the same heap page.  The cursor query scans a big table before the
+-- table of interest (UNION ALL), so that the QE fills the motion send
+-- buffer and blocks at DECLARE time, and only reaches the page of interest
+-- during FETCH, after the hint bit has been set.
+--
+CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
+INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
+BEGIN;
+INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
+DECLARE combocid_vischeck_cur CURSOR FOR
+    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
+INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+-- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
+INSERT INTO combocid_vischeck VALUES (2, 0);
+SAVEPOINT s;
+-- Assigns combo-CID index 0, colliding with the first row's cmin.
+DELETE FROM combocid_vischeck WHERE a = 2;
+ROLLBACK TO s;
+-- This scan sets the HEAP_XMAX_INVALID hint bit (the deleter aborted).
+SELECT count(*) FROM combocid_vischeck;
+ count 
+-------
+     2
+(1 row)
+
+-- Skip past the big table's rows; the segment scans the page of interest
+-- only now.  The cursor's snapshot predates the insertion of (2), so it
+-- must see only (1).
+MOVE 200000 FROM combocid_vischeck_cur;
+FETCH ALL FROM combocid_vischeck_cur;
+ a 
+---
+ 1
+(1 row)
+
+COMMIT;

--- a/src/test/regress/expected/combocid_gp_optimizer.out
+++ b/src/test/regress/expected/combocid_gp_optimizer.out
@@ -269,25 +269,37 @@ rollback;
 -- lies between the two real cmins then returned a wrong extra row: the
 -- plain tuple primed the cache and the combo tuple falsely hit it.
 --
--- All rows use the same distribution key, so they land on the same segment
--- and the same heap page.  The cursor query scans a big table before the
--- table of interest (UNION ALL), so that the QE fills the motion send
--- buffer and blocks at DECLARE time, and only reaches the page of interest
--- during FETCH, after the hint bit has been set.
+-- Both rows use the same distribution key (2 hashes to content 0, dbid 2),
+-- so they land on the same segment and the same heap page.  QEs execute a
+-- cursor's plan eagerly at DECLARE, which would scan the page before the
+-- combo state exists; suspend the cursor's reader QE right after it has
+-- acquired its snapshot and set up interconnect, and resume it only after
+-- the combo tuple and the hint bit are in place, so the page is scanned at
+-- FETCH time.  The fault is armed for a single occurrence: the count(*)
+-- below passes the same fault point and must go through.
 --
 CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
 CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
-CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
-INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
 BEGIN;
-INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
-INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
-INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
-DECLARE combocid_vischeck_cur CURSOR FOR
-    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
-INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+INSERT INTO combocid_vischeck VALUES (1, 2);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 2);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 2);   -- burn a command id
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+DECLARE combocid_vischeck_cur CURSOR FOR SELECT a FROM combocid_vischeck;
+SELECT gp_wait_until_triggered_fault('qe_got_snapshot_and_interconnect', 1, 2);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+INSERT INTO combocid_vischeck_filler VALUES (3, 2);   -- burn a command id
 -- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
-INSERT INTO combocid_vischeck VALUES (2, 0);
+INSERT INTO combocid_vischeck VALUES (2, 2);
 SAVEPOINT s;
 -- Assigns combo-CID index 0, colliding with the first row's cmin.
 DELETE FROM combocid_vischeck WHERE a = 2;
@@ -299,10 +311,14 @@ SELECT count(*) FROM combocid_vischeck;
      2
 (1 row)
 
--- Skip past the big table's rows; the segment scans the page of interest
--- only now.  The cursor's snapshot predates the insertion of (2), so it
--- must see only (1).
-MOVE 200000 FROM combocid_vischeck_cur;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- The cursor's snapshot predates the insertion of (2), so it must see
+-- only (1).
 FETCH ALL FROM combocid_vischeck_cur;
  a 
 ---
@@ -310,3 +326,9 @@ FETCH ALL FROM combocid_vischeck_cur;
 (1 row)
 
 COMMIT;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -51,7 +51,11 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types combocid_gp gp_sort gp_prepared_xacts gp_backend_info gp_locale foreign_key_gp
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types gp_sort gp_prepared_xacts gp_backend_info gp_locale foreign_key_gp
+
+# combocid_gp uses fault injection (suspend/resume of a cursor's reader QE),
+# so it must run in its own group.
+test: combocid_gp
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults

--- a/src/test/regress/sql/combocid_gp.sql
+++ b/src/test/regress/sql/combocid_gp.sql
@@ -141,35 +141,37 @@ rollback;
 -- lies between the two real cmins then returned a wrong extra row: the
 -- plain tuple primed the cache and the combo tuple falsely hit it.
 --
--- All rows use the same distribution key, so they land on the same segment
--- and the same heap page.  The cursor query scans a big table before the
--- table of interest (UNION ALL), so that the QE fills the motion send
--- buffer and blocks at DECLARE time, and only reaches the page of interest
--- during FETCH, after the hint bit has been set.
+-- Both rows use the same distribution key (2 hashes to content 0, dbid 2),
+-- so they land on the same segment and the same heap page.  QEs execute a
+-- cursor's plan eagerly at DECLARE, which would scan the page before the
+-- combo state exists; suspend the cursor's reader QE right after it has
+-- acquired its snapshot and set up interconnect, and resume it only after
+-- the combo tuple and the hint bit are in place, so the page is scanned at
+-- FETCH time.  The fault is armed for a single occurrence: the count(*)
+-- below passes the same fault point and must go through.
 --
 CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
 CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
-CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
-INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
 
 BEGIN;
-INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
-INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
-INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
-DECLARE combocid_vischeck_cur CURSOR FOR
-    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
-INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+INSERT INTO combocid_vischeck VALUES (1, 2);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 2);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 2);   -- burn a command id
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'suspend', 2);
+DECLARE combocid_vischeck_cur CURSOR FOR SELECT a FROM combocid_vischeck;
+SELECT gp_wait_until_triggered_fault('qe_got_snapshot_and_interconnect', 1, 2);
+INSERT INTO combocid_vischeck_filler VALUES (3, 2);   -- burn a command id
 -- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
-INSERT INTO combocid_vischeck VALUES (2, 0);
+INSERT INTO combocid_vischeck VALUES (2, 2);
 SAVEPOINT s;
 -- Assigns combo-CID index 0, colliding with the first row's cmin.
 DELETE FROM combocid_vischeck WHERE a = 2;
 ROLLBACK TO s;
 -- This scan sets the HEAP_XMAX_INVALID hint bit (the deleter aborted).
 SELECT count(*) FROM combocid_vischeck;
--- Skip past the big table's rows; the segment scans the page of interest
--- only now.  The cursor's snapshot predates the insertion of (2), so it
--- must see only (1).
-MOVE 200000 FROM combocid_vischeck_cur;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'resume', 2);
+-- The cursor's snapshot predates the insertion of (2), so it must see
+-- only (1).
 FETCH ALL FROM combocid_vischeck_cur;
 COMMIT;
+SELECT gp_inject_fault('qe_got_snapshot_and_interconnect', 'reset', 2);

--- a/src/test/regress/sql/combocid_gp.sql
+++ b/src/test/regress/sql/combocid_gp.sql
@@ -126,3 +126,50 @@ MOVE 9900 FROM c;
 FETCH ALL FROM c;
 
 rollback;
+
+--
+-- Test that the one-item tuple-visibility cache in heapgetpage() ignores
+-- tuples carrying HEAP_COMBOCID.  Such a tuple's raw command id is an index
+-- into the backend-local combo-CID array, not a real cmin, so it must not be
+-- compared against another tuple's plain command id.
+--
+-- The scenario: a tuple whose deleting subtransaction aborted keeps its
+-- combo cid, and a later scan sets the HEAP_XMAX_INVALID hint bit, which
+-- used to make it eligible for the cache.  Combo-CID indexes and command
+-- ids both count from zero, so the combo index easily collides with the
+-- plain cmin of another tuple on the same page.  A cursor whose snapshot
+-- lies between the two real cmins then returned a wrong extra row: the
+-- plain tuple primed the cache and the combo tuple falsely hit it.
+--
+-- All rows use the same distribution key, so they land on the same segment
+-- and the same heap page.  The cursor query scans a big table before the
+-- table of interest (UNION ALL), so that the QE fills the motion send
+-- buffer and blocks at DECLARE time, and only reaches the page of interest
+-- during FETCH, after the hint bit has been set.
+--
+CREATE TEMP TABLE combocid_vischeck (a int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_filler (x int, distkey int) distributed by (distkey);
+CREATE TEMP TABLE combocid_vischeck_big (a int, distkey int) distributed by (distkey);
+INSERT INTO combocid_vischeck_big SELECT 0, 0 FROM generate_series(1, 200000);
+
+BEGIN;
+INSERT INTO combocid_vischeck VALUES (1, 0);          -- cmin 0
+INSERT INTO combocid_vischeck_filler VALUES (1, 0);   -- burn a command id
+INSERT INTO combocid_vischeck_filler VALUES (2, 0);   -- burn a command id
+DECLARE combocid_vischeck_cur CURSOR FOR
+    SELECT a FROM combocid_vischeck_big UNION ALL SELECT a FROM combocid_vischeck;
+INSERT INTO combocid_vischeck_filler VALUES (3, 0);   -- burn a command id
+-- Insert before the savepoint, so the tuple keeps the main transaction's xmin.
+INSERT INTO combocid_vischeck VALUES (2, 0);
+SAVEPOINT s;
+-- Assigns combo-CID index 0, colliding with the first row's cmin.
+DELETE FROM combocid_vischeck WHERE a = 2;
+ROLLBACK TO s;
+-- This scan sets the HEAP_XMAX_INVALID hint bit (the deleter aborted).
+SELECT count(*) FROM combocid_vischeck;
+-- Skip past the big table's rows; the segment scans the page of interest
+-- only now.  The cursor's snapshot predates the insertion of (2), so it
+-- must see only (1).
+MOVE 200000 FROM combocid_vischeck_cur;
+FETCH ALL FROM combocid_vischeck_cur;
+COMMIT;


### PR DESCRIPTION
Fixes #264.

`heapgetpage()`'s one-item (xmin, cmin) tuple-visibility cache keys on `HeapTupleHeaderGetRawCommandId()`, but for a tuple carrying `HEAP_COMBOCID` that raw field holds a combo-CID array index, not a real cmin, while the actual visibility check resolves it through `HeapTupleHeaderGetCmin()`.

The cache gate from fec5f0b56c3 ("Fix the one-element tuple visibility cache in heap scans, for multi-xids.") excludes most combo-CID tuples, since creating a combo CID requires a same-transaction delete which sets a real xmax. But if the deleting subtransaction aborted, the tuple keeps `HEAP_COMBOCID` with raw cid = combo index, and once a later scan sets the `HEAP_XMAX_INVALID` hint bit it passes the gate. Combo indexes and cmins both count from 0, so the index easily collides with another same-page, same-xmin tuple's plain cmin; a cursor whose snapshot curcid lies between the two real cmins then sees a row it must not: the plain tuple primes the cache and the combo tuple falsely hits it (full repro in the linked issue).

Fix: exclude `HEAP_COMBOCID` tuples from the cache. Their raw command id is not comparable with a plain cmin; they merely fall back to the full visibility check, so eligible-tuple performance is unchanged. The gate covers both admission legs, which also closes the variant where a tuple carrying a stale combo cid is later locked-only by the same transaction.

Test: a dispatch-mode case appended to `combocid_gp` (both expected variants). The naive shape cannot trigger the bug through dispatch — QEs execute a cursor plan eagerly at DECLARE, so the tiny page is scanned before the combo state exists. The test therefore stalls the QE by scanning a large same-distribution-key table first via UNION ALL, so the page of interest is reached only at FETCH, after the hint-bit-setting scan. Verified the test fails on the unfixed binary and passes with the fix, under both ORCA and the Postgres planner.

Local verification is arm64 (full parallel_schedule green on the fixed build); CI amd64 is authoritative.
