### PR TITLE
Fix issues on ppc64le for WarehousePG 7

### DIFF
--- a/concourse/scripts/unit_tests_gporca.bash
+++ b/concourse/scripts/unit_tests_gporca.bash
@@ -3,15 +3,6 @@ set -exo pipefail
 
 GPDB_SRC_PATH=${GPDB_SRC_PATH:=gpdb_src}
 
-function build_xerces
-{
-    OUTPUT_DIR="gpdb_src/gpAux/ext/${BLD_ARCH}"
-    mkdir -p xerces_patch/concourse
-    cp -r gpdb_src/src/backend/gporca/concourse/xerces-c xerces_patch/concourse
-    /usr/bin/python3 xerces_patch/concourse/xerces-c/build_xerces.py --output_dir=${OUTPUT_DIR}
-    rm -rf build
-}
-
 function test_orca
 {
     if [ -n "${SKIP_UNITTESTS}" ]; then
@@ -26,8 +17,9 @@ function test_orca
 
 function _main
 {
+  # Install prefix for the ORCA build; WHPG 7 builds and tests ORCA against
+  # the distribution's xerces-c-devel, like the RPM does, and vendors nothing.
   mkdir gpdb_src/gpAux/ext
-  build_xerces
   test_orca
 }
 

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -116,6 +116,13 @@ def before_scenario(context, scenario):
     if 'gpssh-exkeys' in context.feature.tags:
         context.gpssh_exkeys_context = GpsshExkeysMgmtContext(context)
 
+    # Must happen before the feature-level early return below: after_scenario()
+    # restores ~/.bashrc for these scenarios unconditionally, and features in
+    # tags_to_skip (gpinitsystem among them) carry @backup_restore_bashrc
+    # scenarios too.
+    if 'gp_bash_functions.sh' in context.feature.tags or 'backup_restore_bashrc' in scenario.effective_tags:
+        backup_bashrc()
+
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
                     'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet']
     if set(context.feature.tags).intersection(tags_to_skip):
@@ -124,8 +131,6 @@ def before_scenario(context, scenario):
     if 'analyzedb' not in context.feature.tags:
         start_database_if_not_started(context)
         drop_database_if_exists(context, 'testdb')
-    if 'gp_bash_functions.sh' in context.feature.tags or 'backup_restore_bashrc' in scenario.effective_tags:
-        backup_bashrc()
 
 def after_scenario(context, scenario):
     #TODO: you'd think that the scenario.skip() in before_scenario() would

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -989,7 +989,7 @@ static void
 updateCursorIcEntry(CursorICHistoryTable *t, uint32 icId, uint8 status)
 {
 	struct CursorICHistoryEntry *p;
-	uint8		index = icId % t->size;
+	uint32		index = icId % t->size;
 
 	for (p = t->table[index]; p; p = p->next)
 	{
@@ -1010,7 +1010,7 @@ static CursorICHistoryEntry *
 getCursorIcEntry(CursorICHistoryTable *t, uint32 icId)
 {
 	struct CursorICHistoryEntry *p;
-	uint8		index = icId % t->size;
+	uint32		index = icId % t->size;
 
 	for (p = t->table[index]; p; p = p->next)
 	{
@@ -1030,7 +1030,7 @@ getCursorIcEntry(CursorICHistoryTable *t, uint32 icId)
 static void
 pruneCursorIcEntry(CursorICHistoryTable *t, uint32 icId)
 {
-	uint8		index;
+	uint32		index;
 
 	for (index = 0; index < t->size; index++)
 	{
@@ -1079,7 +1079,7 @@ pruneCursorIcEntry(CursorICHistoryTable *t, uint32 icId)
 static void
 purgeCursorIcEntry(CursorICHistoryTable *t)
 {
-	uint8		index;
+	uint32		index;
 
 	for (index = 0; index < t->size; index++)
 	{

--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -70,8 +70,17 @@ CStackDescriptor::BackTrace(ULONG top_frames_to_skip)
 		}
 		else
 		{
-			// get return address (one above the base pointer)
+			// get return address of the function owning this frame
+#if defined(__powerpc64__)
+			// ELFv1/ELFv2: a function saves its LR into the caller's frame,
+			// two words past that frame's back chain; *next_frame passed the
+			// range check above, so the dereference stays on the stack
+			ULONG_PTR *frame_address = (ULONG_PTR *) *next_frame + 2;
+#else
+			// x86-64 / AArch64: the return address sits right after the
+			// saved frame pointer in the function's own frame
 			ULONG_PTR *frame_address = (ULONG_PTR *) (next_frame + 1);
+#endif
 			m_array_of_addresses[m_depth++] = (void *) *frame_address;
 		}
 

--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -225,12 +225,23 @@ ShmemAllocNoError(Size size)
 
 	/*
 	 * Extra alignment for large requests, since they are probably buffers.
-	 * This is also needed for mprotect based shared buffer debugging
-	 * (-DMPROTECT_BUFFERS).
+	 *
+	 * Only mprotect-based shared buffer debugging (-DMPROTECT_BUFFERS) needs
+	 * the buffer pool to start on an OS page boundary; otherwise BUFFERALIGN
+	 * is sufficient, as in upstream.  Page alignment is not modelled by the
+	 * size estimate in CreateSharedMemoryAndSemaphores(), so every >= BLCKSZ
+	 * request silently consumes up to one page of unaccounted slack.  That
+	 * is tolerable with 4KB pages but on 64KB-page kernels (ppc64le, some
+	 * aarch64 distributions) it adds up to several MB and can exhaust the
+	 * segment during startup.
 	 */
 	if (size >= BLCKSZ)
 	{
-		newStart =  TYPEALIGN(ShmemSystemPageSize, newStart);
+#ifdef MPROTECT_BUFFERS
+		newStart = TYPEALIGN(ShmemSystemPageSize, newStart);
+#else
+		newStart = BUFFERALIGN(newStart);
+#endif
 	}
 
 	newFree = newStart + size;

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -422,7 +422,19 @@ class SQLIsolationExecutor(object):
                         break
                     elif (("the database system is starting up" in str(e) or
                          "the database system is resetting" in str(e) or
-                         "the database system is in recovery mode" in str(e)) and
+                         "the database system is in recovery mode" in str(e) or
+                         # A connection opened in the narrow window after a
+                         # backend crash but before the postmaster has entered
+                         # its reset cycle is accepted and then killed, which
+                         # surfaces as a connection reset rather than one of the
+                         # "system is <state>" messages above. The postmaster's
+                         # own HINT ("In a moment you should be able to
+                         # reconnect") says to retry, so treat it the same. On a
+                         # slow platform this window is wide enough that
+                         # crash_recovery_dtm's utility reconnect lands in it.
+                         "server closed the connection unexpectedly" in str(e) or
+                         "terminating connection because of crash of another server process" in str(e) or
+                         "Connection reset by peer" in str(e)) and
                         retry > 1):
                         retry -= 1
                         time.sleep(0.1)

--- a/src/test/regress/expected/mirror_replay.out
+++ b/src/test/regress/expected/mirror_replay.out
@@ -72,11 +72,15 @@ VACUUM mirror_reply_test_table;
 -- expecting mirror to be marked down
 do $$
 begin
-  for i in 1..120 loop
+  -- The mirror is only marked down after its startup process replays the
+  -- truncate record and PANICs; on a slow platform that can take longer
+  -- than a burst of back-to-back probes, so wait between probes (60s max).
+  for i in 1..300 loop
     if (select status = 'd' from gp_segment_configuration where content=0 and role = 'm') then
       return;
     end if;
     perform gp_request_fts_probe_scan();
+    perform pg_sleep(0.2);
   end loop;
 end;
 $$;
@@ -94,11 +98,12 @@ SELECT role, preferred_role, mode, status FROM gp_segment_configuration WHERE co
 -- loop while segments come in sync
 do $$
 begin
-  for i in 1..120 loop
+  for i in 1..300 loop
     if (select mode = 's' from gp_segment_configuration where content=0 and role = 'p') then
       return;
     end if;
     perform gp_request_fts_probe_scan();
+    perform pg_sleep(0.2);
   end loop;
 end;
 $$;

--- a/src/test/regress/input/uao_dml/gp_fastsequence.source
+++ b/src/test/regress/input/uao_dml/gp_fastsequence.source
@@ -6,7 +6,7 @@ SET search_path="$user",test_gp_fastsequence_@amname@,public;
 
 SET default_table_access_method=@amname@;
 
-CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+CREATE OR REPLACE FUNCTION fastseq_log_rows(input_query_regex text)
   RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
   LANGUAGE plpgsql AS
 $func$
@@ -37,6 +37,29 @@ BEGIN
       AND l2.logmessage LIKE 'In-place update to gp_fastsequence%'
       AND l2.logdebug LIKE input_query_regex) s
   ORDER BY logdebug, logmessage;
+END
+$func$;
+
+-- The syslogger stamps and writes log lines asynchronously, and with
+-- debug_appendonly_print_insert_tuple on it has hundreds of per-tuple lines
+-- queued behind the gp_fastsequence ones we want.  On a slow machine the last
+-- line of the preceding statement may not have reached the log file yet when
+-- we read it, so poll until the set of matching rows stops growing.
+CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+  RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
+  LANGUAGE plpgsql AS
+$func$
+DECLARE
+  prev_count int := -1;
+  cur_count int;
+BEGIN
+  FOR i IN 1..50 LOOP
+    SELECT count(*) INTO cur_count FROM fastseq_log_rows(input_query_regex);
+    EXIT WHEN cur_count > 0 AND cur_count = prev_count;
+    prev_count := cur_count;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  RETURN QUERY SELECT * FROM fastseq_log_rows(input_query_regex);
 END
 $func$;
 

--- a/src/test/regress/output/uao_dml/gp_fastsequence.source
+++ b/src/test/regress/output/uao_dml/gp_fastsequence.source
@@ -3,7 +3,7 @@
 CREATE SCHEMA test_gp_fastsequence_@amname@;
 SET search_path="$user",test_gp_fastsequence_@amname@,public;
 SET default_table_access_method=@amname@;
-CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+CREATE OR REPLACE FUNCTION fastseq_log_rows(input_query_regex text)
   RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
   LANGUAGE plpgsql AS
 $func$
@@ -34,6 +34,28 @@ BEGIN
       AND l2.logmessage LIKE 'In-place update to gp_fastsequence%'
       AND l2.logdebug LIKE input_query_regex) s
   ORDER BY logdebug, logmessage;
+END
+$func$;
+-- The syslogger stamps and writes log lines asynchronously, and with
+-- debug_appendonly_print_insert_tuple on it has hundreds of per-tuple lines
+-- queued behind the gp_fastsequence ones we want.  On a slow machine the last
+-- line of the preceding statement may not have reached the log file yet when
+-- we read it, so poll until the set of matching rows stops growing.
+CREATE OR REPLACE FUNCTION fastseq_details(input_query_regex text)
+  RETURNS TABLE (logdatabase text, logsegment text, logseverity text, logdebug text, logmessage text)
+  LANGUAGE plpgsql AS
+$func$
+DECLARE
+  prev_count int := -1;
+  cur_count int;
+BEGIN
+  FOR i IN 1..50 LOOP
+    SELECT count(*) INTO cur_count FROM fastseq_log_rows(input_query_regex);
+    EXIT WHEN cur_count > 0 AND cur_count = prev_count;
+    prev_count := cur_count;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  RETURN QUERY SELECT * FROM fastseq_log_rows(input_query_regex);
 END
 $func$;
 SET debug_appendonly_print_insert_tuple TO on;

--- a/src/test/regress/sql/mirror_replay.sql
+++ b/src/test/regress/sql/mirror_replay.sql
@@ -63,11 +63,15 @@ VACUUM mirror_reply_test_table;
 -- expecting mirror to be marked down
 do $$
 begin
-  for i in 1..120 loop
+  -- The mirror is only marked down after its startup process replays the
+  -- truncate record and PANICs; on a slow platform that can take longer
+  -- than a burst of back-to-back probes, so wait between probes (60s max).
+  for i in 1..300 loop
     if (select status = 'd' from gp_segment_configuration where content=0 and role = 'm') then
       return;
     end if;
     perform gp_request_fts_probe_scan();
+    perform pg_sleep(0.2);
   end loop;
 end;
 $$;
@@ -81,11 +85,12 @@ SELECT role, preferred_role, mode, status FROM gp_segment_configuration WHERE co
 -- loop while segments come in sync
 do $$
 begin
-  for i in 1..120 loop
+  for i in 1..300 loop
     if (select mode = 's' from gp_segment_configuration where content=0 and role = 'p') then
       return;
     end if;
     perform gp_request_fts_probe_scan();
+    perform pg_sleep(0.2);
   end loop;
 end;
 $$;


### PR DESCRIPTION
## Summary
Server-side fixes that make WHPG 7 build and pass the full smoke suite on
ppc64le (el8/el9). Eight self-contained commits, each fixing one issue found
on Power: a real portability bug in ORCA, a shared-memory sizing assumption,
an interconnect index type, and four test/CI-timing issues.

## Background
Earlier ppc64le testing recorded a number of failures; this lands the actual
fixes. The load-bearing one is the ORCA stack walker reading the return
address from the wrong slot on the ppc64 ELF ABI, which crashed 58 of the 179
ORCA unit tests in Debug builds. The rest: mirror_replay / gp_fastsequence /
crash_recovery_dtm timing assumptions, 64KB-page shared-memory drift, the
cursor IC table uint8 index, the behave ~/.bashrc backup order, and dropping
the now-unused vendored xerces build.

## Test plan
- [x] Full smoke matrix on el8 + el9 ppc64le, all jobs green
- [x] amd64 full matrix to confirm no regression from the all-platform changes
