### PR TITLE
Backport ascii()/to_char()/PL/Perl Aug-2026 CVE fixes (CVE-2026-18024, CVE-2026-14669, CVE-2026-14670)

### DIFF
--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -2474,10 +2474,18 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					/* We assume here that timezone names aren't localized */
+					/*
+					 * We assume here that timezone abbreviations aren't
+					 * localized, so ASCII-only downcasing is sufficient.
+					 */
 					char	   *p = asc_tolower_z(tmtcTzn(in));
 
-					strcpy(s, p);
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					pfree(p);
 					s += strlen(s);
 				}
@@ -2486,7 +2494,14 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				INVALID_FOR_INTERVAL;
 				if (tmtcTzn(in))
 				{
-					strcpy(s, tmtcTzn(in));
+					const char *p = tmtcTzn(in);
+
+					if (strlen(p) <= n->key->len * DCH_MAX_ITEM_SIZ)
+						strcpy(s, p);
+					else
+						ereport(ERROR,
+								(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+								 errmsg("time zone format value too long")));
 					s += strlen(s);
 				}
 				break;

--- a/src/backend/utils/adt/oracle_compat.c
+++ b/src/backend/utils/adt/oracle_compat.c
@@ -857,8 +857,10 @@ ascii(PG_FUNCTION_ARGS)
 	text	   *string = PG_GETARG_TEXT_PP(0);
 	int			encoding = GetDatabaseEncoding();
 	unsigned char *data;
+	int			len;
 
-	if (VARSIZE_ANY_EXHDR(string) <= 0)
+	len = VARSIZE_ANY_EXHDR(string);
+	if (len <= 0)
 		PG_RETURN_INT32(0);
 
 	data = (unsigned char *) VARDATA_ANY(string);
@@ -881,18 +883,31 @@ ascii(PG_FUNCTION_ARGS)
 			result = *data & 0x0F;
 			tbytes = 2;
 		}
-		else
+		else if (*data > 0xC0)
 		{
-			Assert(*data > 0xC0);
 			result = *data & 0x1f;
 			tbytes = 1;
 		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+					 errmsg("invalid byte sequence for encoding \"%s\"",
+							GetDatabaseEncodingName())));
 
-		Assert(tbytes > 0);
+		/* All continuation bytes are present in the input */
+		if (tbytes >= len)
+			ereport(ERROR,
+					(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+					 errmsg("invalid byte sequence for encoding \"%s\"",
+							GetDatabaseEncodingName())));
 
 		for (i = 1; i <= tbytes; i++)
 		{
-			Assert((data[i] & 0xC0) == 0x80);
+			if (unlikely((data[i] & 0xC0) != 0x80))
+				ereport(ERROR,
+						(errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+						 errmsg("invalid byte sequence for encoding \"%s\"",
+								GetDatabaseEncodingName())));
 			result = (result << 6) + (data[i] & 0x3f);
 		}
 

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -1165,6 +1165,10 @@ get_perl_array_ref(SV *sv)
 
 /*
  * helper function for plperl_array_to_datum, recurses for multi-D arrays
+ *
+ * Caller is required to have set dims[cur_depth - 1] to the length of the
+ * input array, i.e., av_len(av) + 1.  We make this requirement so as to
+ * avoid reading av_len() twice, which is hazardous for tied arrays.
  */
 static ArrayBuildState *
 array_to_datum_internal(AV *av, ArrayBuildState *astate,
@@ -1174,7 +1178,7 @@ array_to_datum_internal(AV *av, ArrayBuildState *astate,
 {
 	dTHX;
 	int			i;
-	int			len = av_len(av) + 1;
+	int			len = dims[cur_depth - 1];
 
 	for (i = 0; i < len; i++)
 	{
@@ -1697,8 +1701,7 @@ plperl_event_trigger_build_args(FunctionCallInfo fcinfo)
 	return newRV_noinc((SV *) hv);
 }
 
-/* Set up the new tuple returned from a trigger. */
-
+/* Construct the modified new tuple to be returned from a trigger. */
 static HeapTuple
 plperl_modify_tuple(HV *hvTD, TriggerData *tdata, HeapTuple otup)
 {
@@ -1707,14 +1710,11 @@ plperl_modify_tuple(HV *hvTD, TriggerData *tdata, HeapTuple otup)
 	HV		   *hvNew;
 	HE		   *he;
 	HeapTuple	rtup;
-	int			slotsused;
-	int		   *modattrs;
-	Datum	   *modvalues;
-	char	   *modnulls;
-
 	TupleDesc	tupdesc;
-
-	tupdesc = tdata->tg_relation->rd_att;
+	int			natts;
+	Datum	   *modvalues;
+	bool	   *modnulls;
+	bool	   *modrepls;
 
 	svp = hv_fetch_string(hvTD, "new");
 	if (!svp)
@@ -1727,51 +1727,50 @@ plperl_modify_tuple(HV *hvTD, TriggerData *tdata, HeapTuple otup)
 				 errmsg("$_TD->{new} is not a hash reference")));
 	hvNew = (HV *) SvRV(*svp);
 
-	modattrs = palloc_array(int, tupdesc->natts);
-	modvalues = palloc_array(Datum, tupdesc->natts);
-	modnulls = palloc_array(char, tupdesc->natts);
-	slotsused = 0;
+	tupdesc = tdata->tg_relation->rd_att;
+	natts = tupdesc->natts;
+
+	modvalues = palloc0_array(Datum, natts);
+	modnulls = palloc0_array(bool, natts);
+	modrepls = palloc0_array(bool, natts);
 
 	hv_iterinit(hvNew);
 	while ((he = hv_iternext(hvNew)))
 	{
-		bool		isnull;
 		char	   *key = hek2cstr(he);
 		SV		   *val = HeVAL(he);
 		int			attn = SPI_fnumber(tupdesc, key);
 
-		if (attn <= 0 || tupdesc->attrs[attn - 1]->attisdropped)
+		if (attn == SPI_ERROR_NOATTRIBUTE ||
+			(attn > 0 && tupdesc->attrs[attn - 1]->attisdropped))
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_COLUMN),
 					 errmsg("Perl hash contains nonexistent column \"%s\"",
 							key)));
+		if (attn <= 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot set system attribute \"%s\"",
+							key)));
 
-		modvalues[slotsused] = plperl_sv_to_datum(val,
-										  tupdesc->attrs[attn - 1]->atttypid,
-										 tupdesc->attrs[attn - 1]->atttypmod,
-												  NULL,
-												  NULL,
-												  InvalidOid,
-												  &isnull);
-
-		modnulls[slotsused] = isnull ? 'n' : ' ';
-		modattrs[slotsused] = attn;
-		slotsused++;
+		modvalues[attn - 1] = plperl_sv_to_datum(val,
+												 tupdesc->attrs[attn - 1]->atttypid,
+												 tupdesc->attrs[attn - 1]->atttypmod,
+												 NULL,
+												 NULL,
+												 InvalidOid,
+												 &modnulls[attn - 1]);
+		modrepls[attn - 1] = true;
 
 		pfree(key);
 	}
 	hv_iterinit(hvNew);
 
-	rtup = SPI_modifytuple(tdata->tg_relation, otup, slotsused,
-						   modattrs, modvalues, modnulls);
+	rtup = heap_modify_tuple(otup, tupdesc, modvalues, modnulls, modrepls);
 
-	pfree(modattrs);
 	pfree(modvalues);
 	pfree(modnulls);
-
-	if (rtup == NULL)
-		elog(ERROR, "SPI_modifytuple failed: %s",
-			 SPI_result_code_string(SPI_result));
+	pfree(modrepls);
 
 	return rtup;
 }

--- a/src/test/regress/input/encoding.source
+++ b/src/test/regress/input/encoding.source
@@ -227,6 +227,18 @@ ALTER TABLE toast_3b_utf8 RENAME TO toast_4b_utf8;
 UPDATE toast_4b_utf8 SET c = repeat(U&'\+01F680', 3000);
 SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+SELECT ascii(test_bytea_to_text('\xe2'));
+SELECT ascii(test_bytea_to_text('\xe282'));
+SELECT ascii(test_bytea_to_text('\xf0'));
+SELECT ascii(test_bytea_to_text('\xf09f'));
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 -- WarehousePG: omitting the argument list needs PG10; spell it out.

--- a/src/test/regress/output/encoding.source
+++ b/src/test/regress/output/encoding.source
@@ -422,6 +422,25 @@ SELECT SUBSTRING(c FROM 3000 FOR 1) FROM toast_4b_utf8;
  🚀
 (1 row)
 
+-- ascii() and multibyte characters
+SELECT ascii(test_bytea_to_text('\xc3'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe2'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xe282'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf0'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+SELECT ascii(test_bytea_to_text('\xf09f98'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid continuation byte
+SELECT ascii(test_bytea_to_text('\xc3ff'));
+ERROR:  invalid byte sequence for encoding "UTF8"
+-- invalid leading byte
+SELECT ascii(test_bytea_to_text('\x80'));
+ERROR:  invalid byte sequence for encoding "UTF8"
 DROP TABLE encoding_tests;
 DROP TABLE toast_4b_utf8;
 -- WarehousePG: omitting the argument list needs PG10; spell it out.


### PR DESCRIPTION
Backport three Aug-2026 upstream security fixes to `WHPG_6X_STABLE`.

## Summary

- **CVE-2026-18024** (CVSS 4.3) — `ascii()` trusted the lead byte of a UTF-8
  string and read the continuation bytes it implied without checking that the
  input was long enough, validating them only with `Assert()`. Invalid multibyte
  input could disclose a few bytes of QE memory; on a cassert build it fails the
  assertion. The length is now checked up front and every byte is validated
  with a real error. Includes the upstream regression test.
- **CVE-2026-14669** (CVSS 8.8) — `to_char()`'s `TZ`/`tz` patterns copied the
  time-zone abbreviation into the output buffer with an unguarded `strcpy()`.
  A POSIX-style `SET TIME ZONE` string with a long abbreviation overruns the
  12-bytes-per-format-character allocation. Both sites now error out with
  "time zone format value too long" when the abbreviation exceeds the budget.
- **CVE-2026-14670** (CVSS 8.8) — PL/Perl's `plperl_array_to_datum()` read
  `av_len()` of each input array twice, so a tied array that reports a
  different size on each call produced a corrupt result array. The length is
  now read once and carried in `dims[]`.

No catalog, WAL or ABI changes.

## Background

All three were fixed on `main` earlier (#236 and #263); these are the 6X
counterparts. The `ascii()` and `to_char()` commits are the upstream REL_14
fixes applied verbatim. The PL/Perl fix takes only the `plperl.c` half of the
upstream commit: `contrib/hstore_plperl` does not exist on this branch (it
arrived in PostgreSQL 9.5), so the `plperl_to_hstore()` hunk has nothing to
apply to.

## Test plan

- [x] `encoding` / `euc_kr` / `strings` regression tests green on a gpdemo cluster
- [x] `src/pl/plperl` `installcheck` 12/12 (rebuilt with `--with-perl`)
- [x] `to_char(..., 'TZ')` with a 20-char abbreviation prints; 40-char errors with "time zone format value too long" (TZ, tz and TZTZ)
- [x] `ascii()` rejects invalid multibyte input instead of over-reading; valid é / € / 😀 still return their code points
- [x] plperlu functions returning tied arrays that grow / shrink under
      iteration return well-formed arrays
- [x] `plperl_modify_tuple()` bounded-index rewrite: a trusted-plperl BEFORE
      trigger returning a tied hash crashes a 6X segment (SIGSEGV) before this
      change and inserts cleanly after; `src/pl/plperl` installcheck 12/12

Rebased onto `WHPG_6X_STABLE` (2026-09-10) after the palloc_array() overflow
series landed there; the `plperl_modify_tuple()` rewrite now uses
`palloc0_array()`.  The to_char() commit gained a note recording why its
cherry-pick reference is the REL_17 SHA (REL_14/15/16 have no standalone
to_char fix).
