### PR TITLE
Check for USAGE privilege on types used by stored expressions, ALTER TABLE OF and CREATE TYPE AS RANGE (CVE-2026-6470)

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -15,3 +15,4 @@ gp_resgroup_print_operator_memory_limits
 pqFunctionCall3
 SetTuplestoreDestReceiverParams
 build_gpqeid_param
+AlterDomainAddConstraint

--- a/doc/src/sgml/ref/create_type.sgml
+++ b/doc/src/sgml/ref/create_type.sgml
@@ -176,6 +176,11 @@ CREATE TYPE <replaceable class="parameter">name</replaceable>
     the range type.  See <xref linkend="rangetypes-defining"/> for more
     information.
    </para>
+
+   <para>
+    To be able to create a range type, you must have <literal>USAGE</literal>
+    privilege on the subtype.
+   </para>
   </refsect2>
 
   <refsect2>

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1772,6 +1772,83 @@ recordDependencyOnSingleRelExpr(const ObjectAddress *depender,
 }
 
 /*
+ * We require USAGE on a type to store a dependency on it.  This helper
+ * function does the appropriate privilege checks.
+ *
+ * NB: Other objects have privileges of their own, but recording those
+ * dependencies doesn't require holding them.  For example, an expression may
+ * reference a function for which the user lacks EXECUTE.  Instead, EXECUTE is
+ * checked when the function is executed.
+ */
+static void
+check_usage_on_types(ObjectAddresses *addrs, Oid roleid)
+{
+	for (int i = 0; i < addrs->numrefs; i++)
+	{
+		ObjectAddress *ref = &addrs->refs[i];
+		AclResult	aclresult;
+
+		if (ref->classId != TypeRelationId)
+			continue;
+
+		aclresult = pg_type_aclcheck(ref->objectId,
+									 roleid, ACL_USAGE);
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error_type(aclresult, ref->objectId);
+	}
+}
+
+/*
+ * CheckUsageOnTypesInExpr - require USAGE on all types named by an expression
+ *
+ * rtable is the rangetable for interpreting Vars (or NIL if none are
+ * expected).  roleid is the role whose USAGE is required.
+ */
+void
+CheckUsageOnTypesInExpr(Node *expr, List *rtable, Oid roleid)
+{
+	find_expr_references_context context;
+
+	context.addrs = new_object_addresses();
+
+	/* Set up interpretation for Vars at varlevelsup = 0 */
+	context.rtables = list_make1(rtable);
+
+	find_expr_references_walker(expr, &context);
+	eliminate_duplicate_dependencies(context.addrs);
+	check_usage_on_types(context.addrs, roleid);
+	free_object_addresses(context.addrs);
+}
+
+/*
+ * CheckUsageOnTypesInSingleRelExpr - as above, for a single-rel expression
+ *
+ * Like recordDependencyOnSingleRelExpr(), this handles expressions whose Vars
+ * all refer to one relation.  roleid is the role whose USAGE is required.
+ */
+void
+CheckUsageOnTypesInSingleRelExpr(Node *expr, Oid relId, Oid roleid)
+{
+	find_expr_references_context context;
+	RangeTblEntry rte = {0};
+
+	context.addrs = new_object_addresses();
+
+	/* We gin up a rather bogus rangetable list to handle Vars */
+	rte.type = T_RangeTblEntry;
+	rte.rtekind = RTE_RELATION;
+	rte.relid = relId;
+	rte.relkind = RELKIND_RELATION;
+	rte.rellockmode = AccessShareLock;
+	context.rtables = list_make1(list_make1(&rte));
+
+	find_expr_references_walker(expr, &context);
+	eliminate_duplicate_dependencies(context.addrs);
+	check_usage_on_types(context.addrs, roleid);
+	free_object_addresses(context.addrs);
+}
+
+/*
  * Recursively search an expression tree for object references.
  *
  * Note: we avoid creating references to columns of tables that participate

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2785,6 +2785,9 @@ SetAttrMissing(Oid relid, char *attname, char *value)
  * the value - like in upstream - and returns it in
  * *missingval_p/missingIsNull_p. In the QE, the caller is expected to pass
  * the pre-computed values in missingval/missingIsNull.
+ *
+ * NB: Caller is responsible for ensuring the user has USAGE on all types expr
+ * depends on.
  */
 Oid
 StoreAttrDefault(Relation rel, AttrNumber attnum,
@@ -2991,6 +2994,9 @@ StoreAttrDefault(Relation rel, AttrNumber attnum,
  * in the pg_class entry for the relation.
  *
  * The OID of the new constraint is returned.
+ *
+ * NB: Caller is responsible for ensuring the user has USAGE on all types expr
+ * depends on.
  */
 static Oid
 StoreRelCheck(Relation rel, const char *ccname, Node *expr,
@@ -3252,6 +3258,13 @@ AddRelationNewConstraints(Relation rel,
 		if (colDef->missingMode && contain_volatile_functions((Node *) expr))
 			colDef->missingMode = false;
 
+		/*
+		 * The below call to StoreAttrDefault() adds the dependencies on
+		 * types.  We are responsible for checking USAGE.
+		 */
+		if (!is_internal)
+			CheckUsageOnTypesInSingleRelExpr(expr, RelationGetRelid(rel), GetUserId());
+
 		defOid = StoreAttrDefault(rel, colDef->attnum, expr,
 								  &colDef->hasCookedMissingVal,
 								  &colDef->missingVal,
@@ -3296,6 +3309,14 @@ AddRelationNewConstraints(Relation rel,
 			 */
 			expr = cookConstraint(pstate, cdef->raw_expr,
 								  RelationGetRelationName(rel));
+
+			/*
+			 * The below call to StoreRelCheck() calls CreateConstraintEntry(),
+			 * which adds the dependencies on types.  We are responsible for
+			 * checking USAGE.
+			 */
+			if (!is_internal)
+				CheckUsageOnTypesInSingleRelExpr(expr, RelationGetRelid(rel), GetUserId());
 		}
 		else
 		{
@@ -4387,12 +4408,16 @@ StorePartitionKey(Relation rel,
 	 * columns, i.e. they become internally dependent on the whole table.
 	 */
 	if (partexprs)
+	{
+		CheckUsageOnTypesInSingleRelExpr((Node *) partexprs, RelationGetRelid(rel),
+										 GetUserId());
 		recordDependencyOnSingleRelExpr(&myself,
 										(Node *) partexprs,
 										RelationGetRelid(rel),
 										DEPENDENCY_NORMAL,
 										DEPENDENCY_INTERNAL,
 										true /* reverse the self-deps */ );
+	}
 
 	/*
 	 * We must invalidate the relcache so that the next

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -736,6 +736,9 @@ UpdateIndexRelation(Oid indexoid,
  * constraintId: if not NULL, receives OID of created constraint
  *
  * Returns the OID of the created index.
+ *
+ * NB: Caller is responsible for ensuring the user has USAGE on all types
+ * indexInfo->ii_{Expressions,Predicate} depend on.
  */
 Oid
 index_create(Relation heapRelation,

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -48,6 +48,9 @@
  * from the constraint to the things it depends on.
  *
  * The new constraint's OID is returned.
+ *
+ * NB: Caller is responsible for ensuring the user has USAGE on all types
+ * conExpr depends on.
  */
 Oid
 CreateConstraintEntry(const char *constraintName,

--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -734,8 +734,11 @@ ProcedureCreate(const char *procedureName,
 
 	/* dependency on parameter default expressions */
 	if (parameterDefaults)
+	{
+		CheckUsageOnTypesInExpr((Node *) parameterDefaults, NIL, GetUserId());
 		recordDependencyOnExpr(&myself, (Node *) parameterDefaults,
 							   NIL, DEPENDENCY_NORMAL);
+	}
 
 	/* dependency on support function, if any */
 	if (OidIsValid(prosupport))

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -337,6 +337,9 @@ TypeShellMake(const char *typeName, Oid typeNamespace, Oid ownerId)
  *		Returns the ObjectAddress assigned to the new type.
  *		If newTypeOid is zero (the normal case), a new OID is created;
  *		otherwise we use exactly that OID.
+ *
+ *		NB: Caller is responsible for ensuring the user has USAGE
+ *		on all types defaultTypeBin depends on.
  * ----------------------------------------------------------------
  */
 ObjectAddress
@@ -672,6 +675,9 @@ TypeCreate(Oid newTypeOid,
  * That means an extension can't absorb a shell type that is free-standing
  * or belongs to another extension, nor ALTER a type that is free-standing or
  * belongs to another extension.
+ *
+ * NB: Caller is responsible for ensuring the user has USAGE on all types
+ * defaultExpr depends on.
  */
 void
 GenerateTypeDependencies(Oid typeObjectId,

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1090,6 +1090,22 @@ DefineIndex(Oid relationId,
 					  root_save_sec_context, &root_save_nestlevel);
 
 	/*
+	 * The below call to index_create() creates the dependencies on types.  We
+	 * are responsible for checking USAGE.
+	 */
+	if (check_rights)
+	{
+		if (indexInfo->ii_Expressions)
+			CheckUsageOnTypesInSingleRelExpr((Node *) indexInfo->ii_Expressions,
+											 relationId,
+											 root_save_userid);
+		if (indexInfo->ii_Predicate)
+			CheckUsageOnTypesInSingleRelExpr((Node *) indexInfo->ii_Predicate,
+											 relationId,
+											 root_save_userid);
+	}
+
+	/*
 	 * Extra checks when creating a PRIMARY KEY index.
 	 */
 	if (stmt->primary)

--- a/src/backend/commands/policy.c
+++ b/src/backend/commands/policy.c
@@ -735,9 +735,12 @@ CreatePolicy(CreatePolicyStmt *stmt)
 
 	recordDependencyOn(&myself, &target, DEPENDENCY_AUTO);
 
+	CheckUsageOnTypesInExpr(qual, qual_pstate->p_rtable, GetUserId());
 	recordDependencyOnExpr(&myself, qual, qual_pstate->p_rtable,
 						   DEPENDENCY_NORMAL);
 
+	CheckUsageOnTypesInExpr(with_check_qual, with_check_pstate->p_rtable,
+							GetUserId());
 	recordDependencyOnExpr(&myself, with_check_qual,
 						   with_check_pstate->p_rtable, DEPENDENCY_NORMAL);
 
@@ -1081,8 +1084,13 @@ AlterPolicy(AlterPolicyStmt *stmt)
 
 	recordDependencyOn(&myself, &target, DEPENDENCY_AUTO);
 
+	if (stmt->qual)
+		CheckUsageOnTypesInExpr(qual, qual_parse_rtable, GetUserId());
 	recordDependencyOnExpr(&myself, qual, qual_parse_rtable, DEPENDENCY_NORMAL);
 
+	if (stmt->with_check)
+		CheckUsageOnTypesInExpr(with_check_qual, with_check_parse_rtable,
+								GetUserId());
 	recordDependencyOnExpr(&myself, with_check_qual, with_check_parse_rtable,
 						   DEPENDENCY_NORMAL);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -913,6 +913,14 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	}
 
 	/*
+	 * NB: The defaults and constraints we just inherited are already cooked,
+	 * so they don't get the USAGE checks that AddRelationNewConstraints()
+	 * applies to raw ones.  That's intentional: the parent's own catalog
+	 * entries already depend on those types, so copying them pins nothing
+	 * new, and creating a child requires owning the parent, anyway.
+	 */
+
+	/*
 	 * Create a tuple descriptor from the relation schema.  Note that this
 	 * deals with column names, types, and NOT NULL constraints, but not
 	 * default values or CHECK constraints; we handle those below.
@@ -5633,7 +5641,7 @@ ATExecCmd(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			address =
 				AlterDomainAddConstraint(((AlterDomainStmt *) cmd->def)->typeName,
 										 ((AlterDomainStmt *) cmd->def)->def,
-										 NULL);
+										 NULL, true);
 			break;
 		case AT_ReAddComment:	/* Re-add existing comment */
 			address = CommentObject((CommentStmt *) cmd->def);
@@ -8631,7 +8639,14 @@ ATExecCookedColumnDefault(Relation rel, AttrNumber attnum,
 {
 	ObjectAddress address;
 
-	/* We assume no checking is required */
+	/*
+	 * This is used for a cooked default copied by CREATE TABLE ... LIKE,
+	 * which adds new type dependencies.  Such a default doesn't go through
+	 * AddRelationNewConstraints(), and StoreAttrDefault() leaves the
+	 * privilege checks to its caller, so we must check for USAGE on the types
+	 * here.
+	 */
+	CheckUsageOnTypesInSingleRelExpr(newDefault, RelationGetRelid(rel), GetUserId());
 
 	/*
 	 * Remove any old default for the column.  We use RESTRICT here for

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -18632,12 +18632,17 @@ ATExecAddOf(Relation rel, const TypeName *ofTypename, LOCKMODE lockmode)
 	ObjectAddress tableobj,
 				typeobj;
 	HeapTuple	classtuple;
+	AclResult	aclresult;
 
 	/* Validate the type. */
 	typetuple = typenameType(NULL, ofTypename, NULL);
 	check_of_type(typetuple);
 	typeform = (Form_pg_type) GETSTRUCT(typetuple);
 	typeid = typeform->oid;
+
+	aclresult = pg_type_aclcheck(typeid, GetUserId(), ACL_USAGE);
+	if (aclresult != ACLCHECK_OK)
+		aclcheck_error_type(aclresult, typeid);
 
 	/* Fail if the table has any inheritance parents. */
 	inheritsRelation = table_open(InheritsRelationId, AccessShareLock);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1168,8 +1168,13 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	 * expression (eg, functions, as well as any columns used).
 	 */
 	if (whenRtable != NIL)
+	{
+		if (!isInternal)
+			CheckUsageOnTypesInExpr(whenClause, whenRtable, GetUserId());
+
 		recordDependencyOnExpr(&myself, whenClause, whenRtable,
 							   DEPENDENCY_NORMAL);
+	}
 
 	/* Post creation hook for new trigger */
 	InvokeObjectPostCreateHookArg(TriggerRelationId, trigoid, 0,

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -112,7 +112,8 @@ static void checkEnumOwner(HeapTuple tup);
 static char *domainAddConstraint(Oid domainOid, Oid domainNamespace,
 								 Oid baseTypeOid,
 								 int typMod, Constraint *constr,
-								 const char *domainName, ObjectAddress *constrAddr);
+								 const char *domainName, ObjectAddress *constrAddr,
+								 bool is_readd);
 static Node *replace_domain_constraint_value(ParseState *pstate,
 											 ColumnRef *cref);
 
@@ -1115,6 +1116,13 @@ DefineDomain(CreateDomainStmt *stmt)
 		}
 	}
 
+	/*
+	 * The below call to TypeCreate() calls GenerateTypeDependencies(), which
+	 * adds the dependencies on types.  We are responsible for checking USAGE.
+	 */
+	if (defaultValueBin)
+		CheckUsageOnTypesInExpr(stringToNode(defaultValueBin), NIL, GetUserId());
+
 	/* Allocate OID for array type */
 	domainArrayName = makeArrayTypeName(domainName, domainNamespace);
 	domainArrayOid = AssignTypeArrayOid(domainArrayName, domainNamespace);
@@ -1210,7 +1218,7 @@ DefineDomain(CreateDomainStmt *stmt)
 			case CONSTR_CHECK:
 				domainAddConstraint(address.objectId, domainNamespace,
 									basetypeoid, basetypeMod,
-									constr, domainName, NULL);
+									constr, domainName, NULL, false);
 				break;
 
 				/* Other constraint types were fully processed above */
@@ -2388,6 +2396,12 @@ AlterDomainDefault(List *names, Node *defaultRaw)
 		else
 		{
 			/*
+			 * The below call to GenerateTypeDependencies() creates the
+			 * dependencies on types.  We are responsible for checking USAGE.
+			 */
+			CheckUsageOnTypesInExpr(defaultExpr, NIL, GetUserId());
+
+			/*
 			 * Expression must be stored as a nodeToString result, but we also
 			 * require a valid textual representation (mainly to make life
 			 * easier for pg_dump).
@@ -2677,7 +2691,7 @@ AlterDomainDropConstraint(List *names, const char *constrName,
  */
 ObjectAddress
 AlterDomainAddConstraint(List *names, Node *newConstraint,
-						 ObjectAddress *constrAddr)
+						 ObjectAddress *constrAddr, bool is_readd)
 {
 	TypeName   *typename;
 	Oid			domainoid;
@@ -2762,7 +2776,8 @@ AlterDomainAddConstraint(List *names, Node *newConstraint,
 
 	ccbin = domainAddConstraint(domainoid, typTup->typnamespace,
 								typTup->typbasetype, typTup->typtypmod,
-								constr, NameStr(typTup->typname), constrAddr);
+								constr, NameStr(typTup->typname), constrAddr,
+								is_readd);
 
 	/*
 	 * If requested to validate the constraint, test all values stored in the
@@ -3205,7 +3220,8 @@ checkDomainOwner(HeapTuple tup)
 static char *
 domainAddConstraint(Oid domainOid, Oid domainNamespace, Oid baseTypeOid,
 					int typMod, Constraint *constr,
-					const char *domainName, ObjectAddress *constrAddr)
+					const char *domainName, ObjectAddress *constrAddr,
+					bool is_readd)
 {
 	Node	   *expr;
 	char	   *ccbin;
@@ -3270,6 +3286,13 @@ domainAddConstraint(Oid domainOid, Oid domainNamespace, Oid baseTypeOid,
 	 * Fix up collation information.
 	 */
 	assign_expr_collations(pstate, expr);
+
+	/*
+	 * The below call to CreateConstraintEntry() creates the dependencies on
+	 * types.  We are responsible for checking USAGE.
+	 */
+	if (!is_readd)
+		CheckUsageOnTypesInExpr(expr, NIL, GetUserId());
 
 	/*
 	 * Domains don't allow variables (this is probably dead code now that

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -1586,6 +1586,10 @@ DefineRange(CreateRangeStmt *stmt)
 				 errmsg("range subtype cannot be %s",
 						format_type_be(rangeSubtype))));
 
+	aclresult = pg_type_aclcheck(rangeSubtype, GetUserId(), ACL_USAGE);
+	if (aclresult != ACLCHECK_OK)
+		aclcheck_error_type(aclresult, rangeSubtype);
+
 	/* Identify subopclass */
 	rangeSubOpclass = findRangeSubOpclass(rangeSubOpclassName, rangeSubtype);
 

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1519,6 +1519,16 @@ expandTableLikeClause(RangeVar *heapRel, TableLikeClause *table_like_clause)
 								   ccname,
 								   RelationGetRelationName(relation))));
 
+			/*
+			 * Copying a CHECK constraint adds new references.  Since the
+			 * constraint arrives pre-cooked, it bypasses the checks in
+			 * AddRelationNewConstraints(), so we must check for USAGE on
+			 * types here.
+			 */
+			CheckUsageOnTypesInSingleRelExpr(stringToNode(ccbin),
+											 RelationGetRelid(relation),
+											 GetUserId());
+
 			n = makeNode(Constraint);
 			n->contype = CONSTR_CHECK;
 			n->location = -1;

--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -178,6 +178,7 @@ InsertRule(const char *rulname,
 	/*
 	 * Also install dependencies on objects referenced in action and qual.
 	 */
+	CheckUsageOnTypesInExpr((Node *) action, NIL, GetUserId());
 	recordDependencyOnExpr(&myself, (Node *) action, NIL,
 						   DEPENDENCY_NORMAL);
 
@@ -187,6 +188,7 @@ InsertRule(const char *rulname,
 		Query	   *qry = linitial_node(Query, action);
 
 		qry = getInsertSelectQuery(qry, NULL);
+		CheckUsageOnTypesInExpr(event_qual, qry->rtable, GetUserId());
 		recordDependencyOnExpr(&myself, event_qual, qry->rtable,
 							   DEPENDENCY_NORMAL);
 	}

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1564,7 +1564,8 @@ ProcessUtilitySlow(ParseState *pstate,
 							address =
 								AlterDomainAddConstraint(stmt->typeName,
 														 stmt->def,
-														 &secondaryObject);
+														 &secondaryObject,
+														 false);
 							break;
 						case 'X':	/* DROP CONSTRAINT */
 							address =

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -174,6 +174,10 @@ extern void recordDependencyOnSingleRelExpr(const ObjectAddress *depender,
 
 extern ObjectClass getObjectClass(const ObjectAddress *object);
 
+extern void CheckUsageOnTypesInExpr(Node *expr, List *rtable, Oid roleid);
+
+extern void CheckUsageOnTypesInSingleRelExpr(Node *expr, Oid relId, Oid roleid);
+
 extern ObjectAddresses *new_object_addresses(void);
 
 extern void add_exact_object_address(const ObjectAddress *object,

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -34,7 +34,8 @@ extern Oid AssignTypeArrayOid(char *arrayTypeName, Oid typeNamespace);
 extern ObjectAddress AlterDomainDefault(List *names, Node *defaultRaw);
 extern ObjectAddress AlterDomainNotNull(List *names, bool notNull);
 extern ObjectAddress AlterDomainAddConstraint(List *names, Node *constr,
-											  ObjectAddress *constrAddr);
+											  ObjectAddress *constrAddr,
+											  bool is_readd);
 extern ObjectAddress AlterDomainValidateConstraint(List *names, const char *constrName);
 extern ObjectAddress AlterDomainDropConstraint(List *names, const char *constrName,
 											   DropBehavior behavior, bool missing_ok);

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1011,10 +1011,14 @@ CREATE CAST (priv_testdomain1 AS priv_testdomain3a) WITH FUNCTION castfunc(int);
 ERROR:  permission denied for type priv_testdomain1
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3a;
+CREATE DOMAIN priv_testdomain4a AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
+ERROR:  permission denied for type priv_testtype1
 CREATE FUNCTION priv_testfunc5a(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 ERROR:  permission denied for type priv_testdomain1
 CREATE FUNCTION priv_testfunc6a(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
 ERROR:  permission denied for type priv_testdomain1
+CREATE FUNCTION priv_testfunc7a(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
+ERROR:  permission denied for type priv_testtype1
 CREATE OPERATOR !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test5a (a int, b priv_testdomain1);
@@ -1028,6 +1032,8 @@ ALTER TABLE test9a ADD COLUMN c priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
 ALTER TABLE test9a ALTER COLUMN b TYPE priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
+CREATE INDEX ON test9a ((a::priv_testdomain1));
+ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test7a AS (a int, b priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test8a AS (a int, b int);
@@ -1035,9 +1041,21 @@ ALTER TYPE test8a ADD ATTRIBUTE c priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
 ALTER TYPE test8a ALTER ATTRIBUTE b TYPE priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
+CREATE DOMAIN priv_testdomain5a AS test8a CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test11a AS (SELECT 1::priv_testdomain1 AS a);
 ERROR:  permission denied for type priv_testdomain1
+CREATE VIEW test16a AS SELECT ('(0,1)'::priv_testtype1).a;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test17a (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+ERROR:  permission denied for type priv_testtype1
+CREATE POLICY priv_testpolicy1a ON test9a USING (('(0,1)'::priv_testtype1).a > 0);
+ERROR:  permission denied for type priv_testtype1
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
 ERROR:  permission denied for type priv_testtype1
 SET SESSION AUTHORIZATION regress_priv_user2;
 -- commands that should succeed
@@ -1047,8 +1065,10 @@ CREATE DOMAIN priv_testdomain3b AS int;
 CREATE FUNCTION castfunc(int) RETURNS priv_testdomain3b AS $$ SELECT $1::priv_testdomain3b $$ LANGUAGE SQL;
 CREATE CAST (priv_testdomain1 AS priv_testdomain3b) WITH FUNCTION castfunc(int);
 WARNING:  cast will be ignored because the source data type is a domain
+CREATE DOMAIN priv_testdomain4b AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
 CREATE FUNCTION priv_testfunc5b(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE FUNCTION priv_testfunc6b(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
+CREATE FUNCTION priv_testfunc7b(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
@@ -1056,20 +1076,42 @@ CREATE TABLE test10b (a int[], b priv_testtype1[]);
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
 ALTER TABLE test9b ALTER COLUMN b TYPE priv_testdomain1;
+CREATE INDEX ON test9b ((a::priv_testdomain1));
 CREATE TYPE test7b AS (a int, b priv_testdomain1);
 CREATE TYPE test8b AS (a int, b int);
 ALTER TYPE test8b ADD ATTRIBUTE c priv_testdomain1;
 ALTER TYPE test8b ALTER ATTRIBUTE b TYPE priv_testdomain1;
+CREATE DOMAIN priv_testdomain5b AS test8b CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
 CREATE TABLE test11b AS (SELECT 1::priv_testdomain1 AS a);
+CREATE VIEW test16b AS SELECT ('(0,1)'::priv_testtype1).a;
+CREATE TABLE test17b (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+CREATE POLICY priv_testpolicy1b ON test9b USING (('(0,1)'::priv_testtype1).a > 0);
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
 WARNING:  no privileges could be revoked for "priv_testtype1"
 NOTICE:  no privileges could be revoked
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
+-- new stored expressions require USAGE on types, rebuilds do not
+\c -
+REVOKE USAGE ON TYPE priv_testtype1 FROM regress_priv_user2;
+SET SESSION AUTHORIZATION regress_priv_user2;
+ALTER TABLE test12 ALTER COLUMN c TYPE bigint;
+ALTER TYPE test8b ALTER ATTRIBUTE a TYPE bigint CASCADE;
+ALTER TABLE test12 ALTER COLUMN c SET DEFAULT ('(0,1)'::priv_testtype1).a;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test14 (LIKE test12 INCLUDING CONSTRAINTS);
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test15 (LIKE test13 INCLUDING DEFAULTS);
+ERROR:  permission denied for type priv_testtype1
 \c -
 DROP AGGREGATE priv_testagg1b(priv_testdomain1);
 DROP DOMAIN priv_testdomain2b;
+DROP DOMAIN priv_testdomain4b;
+DROP DOMAIN priv_testdomain5b;
 DROP OPERATOR !! (NONE, priv_testdomain1);
 DROP FUNCTION priv_testfunc5b(a priv_testdomain1);
 DROP FUNCTION priv_testfunc6b(b int);
+DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
 DROP TABLE test9b;
@@ -1079,7 +1121,11 @@ DROP TYPE test8b;
 DROP CAST (priv_testdomain1 AS priv_testdomain3b);
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3b;
+DROP VIEW test16b;
 DROP TABLE test11b;
+DROP TABLE test17b;
+DROP TABLE test12;
+DROP TABLE test13;
 DROP TYPE priv_testtype1; -- ok
 DROP DOMAIN priv_testdomain1; -- ok
 -- truncate

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1025,6 +1025,9 @@ CREATE TABLE test5a (a int, b priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test6a OF priv_testtype1;
 ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test6a2 (a int, b text);
+ALTER TABLE test6a2 OF priv_testtype1;
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test10a (a int[], b priv_testtype1[]);
 ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test9a (a int, b int);
@@ -1072,6 +1075,8 @@ CREATE FUNCTION priv_testfunc7b(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETUR
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
+CREATE TABLE test6b2 (a int, b text);
+ALTER TABLE test6b2 OF priv_testtype1;
 CREATE TABLE test10b (a int[], b priv_testtype1[]);
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
@@ -1114,6 +1119,7 @@ DROP FUNCTION priv_testfunc6b(b int);
 DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
+DROP TABLE test6b2;
 DROP TABLE test9b;
 DROP TABLE test10b;
 DROP TYPE test7b;

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -1082,10 +1082,14 @@ CREATE CAST (priv_testdomain1 AS priv_testdomain3a) WITH FUNCTION castfunc(int);
 ERROR:  permission denied for type priv_testdomain1
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3a;
+CREATE DOMAIN priv_testdomain4a AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
+ERROR:  permission denied for type priv_testtype1
 CREATE FUNCTION priv_testfunc5a(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 ERROR:  permission denied for type priv_testdomain1
 CREATE FUNCTION priv_testfunc6a(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
 ERROR:  permission denied for type priv_testdomain1
+CREATE FUNCTION priv_testfunc7a(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
+ERROR:  permission denied for type priv_testtype1
 CREATE OPERATOR !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test5a (a int, b priv_testdomain1);
@@ -1099,6 +1103,8 @@ ALTER TABLE test9a ADD COLUMN c priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
 ALTER TABLE test9a ALTER COLUMN b TYPE priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
+CREATE INDEX ON test9a ((a::priv_testdomain1));
+ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test7a AS (a int, b priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TYPE test8a AS (a int, b int);
@@ -1106,9 +1112,21 @@ ALTER TYPE test8a ADD ATTRIBUTE c priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
 ALTER TYPE test8a ALTER ATTRIBUTE b TYPE priv_testdomain1;
 ERROR:  permission denied for type priv_testdomain1
+CREATE DOMAIN priv_testdomain5a AS test8a CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test11a AS (SELECT 1::priv_testdomain1 AS a);
 ERROR:  permission denied for type priv_testdomain1
+CREATE VIEW test16a AS SELECT ('(0,1)'::priv_testtype1).a;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test17a (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+ERROR:  permission denied for type priv_testtype1
+CREATE POLICY priv_testpolicy1a ON test9a USING (('(0,1)'::priv_testtype1).a > 0);
+ERROR:  permission denied for type priv_testtype1
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
 ERROR:  permission denied for type priv_testtype1
 SET SESSION AUTHORIZATION regress_priv_user2;
 -- commands that should succeed
@@ -1118,8 +1136,10 @@ CREATE DOMAIN priv_testdomain3b AS int;
 CREATE FUNCTION castfunc(int) RETURNS priv_testdomain3b AS $$ SELECT $1::priv_testdomain3b $$ LANGUAGE SQL;
 CREATE CAST (priv_testdomain1 AS priv_testdomain3b) WITH FUNCTION castfunc(int);
 WARNING:  cast will be ignored because the source data type is a domain
+CREATE DOMAIN priv_testdomain4b AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
 CREATE FUNCTION priv_testfunc5b(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE FUNCTION priv_testfunc6b(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
+CREATE FUNCTION priv_testfunc7b(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
@@ -1127,20 +1147,42 @@ CREATE TABLE test10b (a int[], b priv_testtype1[]);
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
 ALTER TABLE test9b ALTER COLUMN b TYPE priv_testdomain1;
+CREATE INDEX ON test9b ((a::priv_testdomain1));
 CREATE TYPE test7b AS (a int, b priv_testdomain1);
 CREATE TYPE test8b AS (a int, b int);
 ALTER TYPE test8b ADD ATTRIBUTE c priv_testdomain1;
 ALTER TYPE test8b ALTER ATTRIBUTE b TYPE priv_testdomain1;
+CREATE DOMAIN priv_testdomain5b AS test8b CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
 CREATE TABLE test11b AS (SELECT 1::priv_testdomain1 AS a);
+CREATE VIEW test16b AS SELECT ('(0,1)'::priv_testtype1).a;
+CREATE TABLE test17b (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+CREATE POLICY priv_testpolicy1b ON test9b USING (('(0,1)'::priv_testtype1).a > 0);
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
 WARNING:  no privileges could be revoked for "priv_testtype1"
 NOTICE:  no privileges could be revoked
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
+-- new stored expressions require USAGE on types, rebuilds do not
+\c -
+REVOKE USAGE ON TYPE priv_testtype1 FROM regress_priv_user2;
+SET SESSION AUTHORIZATION regress_priv_user2;
+ALTER TABLE test12 ALTER COLUMN c TYPE bigint;
+ALTER TYPE test8b ALTER ATTRIBUTE a TYPE bigint CASCADE;
+ALTER TABLE test12 ALTER COLUMN c SET DEFAULT ('(0,1)'::priv_testtype1).a;
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test14 (LIKE test12 INCLUDING CONSTRAINTS);
+ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test15 (LIKE test13 INCLUDING DEFAULTS);
+ERROR:  permission denied for type priv_testtype1
 \c -
 DROP AGGREGATE priv_testagg1b(priv_testdomain1);
 DROP DOMAIN priv_testdomain2b;
+DROP DOMAIN priv_testdomain4b;
+DROP DOMAIN priv_testdomain5b;
 DROP OPERATOR !! (NONE, priv_testdomain1);
 DROP FUNCTION priv_testfunc5b(a priv_testdomain1);
 DROP FUNCTION priv_testfunc6b(b int);
+DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
 DROP TABLE test9b;
@@ -1150,7 +1192,11 @@ DROP TYPE test8b;
 DROP CAST (priv_testdomain1 AS priv_testdomain3b);
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3b;
+DROP VIEW test16b;
 DROP TABLE test11b;
+DROP TABLE test17b;
+DROP TABLE test12;
+DROP TABLE test13;
 DROP TYPE priv_testtype1; -- ok
 DROP DOMAIN priv_testdomain1; -- ok
 -- truncate

--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -1096,6 +1096,9 @@ CREATE TABLE test5a (a int, b priv_testdomain1);
 ERROR:  permission denied for type priv_testdomain1
 CREATE TABLE test6a OF priv_testtype1;
 ERROR:  permission denied for type priv_testtype1
+CREATE TABLE test6a2 (a int, b text);
+ALTER TABLE test6a2 OF priv_testtype1;
+ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test10a (a int[], b priv_testtype1[]);
 ERROR:  permission denied for type priv_testtype1
 CREATE TABLE test9a (a int, b int);
@@ -1143,6 +1146,8 @@ CREATE FUNCTION priv_testfunc7b(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETUR
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
+CREATE TABLE test6b2 (a int, b text);
+ALTER TABLE test6b2 OF priv_testtype1;
 CREATE TABLE test10b (a int[], b priv_testtype1[]);
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
@@ -1185,6 +1190,7 @@ DROP FUNCTION priv_testfunc6b(b int);
 DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
+DROP TABLE test6b2;
 DROP TABLE test9b;
 DROP TABLE test10b;
 DROP TYPE test7b;

--- a/src/test/regress/expected/rangetypes.out
+++ b/src/test/regress/expected/rangetypes.out
@@ -1291,6 +1291,21 @@ ERROR:  range lower bound must be less than or equal to range upper bound
 LINE 1: select '[2010-01-01 01:00:00 -08, 2010-01-01 02:00:00 -05)':...
                ^
 set timezone to default;
+-- CREATE TYPE AS RANGE checks for USAGE on subtype
+CREATE ROLE regress_subtype;
+CREATE TYPE mytype AS (a INT, b INT);
+REVOKE USAGE ON TYPE mytype FROM PUBLIC;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+ERROR:  permission denied for type mytype
+RESET ROLE;
+GRANT USAGE ON TYPE mytype TO regress_subtype;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+RESET ROLE;
+DROP TYPE mytype CASCADE;
+NOTICE:  drop cascades to type myrange
+DROP ROLE regress_subtype;
 --
 -- Test user-defined range of floats
 --

--- a/src/test/regress/expected/rangetypes_optimizer.out
+++ b/src/test/regress/expected/rangetypes_optimizer.out
@@ -1293,6 +1293,21 @@ ERROR:  range lower bound must be less than or equal to range upper bound
 LINE 1: select '[2010-01-01 01:00:00 -08, 2010-01-01 02:00:00 -05)':...
                ^
 set timezone to default;
+-- CREATE TYPE AS RANGE checks for USAGE on subtype
+CREATE ROLE regress_subtype;
+CREATE TYPE mytype AS (a INT, b INT);
+REVOKE USAGE ON TYPE mytype FROM PUBLIC;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+ERROR:  permission denied for type mytype
+RESET ROLE;
+GRANT USAGE ON TYPE mytype TO regress_subtype;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+RESET ROLE;
+DROP TYPE mytype CASCADE;
+NOTICE:  drop cascades to type myrange
+DROP ROLE regress_subtype;
 --
 -- Test user-defined range of floats
 --

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -657,8 +657,11 @@ CREATE CAST (priv_testdomain1 AS priv_testdomain3a) WITH FUNCTION castfunc(int);
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3a;
 
+CREATE DOMAIN priv_testdomain4a AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
+
 CREATE FUNCTION priv_testfunc5a(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE FUNCTION priv_testfunc6a(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
+CREATE FUNCTION priv_testfunc7a(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 
 CREATE OPERATOR !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = priv_testdomain1);
 
@@ -669,6 +672,7 @@ CREATE TABLE test10a (a int[], b priv_testtype1[]);
 CREATE TABLE test9a (a int, b int);
 ALTER TABLE test9a ADD COLUMN c priv_testdomain1;
 ALTER TABLE test9a ALTER COLUMN b TYPE priv_testdomain1;
+CREATE INDEX ON test9a ((a::priv_testdomain1));
 
 CREATE TYPE test7a AS (a int, b priv_testdomain1);
 
@@ -676,9 +680,18 @@ CREATE TYPE test8a AS (a int, b int);
 ALTER TYPE test8a ADD ATTRIBUTE c priv_testdomain1;
 ALTER TYPE test8a ALTER ATTRIBUTE b TYPE priv_testdomain1;
 
+CREATE DOMAIN priv_testdomain5a AS test8a CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
+
 CREATE TABLE test11a AS (SELECT 1::priv_testdomain1 AS a);
 
+CREATE VIEW test16a AS SELECT ('(0,1)'::priv_testtype1).a;
+CREATE TABLE test17a (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+CREATE POLICY priv_testpolicy1a ON test9a USING (('(0,1)'::priv_testtype1).a > 0);
+
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
+
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
 
 SET SESSION AUTHORIZATION regress_priv_user2;
 
@@ -692,8 +705,11 @@ CREATE DOMAIN priv_testdomain3b AS int;
 CREATE FUNCTION castfunc(int) RETURNS priv_testdomain3b AS $$ SELECT $1::priv_testdomain3b $$ LANGUAGE SQL;
 CREATE CAST (priv_testdomain1 AS priv_testdomain3b) WITH FUNCTION castfunc(int);
 
+CREATE DOMAIN priv_testdomain4b AS int CHECK (VALUE > ('(0,1)'::priv_testtype1).a);
+
 CREATE FUNCTION priv_testfunc5b(a priv_testdomain1) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 CREATE FUNCTION priv_testfunc6b(b int) RETURNS priv_testdomain1 LANGUAGE SQL AS $$ SELECT $1::priv_testdomain1 $$;
+CREATE FUNCTION priv_testfunc7b(a int DEFAULT ('(0,1)'::priv_testtype1).a) RETURNS int LANGUAGE SQL AS $$ SELECT $1 $$;
 
 CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 
@@ -704,6 +720,7 @@ CREATE TABLE test10b (a int[], b priv_testtype1[]);
 CREATE TABLE test9b (a int, b int);
 ALTER TABLE test9b ADD COLUMN c priv_testdomain1;
 ALTER TABLE test9b ALTER COLUMN b TYPE priv_testdomain1;
+CREATE INDEX ON test9b ((a::priv_testdomain1));
 
 CREATE TYPE test7b AS (a int, b priv_testdomain1);
 
@@ -711,16 +728,38 @@ CREATE TYPE test8b AS (a int, b int);
 ALTER TYPE test8b ADD ATTRIBUTE c priv_testdomain1;
 ALTER TYPE test8b ALTER ATTRIBUTE b TYPE priv_testdomain1;
 
+CREATE DOMAIN priv_testdomain5b AS test8b CHECK ((VALUE).a > 0 AND ('(0,1)'::priv_testtype1).a >= 0);
+
 CREATE TABLE test11b AS (SELECT 1::priv_testdomain1 AS a);
 
+CREATE VIEW test16b AS SELECT ('(0,1)'::priv_testtype1).a;
+CREATE TABLE test17b (a int) PARTITION BY RANGE ((a + ('(0,1)'::priv_testtype1).a));
+CREATE POLICY priv_testpolicy1b ON test9b USING (('(0,1)'::priv_testtype1).a > 0);
+
 REVOKE ALL ON TYPE priv_testtype1 FROM PUBLIC;
+
+CREATE TABLE test12 (c int DEFAULT 0 CHECK (c > 0 AND '(0,1)'::priv_testtype1 IS NOT NULL)) DISTRIBUTED RANDOMLY;
+CREATE TABLE test13 (c int DEFAULT ('(0,1)'::priv_testtype1).a);
+
+-- new stored expressions require USAGE on types, rebuilds do not
+\c -
+REVOKE USAGE ON TYPE priv_testtype1 FROM regress_priv_user2;
+SET SESSION AUTHORIZATION regress_priv_user2;
+ALTER TABLE test12 ALTER COLUMN c TYPE bigint;
+ALTER TYPE test8b ALTER ATTRIBUTE a TYPE bigint CASCADE;
+ALTER TABLE test12 ALTER COLUMN c SET DEFAULT ('(0,1)'::priv_testtype1).a;
+CREATE TABLE test14 (LIKE test12 INCLUDING CONSTRAINTS);
+CREATE TABLE test15 (LIKE test13 INCLUDING DEFAULTS);
 
 \c -
 DROP AGGREGATE priv_testagg1b(priv_testdomain1);
 DROP DOMAIN priv_testdomain2b;
+DROP DOMAIN priv_testdomain4b;
+DROP DOMAIN priv_testdomain5b;
 DROP OPERATOR !! (NONE, priv_testdomain1);
 DROP FUNCTION priv_testfunc5b(a priv_testdomain1);
 DROP FUNCTION priv_testfunc6b(b int);
+DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
 DROP TABLE test9b;
@@ -730,7 +769,11 @@ DROP TYPE test8b;
 DROP CAST (priv_testdomain1 AS priv_testdomain3b);
 DROP FUNCTION castfunc(int) CASCADE;
 DROP DOMAIN priv_testdomain3b;
+DROP VIEW test16b;
 DROP TABLE test11b;
+DROP TABLE test17b;
+DROP TABLE test12;
+DROP TABLE test13;
 
 DROP TYPE priv_testtype1; -- ok
 DROP DOMAIN priv_testdomain1; -- ok

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -667,6 +667,8 @@ CREATE OPERATOR !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = 
 
 CREATE TABLE test5a (a int, b priv_testdomain1);
 CREATE TABLE test6a OF priv_testtype1;
+CREATE TABLE test6a2 (a int, b text);
+ALTER TABLE test6a2 OF priv_testtype1;
 CREATE TABLE test10a (a int[], b priv_testtype1[]);
 
 CREATE TABLE test9a (a int, b int);
@@ -715,6 +717,8 @@ CREATE OPERATOR !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 
 CREATE TABLE test5b (a int, b priv_testdomain1);
 CREATE TABLE test6b OF priv_testtype1;
+CREATE TABLE test6b2 (a int, b text);
+ALTER TABLE test6b2 OF priv_testtype1;
 CREATE TABLE test10b (a int[], b priv_testtype1[]);
 
 CREATE TABLE test9b (a int, b int);
@@ -762,6 +766,7 @@ DROP FUNCTION priv_testfunc6b(b int);
 DROP FUNCTION priv_testfunc7b(a int);
 DROP TABLE test5b;
 DROP TABLE test6b;
+DROP TABLE test6b2;
 DROP TABLE test9b;
 DROP TABLE test10b;
 DROP TYPE test7b;

--- a/src/test/regress/sql/rangetypes.sql
+++ b/src/test/regress/sql/rangetypes.sql
@@ -381,6 +381,20 @@ select '[2010-01-01 01:00:00 -05, 2010-01-01 02:00:00 -08)'::tstzrange;
 select '[2010-01-01 01:00:00 -08, 2010-01-01 02:00:00 -05)'::tstzrange;
 set timezone to default;
 
+-- CREATE TYPE AS RANGE checks for USAGE on subtype
+CREATE ROLE regress_subtype;
+CREATE TYPE mytype AS (a INT, b INT);
+REVOKE USAGE ON TYPE mytype FROM PUBLIC;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+RESET ROLE;
+GRANT USAGE ON TYPE mytype TO regress_subtype;
+SET ROLE regress_subtype;
+CREATE TYPE myrange AS RANGE (subtype = mytype);
+RESET ROLE;
+DROP TYPE mytype CASCADE;
+DROP ROLE regress_subtype;
+
 --
 -- Test user-defined range of floats
 --


### PR DESCRIPTION
Backport of the upstream fix for CVE-2026-6470 (CVSS 4.3).

Roles without USAGE on a type could still create objects that depend on
it — stored expressions (defaults, CHECK constraints, index and partition
expressions, policies, triggers, rules, domain constraints, function
parameter defaults), `ALTER TABLE ... OF`, and `CREATE TYPE ... AS RANGE` —
which could then prevent the type's owner from altering it.  The fix adds
the missing USAGE checks in the command paths.

## Upstream commits
Cherry-picked from `REL_14_STABLE` (REL_12/REL_13 are EOL and did not
receive the fix), in upstream order:

- 323af0a4ee5 — Check for USAGE privilege on the subtype in CREATE TYPE AS RANGE.
- 1a358b8f2a2 — Check for USAGE privilege on types used by stored expressions.
- b6e45b4f824 — Check for USAGE privilege on the composite type in ALTER TABLE OF.

Upstream authorship is preserved; each commit message carries a
`WarehousePG adaptation:` block describing the deviations.

## Adaptations (details in the commit messages)
- `heap.c`: WarehousePG's `StoreAttrDefault()` takes extra QD/QE
  missing-value arguments; the GPDB call is kept and the USAGE check is
  inserted before it, where upstream places it.
- The `prosqlbody` (SQL-standard function bodies) and `stxexprs`
  (extended statistics on expressions) hunks are omitted — PostgreSQL 14
  features absent from this codebase.  WarehousePG has no
  dependency-recording call sites beyond upstream's, so no path is left
  unchecked.
- `create_type.sgml`: only the new USAGE paragraph is added (upstream's
  hunk carried the PG14 multirange paragraph in its context).
- `privileges.sql`: `test12` is created `DISTRIBUTED RANDOMLY` so that
  `ALTER TABLE test12 ALTER COLUMN c TYPE bigint` exercises the
  rebuild-without-USAGE path instead of failing on the distribution key.
- `privileges_optimizer.out` / `rangetypes_optimizer.out`: the GPORCA
  answer files receive the same new expected output.

## ABI
Upstream records one ABI change for this CVE in `.abi-compliance-history`
(18ec528b8c3): `AlterDomainAddConstraint()` gains a `bool is_readd`
parameter.  In WarehousePG the function has exactly two in-tree callers
(`utility.c`, `tablecmds.c`), both updated by the patch, and no callers in
`contrib/` or `gpcontrib/`.  The two new `dependency.h` functions are
additive; no struct or enum layout changes.

## Testing
- Backend builds cleanly; no new warnings.
- Live check on a gpdemo cluster: `CREATE TYPE ... AS RANGE` on a subtype
  without USAGE fails with `permission denied for type`, succeeds after
  `GRANT USAGE`.
- `rangetypes` and `privileges` pass in both planner (`optimizer=off`) and
  ORCA modes.  (`privileges` depends on `int8_tbl` from the `int8` test,
  so it was run as `int8 privileges`.)