### PR TITLE
dispatcher: do not wedge the QD when QEs die after a slice has finished

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -496,6 +496,23 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 			pParms->waitMode = DISPATCH_WAIT_CANCEL;
 
 		/*
+		 * Deliver the cancel (or finish) request right away instead of from
+		 * the poll-timeout branch below.  A connection that is finished but
+		 * still readable -- a QE that exited after we were done with it and
+		 * left a notice and EOF unread -- makes WaitEventSetWait() return
+		 * immediately on every iteration; the timeout branch, and with it the
+		 * only other call to signalQEs(), would then never be reached and the
+		 * surviving QEs would never be told to stop.
+		 */
+		if (pParms->waitMode != DISPATCH_WAIT_NONE &&
+			pParms->waitMode != DISPATCH_WAIT_ACK_ROOT &&
+			!sentSignal)
+		{
+			signalQEs(pParms);
+			sentSignal = true;
+		}
+
+		/*
 		 * Which QEs are still running and could send results to us?
 		 */
 		for (i = 0; i < db_count; i++)

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -591,17 +591,23 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 					dispatchResult->stillRunning = true;
 				}
 #endif
+				/* done with this QE: take its socket out of the wait set */
+				if (!dispatchResult->stillRunning && i >= 0 && added[i])
+					RemoveWaitEvent(DispWaitSet, added[i] - 1);
 				continue;
 			}
 
-			/* add segment sock to the waitset */
+			/*
+			 * Add the segment socket to the wait set, remembering its position
+			 * (plus one, so that zero still means "not added") so that it can
+			 * be removed again once the QE is finished.
+			 */
 			if (!added[i])
 			{
 				int 	sock = PQsocket(conn);
 				long 	ev_userdata = i; /* the index "i" as the event's userdata */
 				Assert(sock >= 0);
-				AddWaitEventToSet(DispWaitSet, WL_SOCKET_READABLE, sock, NULL, (void *)ev_userdata);
-				added[i] = 1;
+				added[i] = AddWaitEventToSet(DispWaitSet, WL_SOCKET_READABLE, sock, NULL, (void *)ev_userdata) + 1;
 			}
 			nfds++;
 		}
@@ -859,10 +865,19 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 		SegmentDatabaseDescriptor *segdbDesc = dispatchResult->segdbDesc;
 
 		/*
-		 * Skip if already finished or didn't dispatch.
+		 * Already finished with this QE, yet its socket became readable: the
+		 * backend went away after we were done with it (a segment reset kills
+		 * every backend of the session) and left a notice and EOF that nobody
+		 * will read.  Left in the set, such a socket stays readable forever
+		 * and starves the poll-timeout branch of checkDispatchResult().  Drop
+		 * it.  Normally the socket is removed when the QE finishes, below, so
+		 * this is a safety net.
 		 */
 		if (!dispatchResult->stillRunning)
+		{
+			RemoveWaitEvent(DispWaitSet, revents[i].pos);
 			continue;
+		}
 
 		if (pParms->waitMode == DISPATCH_WAIT_ACK_ROOT &&
 				 dispatchResult->receivedAckMsg)
@@ -895,6 +910,7 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 		if (finished)
 		{
 			dispatchResult->stillRunning = false;
+			RemoveWaitEvent(DispWaitSet, revents[i].pos);
 
 			ELOG_DISPATCHER_DEBUG("processResults says we are finished with %ld of %d (%s)",
 								  pos + 1, pParms->dispatchCount, segdbDesc->whoami);

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -280,6 +280,36 @@ cdbdisp_seterrcode(int errcode, /* ERRCODE_xxx or 0 */
 
 
 /*
+ * Would a message of the given elevel reach the server log under the current
+ * log_min_messages?  This mirrors is_log_level_output() in elog.c, which is
+ * static there.  For log_min_messages, LOG sorts between ERROR and FATAL, so
+ * a plain numeric comparison (LOG = 15 is below WARNING = 19) wrongly
+ * suppresses LOG-level messages under the default log_min_messages = WARNING;
+ * that hid every "Error on receive from <segment>" the dispatcher recorded
+ * while a query hung after two segments had crashed.
+ */
+static bool
+dispatch_message_goes_to_log(int elevel)
+{
+	if (elevel == LOG || elevel == LOG_SERVER_ONLY)
+	{
+		if (log_min_messages == LOG || log_min_messages <= ERROR)
+			return true;
+	}
+	else if (log_min_messages == LOG)
+	{
+		/* elevel != LOG */
+		if (elevel >= FATAL)
+			return true;
+	}
+	/* Neither is LOG */
+	else if (elevel >= log_min_messages)
+		return true;
+
+	return false;
+}
+
+/*
  * NonThread version of cdbdisp_appendMessage.
  *
  * It's safe to use palloc/pfree or elog/ereport.
@@ -316,7 +346,7 @@ cdbdisp_appendMessageNonThread(CdbDispatchResult *dispatchResult,
 	 * Display the message on stderr for debugging, if requested. This helps
 	 * to clarify the actual timing of threaded events.
 	 */
-	if (elevel >= log_min_messages)
+	if (dispatch_message_goes_to_log(elevel))
 	{
 		oneTrailingNewlinePQ(dispatchResult->error_message);
 		elog(LOG, "%s", dispatchResult->error_message->data + msgoff);

--- a/src/backend/storage/ipc/latch.c
+++ b/src/backend/storage/ipc/latch.c
@@ -641,6 +641,10 @@ FlushWaitEventSet(WaitEventSet *set)
 	{
 		WaitEvent  *event = &(set->events[i]);
 		int			rc;
+
+		/* removed by RemoveWaitEvent(); nothing left to delete */
+		if (event->fd == PGINVALID_SOCKET)
+			continue;
 		rc = epoll_ctl(set->epoll_fd, EPOLL_CTL_DEL, event->fd, NULL);
 		if (rc < 0)
 		{
@@ -656,6 +660,55 @@ FlushWaitEventSet(WaitEventSet *set)
 	set->nevents = 0;
 	set->latch = NULL;
 	return ret;
+}
+
+/*
+ * Remove a socket event from the set.
+ *
+ * The other events keep their positions: the slot is left in place but made
+ * inert, with its fd set to PGINVALID_SOCKET and its event mask cleared, so
+ * FlushWaitEventSet() skips it and WaitEventSetWait() can never report it.
+ * Only socket events can be removed; the latch and postmaster-death events
+ * are permanent.
+ *
+ * The socket may already have been closed by its owner (libpq drops the
+ * socket of a broken connection, and the kernel then removes it from the
+ * epoll interest list by itself), so EBADF and ENOENT from epoll_ctl() are
+ * not errors here.
+ */
+void
+RemoveWaitEvent(WaitEventSet *set, int pos)
+{
+	WaitEvent  *event;
+
+	Assert(pos < set->nevents);
+	event = &set->events[pos];
+
+	if (event->events == WL_LATCH_SET)
+		elog(ERROR, "cannot remove latch event");
+	if (event->events == WL_POSTMASTER_DEATH)
+		elog(ERROR, "cannot remove postmaster death event");
+	if (event->fd == PGINVALID_SOCKET)
+		return;					/* already removed */
+
+#if defined(WAIT_USE_EPOLL)
+	if (epoll_ctl(set->epoll_fd, EPOLL_CTL_DEL, event->fd, NULL) < 0 &&
+		errno != EBADF && errno != ENOENT)
+		ereport(ERROR,
+				(errcode_for_socket_access(),
+				 errmsg("%s failed: %m",
+						"epoll_ctl()")));
+#elif defined(WAIT_USE_POLL)
+	/* poll() ignores a negative descriptor and reports no events for it */
+	set->pollfds[pos].fd = -1;
+	set->pollfds[pos].events = 0;
+	set->pollfds[pos].revents = 0;
+#else
+	elog(ERROR, "RemoveWaitEvent is not supported on this platform");
+#endif
+
+	event->fd = PGINVALID_SOCKET;
+	event->events = 0;
 }
 
 /*

--- a/src/backend/storage/ipc/test/Makefile
+++ b/src/backend/storage/ipc/test/Makefile
@@ -2,11 +2,15 @@ subdir=src/backend/storage/ipc
 top_builddir=../../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=procarray
+TARGETS=procarray \
+		latch
 
 include $(top_srcdir)/src/backend/mock.mk
 procarray.t: $(MOCK_DIR)/backend/storage/lmgr/lwlock_mock.o \
 			 $(MOCK_DIR)/backend/cdb/cdbtm_mock.o \
 			 $(MOCK_DIR)/backend/access/hash/hash_mock.o \
 			 $(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o \
+
+latch.t: $(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o \
+		 $(MOCK_DIR)/backend/access/hash/hash_mock.o \
 

--- a/src/backend/storage/ipc/test/latch_test.c
+++ b/src/backend/storage/ipc/test/latch_test.c
@@ -1,0 +1,195 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+#include "postgres.h"
+
+#include <sys/socket.h>
+
+#include "utils/memutils.h"
+
+#include "../latch.c"
+
+/*
+ * Tests for RemoveWaitEvent().
+ *
+ * The dispatcher takes a QE's socket out of its wait set when the QE has
+ * finished, so that a socket which later becomes readable on its own -- a
+ * crashing segment leaves a WARNING and the EOF unread in it -- cannot keep
+ * WaitEventSetWait() returning for an event nobody consumes.  Positions have
+ * to survive the removal, because callers hand the returned position back and
+ * store their own index in the event's user_data.
+ */
+
+#define MAX_TEST_EVENTS 8
+
+static int	pairs[MAX_TEST_EVENTS][2];
+static int	npairs;
+
+static WaitEventSet *
+setup_set(int nevents)
+{
+	npairs = 0;
+	return CreateWaitEventSet(CurrentMemoryContext, nevents);
+}
+
+/* A readable/writable socket to register; returns the read end. */
+static int
+new_socket(void)
+{
+	int			sv[2];
+
+	assert_true(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+	pairs[npairs][0] = sv[0];
+	pairs[npairs][1] = sv[1];
+	npairs++;
+	return sv[0];
+}
+
+static void
+make_readable(int idx)
+{
+	assert_true(write(pairs[idx][1], "x", 1) == 1);
+}
+
+static void
+close_sockets(void)
+{
+	for (int i = 0; i < npairs; i++)
+	{
+		close(pairs[i][0]);
+		close(pairs[i][1]);
+	}
+	npairs = 0;
+}
+
+/*
+ * The removed slot is made inert and every other event keeps its position and
+ * its user_data.
+ */
+static void
+test__RemoveWaitEvent__keeps_the_positions_of_the_other_events(void **state)
+{
+	WaitEventSet *set = setup_set(MAX_TEST_EVENTS);
+	int			pos[3];
+
+	for (int i = 0; i < 3; i++)
+		pos[i] = AddWaitEventToSet(set, WL_SOCKET_READABLE, new_socket(),
+								   NULL, (void *) (intptr_t) (100 + i));
+
+	assert_int_equal(pos[0], 0);
+	assert_int_equal(pos[1], 1);
+	assert_int_equal(pos[2], 2);
+	assert_int_equal(set->nevents, 3);
+
+	RemoveWaitEvent(set, pos[1]);
+
+	/* the slot is still there, but inert */
+	assert_int_equal(set->nevents, 3);
+	assert_int_equal(set->events[1].fd, PGINVALID_SOCKET);
+	assert_int_equal(set->events[1].events, 0);
+
+	/* the neighbours are untouched */
+	assert_int_equal(set->events[0].pos, 0);
+	assert_int_equal(set->events[2].pos, 2);
+	assert_true(set->events[0].fd != PGINVALID_SOCKET);
+	assert_true(set->events[2].fd != PGINVALID_SOCKET);
+	assert_int_equal((int) (intptr_t) set->events[0].user_data, 100);
+	assert_int_equal((int) (intptr_t) set->events[2].user_data, 102);
+
+	FreeWaitEventSet(set);
+	close_sockets();
+}
+
+/*
+ * A socket that has been removed is not reported again, even when it is
+ * readable -- which is the whole point: a finished QE's socket becomes
+ * readable when its segment dies.
+ */
+static void
+test__RemoveWaitEvent__stops_reporting_the_removed_socket(void **state)
+{
+	WaitEventSet *set = setup_set(MAX_TEST_EVENTS);
+	WaitEvent	occurred[MAX_TEST_EVENTS];
+	int			pos[3];
+	int			nready;
+
+	for (int i = 0; i < 3; i++)
+		pos[i] = AddWaitEventToSet(set, WL_SOCKET_READABLE, new_socket(),
+								   NULL, (void *) (intptr_t) (100 + i));
+
+	/* every socket has something to read */
+	for (int i = 0; i < 3; i++)
+		make_readable(i);
+
+	nready = WaitEventSetWait(set, 0, occurred, MAX_TEST_EVENTS, 0);
+	assert_int_equal(nready, 3);
+
+	RemoveWaitEvent(set, pos[1]);
+
+	/*
+	 * Without the removal this would still return 3 and the caller would go
+	 * on skipping the finished QE for ever.
+	 */
+	nready = WaitEventSetWait(set, 0, occurred, MAX_TEST_EVENTS, 0);
+	assert_int_equal(nready, 2);
+	for (int i = 0; i < nready; i++)
+	{
+		assert_true(occurred[i].pos != pos[1]);
+		assert_true((int) (intptr_t) occurred[i].user_data == 100 ||
+					(int) (intptr_t) occurred[i].user_data == 102);
+	}
+
+	FreeWaitEventSet(set);
+	close_sockets();
+}
+
+/*
+ * Removing twice is a no-op, and a socket whose owner has already closed it
+ * can still be removed: libpq drops the socket of a broken connection before
+ * the dispatcher gets to it.
+ */
+static void
+test__RemoveWaitEvent__is_idempotent_and_survives_a_closed_socket(void **state)
+{
+	WaitEventSet *set = setup_set(MAX_TEST_EVENTS);
+	int			pos;
+	int			fd;
+
+	fd = new_socket();
+	pos = AddWaitEventToSet(set, WL_SOCKET_READABLE, fd, NULL, NULL);
+
+	/* the owner closed it before we removed the event */
+	close(pairs[0][0]);
+	close(pairs[0][1]);
+	npairs = 0;
+
+	RemoveWaitEvent(set, pos);
+	assert_int_equal(set->events[pos].fd, PGINVALID_SOCKET);
+
+	/* second removal does nothing and must not raise */
+	RemoveWaitEvent(set, pos);
+	assert_int_equal(set->events[pos].fd, PGINVALID_SOCKET);
+
+	/* and the set is still usable for the remaining sockets */
+	assert_true(FlushWaitEventSet(set));
+
+	FreeWaitEventSet(set);
+	close_sockets();
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const		UnitTest tests[] = {
+		unit_test(test__RemoveWaitEvent__keeps_the_positions_of_the_other_events),
+		unit_test(test__RemoveWaitEvent__stops_reporting_the_removed_socket),
+		unit_test(test__RemoveWaitEvent__is_idempotent_and_survives_a_closed_socket)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}

--- a/src/include/storage/latch.h
+++ b/src/include/storage/latch.h
@@ -169,6 +169,7 @@ extern bool FlushWaitEventSet(WaitEventSet *set);
 extern int	AddWaitEventToSet(WaitEventSet *set, uint32 events, pgsocket fd,
 							  Latch *latch, void *user_data);
 extern void ModifyWaitEvent(WaitEventSet *set, int pos, uint32 events, Latch *latch);
+extern void RemoveWaitEvent(WaitEventSet *set, int pos);
 
 extern int	WaitEventSetWait(WaitEventSet *set, long timeout,
 							 WaitEvent *occurred_events, int nevents,


### PR DESCRIPTION
**Summary**
When a segment crash-resets mid-query, the QD could spin forever at 100% CPU instead of cancelling and erroring out. Three fixes: `checkDispatchResult()` now sends the cancel to the QEs at the moment it escalates to `DISPATCH_WAIT_CANCEL`, instead of only from the wait-timeout branches; a QE's socket is removed from the dispatcher's WaitEventSet once that QE is finished, via a new `RemoveWaitEvent()` that leaves the slot inert so positions stay stable; and `cdbdisp_appendMessageNonThread()` decides whether to log with the same rule as elog.c, so its LOG-level connection errors are no longer silently dropped under the default `log_min_messages`.

**Background**
On WHPG 7 ppc64le a MADlib native crash, fixed separately on the MADlib side, killed two segments while a redistribute was in flight. The QD recorded the connection errors and escalated to cancel, but two QEs that had already finished their slice were killed by the same reset and left a NoticeResponse plus EOF unread in sockets still registered in the wait set. Every `WaitEventSetWait()` returned immediately, `handlePollSuccess()` skipped the finished QEs, the timeout branch that sends the cancel never ran, and the surviving segment's QEs waited in the UDP receive loop, which has no peer-liveness check, until the session was killed by hand. Under the TCP interconnect the survivors' sockets reset and the query failed in seconds, which is why forcing tcp had looked like a fix. The coordinator log showed nothing for the whole hang because the dispatcher's LOG messages were compared against `log_min_messages` with the wrong ordering. Root-caused from QD/QE cores on a native Power executor.

**Test plan**
- New unit tests for `RemoveWaitEvent()` in `src/backend/storage/ipc/test/latch_test.c`, 3/3 passing: the removed slot goes inert while the other events keep their positions and `user_data`; a removed socket is no longer reported by `WaitEventSetWait()` even when it is readable, which is the property the dispatcher depends on; removing twice, and removing a socket whose owner already closed it, are both safe
- `src/backend/cdb/dispatcher/test` mock tests pass; builds clean with and without `--enable-cassert`
- No end-to-end regression test. I tried to build one on a local demo cluster: a 3-slice ORCA plan whose lower slice finishes while the upper slice still streams, the crash gated on `gp_wait_until_triggered_fault('qe_exec_finished')` so a QE on the target segment was known to have finished, then an immediate stop of that segment. The query errors out in 1.05 s on this branch and in 1.04 s on unpatched `main`, so the scenario does not discriminate. Stopping a whole segment makes the QD see all of its QEs fail at once and unwind normally; the spin needs a finished QE's socket to become readable while the QD is still waiting on other running QEs, so that the poll never reaches the timeout branch that used to be the only place the cancel was sent. Getting those two conditions to coincide is a race, and a test that hits it only sometimes would be worse than none. The fixes rest on the QD and QE cores from the ppc64le hang instead: `sentSignal = false` on the QD stack with `waitMode = DISPATCH_WAIT_CANCEL`, two finished QEs' descriptors permanently readable, and the surviving segment's QEs parked in the UDP receive loop