### PR TITLE
Fix pg_trgm's picksplit function with all-true datums

### DIFF
--- a/contrib/pg_trgm/trgm_gist.c
+++ b/contrib/pg_trgm/trgm_gist.c
@@ -880,7 +880,7 @@ gtrgm_picksplit(PG_FUNCTION_ARGS)
 				size_alpha = 0;
 			else
 				size_alpha = SIGLENBIT - sizebitvec(
-													(cache[j].allistrue) ? GETSIGN(datum_l) : GETSIGN(cache[j].sign)
+													(cache[j].allistrue) ? GETSIGN(datum_l) : cache[j].sign
 					);
 		}
 		else
@@ -892,7 +892,7 @@ gtrgm_picksplit(PG_FUNCTION_ARGS)
 				size_beta = 0;
 			else
 				size_beta = SIGLENBIT - sizebitvec(
-												   (cache[j].allistrue) ? GETSIGN(datum_r) : GETSIGN(cache[j].sign)
+												   (cache[j].allistrue) ? GETSIGN(datum_r) : cache[j].sign
 					);
 		}
 		else


### PR DESCRIPTION
The CACHESIGN.sign field is a BITVECP, not a TRGM, so you should not use GETSIGN() on it. You don't get a compiler warning because the GETSIGN() macro includes a cast. It resulted in a bogus read beyond end of buffer, which would cause bad split decisions or a crash if you're very unlucky.

Reported-by: Mehmet D. INCE <mehmet@mehmetince.net>
Backpatch-through: 14
Security: CVE-2026-14678
(cherry picked from commit a74aa0854d5e7c6c14c7d31f41bc7adc366f3ef7)

WarehousePG adaptation:

Resolved the conflict in gtrgm_picksplit(): upstream passes the opclass parameter siglen to SIGLENBIT() and sizebitvec(), which this PostgreSQL 12 base does not have.  Kept the fixed-length calls and applied the upstream change of using cache[j].sign directly instead of wrapping it in GETSIGN().
