### PR TITLE
latch: order the is_set/waiting handshake so a cross-thread SetLatch cannot lose a wakeup

### DIFF
--- a/src/backend/storage/ipc/latch.c
+++ b/src/backend/storage/ipc/latch.c
@@ -455,6 +455,18 @@ SetLatch(Latch *latch)
 
 	latch->is_set = true;
 
+	/*
+	 * Order the is_set store before the read of `waiting` below. A SetLatch
+	 * from another thread of the owning process (the UDP interconnect's
+	 * receive thread does this) races with WaitEventSetWait's
+	 * "waiting = true; if (is_set)" sequence; without a barrier on both sides
+	 * each may read the other's old value and the wakeup is lost until the
+	 * caller's timeout. PostgreSQL 14 closed the same window with
+	 * Latch.maybe_sleeping plus barriers on both sides (upstream commit
+	 * c8f3bc2401e, "Optimize latches to send fewer signals").
+	 */
+	pg_memory_barrier();
+
 #ifndef WIN32
 
 	/*
@@ -1082,6 +1094,12 @@ WaitEventSetWait(WaitEventSet *set, long timeout,
 
 #ifndef WIN32
 	waiting = true;
+
+	/*
+	 * Make `waiting` visible before we check is_set; the setter checks
+	 * `waiting` only after storing is_set. See SetLatch.
+	 */
+	pg_memory_barrier();
 #else
 	/* Ensure that signals are serviced even if latch is already set */
 	pgwin32_dispatch_queued_signals();


### PR DESCRIPTION
**Summary**
The UDP interconnect's receive thread wakes the backend's main thread with `SetLatch()` while the main thread sleeps in `WaitEventSetWait()`. latch.c only anticipated same-thread or cross-process callers, whose `waiting`/`is_set` handshake is trivially ordered. Across two threads it is the store-buffering pattern, and without barriers both sides can read stale values and skip the self-pipe write. Add a full barrier after `is_set = true` in `SetLatch()` and after `waiting = true` in `WaitEventSetWait()`, the same ordering PostgreSQL 14 adopted in c8f3bc2401e.

**Background**
Reviewed while tracing a WHPG 7 ppc64le dispatcher hang; this is not that hang's cause. Today a lost wakeup costs at most the 250 ms `MAIN_THREAD_COND_TIMEOUT_MS` re-check in `receiveChunksUDPIFCLoop`, never a stall, so this is hardening for the tree's only cross-thread latch user. Store→load reordering is legal on x86 too, just far more likely on ppc64le and aarch64. No new state, no ABI change; each barrier sits on a path that already makes a syscall.

**Test plan**
- Builds with and without `--enable-cassert`; dispatcher unit tests pass
- No behavioural test: the window is a sub-microsecond race that the 250 ms fallback masks. Suggest running the udpifc interconnect regression (`icudp` suite) on aarch64 before merge; not yet done