### PR TITLE
analyzedb: fix 'Bad file descriptor' when coordinator data directory is on NFS

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -905,7 +905,11 @@ class AnalyzeDb(Operation):
                       root_partition_col_dict, dirty_partitions, target_list):
         lock_file_path = self.ensure_semaphore_file_exists()
 
-        with open(lock_file_path, 'r') as lock_file:
+        # The descriptor must be opened for writing: on NFS the kernel client
+        # translates flock() into a byte-range lock and rejects an exclusive
+        # (F_WRLCK) request on a read-only descriptor with EBADF. The file is
+        # guaranteed to exist here, so 'r+' never truncates or creates it.
+        with open(lock_file_path, 'r+') as lock_file:
             logger.info("about to request exclusive lock on '%s' for analyzedb, to be able to write results..." % lock_file_path)
             fcntl.flock(lock_file, fcntl.LOCK_EX)  # will block until available
             logger.info("acquired analyzedb output lock, proceeding...")


### PR DESCRIPTION
## Problem

`analyzedb` fails with `OSError: [Errno 9] Bad file descriptor` whenever the coordinator data directory lives on an NFS-backed filesystem (for example Amazon EFS, NFSv4.1):

```
analyzedb:cdw:gpadmin-[INFO]:-Created /data/coordinator/gpseg-1/db_analyze/dev
analyzedb:cdw:gpadmin-[INFO]:-about to request exclusive lock on '/data/coordinator/gpseg-1/db_analyze/dev/write_lock_semaphore' for analyzedb, to be able to write results...
analyzedb:cdw:gpadmin-[ERROR]:-[Errno 9] Bad file descriptor
Traceback (most recent call last):
  File "/usr/edb/whpg7/bin/analyzedb", line 451, in execute
    self._write_report(curr_ao_state, curr_last_op, heap_partitions, input_col_dict,
  File "/usr/edb/whpg7/bin/analyzedb", line 910, in _write_report
    fcntl.flock(lock_file, fcntl.LOCK_EX)  # will block until available
OSError: [Errno 9] Bad file descriptor
analyzedb:cdw:gpadmin-[CRITICAL]:-analyzedb failed. (Reason='[Errno 9] Bad file descriptor') exiting...
```

The failure happens at the very last step of the run, **after** every `ANALYZE` has already been executed against the segments. Only the report/results write fails, so the error is both misleading and expensive — all of the analyze work is thrown away.

## Root cause

`AnalyzeDb._write_report()` in `gpMgmt/bin/analyzedb` opened the `write_lock_semaphore` file read-only and then asked for an *exclusive* lock on that descriptor:

```python
with open(lock_file_path, 'r') as lock_file:      # opened READ-ONLY
    fcntl.flock(lock_file, fcntl.LOCK_EX)          # requests an EXCLUSIVE (write) lock
```

On local filesystems (ext4, XFS) `flock()` does not check whether the descriptor was opened for writing before granting an exclusive lock, so this has always worked in the officially supported layout — which is why the bug went unnoticed.

The Linux NFS client is stricter: it translates `flock()` into a byte-range lock tied to the file's open state and explicitly checks that a request for `F_WRLCK` comes from a descriptor opened with `FMODE_WRITE`. When it does not, the client returns `-EBADF` immediately, without even issuing an NFS request. Python surfaces that return value verbatim as `OSError: [Errno 9] Bad file descriptor`.

This is a property of the NFS client, not of EFS, so any NFSv4-backed coordinator storage is affected. (The check has had some churn upstream — removed in "NFS: Remove the flock check for matching open mode" and then reverted — precisely because it surprises callers. Current kernels have it.)

## Fix

Open the semaphore file with `'r+'` instead of `'r'`:

```python
with open(lock_file_path, 'r+') as lock_file:
    fcntl.flock(lock_file, fcntl.LOCK_EX)
```

`ensure_semaphore_file_exists()` runs immediately before this and guarantees the file exists, so `'r+'` neither creates nor truncates it — it only gives the descriptor `FMODE_WRITE`, which satisfies the NFS client's check. Behavior on local filesystems is unchanged: the same exclusive lock is taken and released, and the file's contents are untouched.

A comment is added at the call site so the open mode is not "simplified" back to `'r'` later.