### PR TITLE
cdbdisp_query unit test: set the outer user id so the cassert build can run it

### DIFF
--- a/src/backend/cdb/dispatcher/test/cdbdisp_query_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbdisp_query_test.c
@@ -6,6 +6,7 @@
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
+#include "utils/guc_tables.h"
 
 #include "../cdbdisp_query.c"
 
@@ -336,6 +337,13 @@ main(int argc, char *argv[])
 	MyTmGxactLocal = (TMGXACTLOCAL *) MemoryContextAllocZero(TopMemoryContext, sizeof(TMGXACTLOCAL));
 
 	SetSessionUserId(1000, true);
+	/*
+	 * buildGpQueryString() also reads the outer user id, and GetOuterUserId()
+	 * asserts it is set.  SET ROLE NONE derives it from the session user; it
+	 * also updates the is_superuser GUC, so the GUC table must exist first.
+	 */
+	build_guc_variables();
+	SetCurrentRoleId(InvalidOid, false);
 
 	return run_tests(tests);
 }


### PR DESCRIPTION
**Summary**
`test__CdbDispatchPlan_may_be_interrupted` only set the session user id; `buildGpQueryString()` also calls `GetOuterUserId()`, which asserts the id is valid, so under `--enable-cassert` the test died there before the query reached libpq and cmockery then reported an unexpected `pqPutMsgStart` from the abort path. Derive the outer user id from the session user (SET ROLE NONE semantics) after building the GUC table, since the setter also writes `is_superuser`.

**Background**
Non-assert builds return InvalidOid and pass, and the RPM `unittest-check` is a non-assert build, so CI never saw it. Found while adding dispatcher tests for the ppc64le work; independent of it.

**Test plan**
- `make -C src/backend/cdb/dispatcher/test check` with `--enable-cassert`: 3/3 PASSED (was 2/3 on main)
- Same in the RPM-equivalent non-assert configuration: 3/3 PASSED before and after