### PR TITLE
Fix datalen calculation in tsvectorrecv().

### DIFF
--- a/src/backend/utils/adt/tsvector.c
+++ b/src/backend/utils/adt/tsvector.c
@@ -495,7 +495,7 @@ tsvectorrecv(PG_FUNCTION_ARGS)
 		 * But make sure the buffer is large enough first.
 		 */
 		while (hdrlen + SHORTALIGN(datalen + lex_len) +
-			   (npos + 1) * sizeof(WordEntryPos) >= len)
+			   sizeof(uint16) + npos * sizeof(WordEntryPos) >= len)
 		{
 			len *= 2;
 			vec = (TSVector) repalloc(vec, len);
@@ -541,7 +541,7 @@ tsvectorrecv(PG_FUNCTION_ARGS)
 					elog(ERROR, "position information is misordered");
 			}
 
-			datalen += (npos + 1) * sizeof(WordEntry);
+			datalen += sizeof(uint16) + npos * sizeof(WordEntryPos);
 		}
 	}
 


### PR DESCRIPTION
Follow-up to the CVE-2026-14662 tsvector/tsquery hardening backport: while
working on that fix we found that tsvectorrecv() on this PostgreSQL 12 base
still carries a pre-existing bug that upstream fixed separately in 2023.

## The bug
After reading a lexeme's position data, tsvectorrecv() advanced `datalen`
by `(npos + 1) * sizeof(WordEntry)`. The data actually written is a uint16
count followed by npos WordEntryPos values, i.e.
`sizeof(uint16) + npos * sizeof(WordEntryPos)`. Since sizeof(WordEntry) is 4
but WordEntryPos is 2 bytes, the position bytes were counted at twice their
real size.

This does not make the constructed tsvector invalid, but it:
- wastes storage/transfer space roughly equal to the position data;
- can reject a legal tsvector with "maximum total lexeme length exceeded"
  once the padding pushes it past MAXSTRPOS;
- in edge cases lets SET_VARSIZE() set a length larger than the allocated
  palloc chunk, which can lead to an out-of-bounds read / SIGSEGV when the
  datum is later copied.

## The fix
Clean cherry-pick of upstream 5b7b3824648 ("Fix datalen calculation in
tsvectorrecv()", Tom Lane, 2023). It corrects the increment and rewrites the
equivalent buffer-size estimate in the same clearer form. Two lines, no
adaptation needed on this base.

## Testing
- src/backend builds cleanly; tsvector.o compiles with no new warnings and
  postgres links.
- No expected-output changes: the tsvector text path (tsvectorin/tsvectorout)
  is untouched; only the binary-receive path's internal length bookkeeping
  changes. PR CI (installcheck-good) covers the tstypes/tsearch suites.