### PR TITLE
[WHPG6X] Fix potential buffer overrun in regexp match/split functions(CVE-2026-14664)

### DIFF
--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -891,7 +891,7 @@ setup_regexp_matches(text *orig_str, text *pattern, text *flags,
 
 	/* convert string to pg_wchar form for matching */
 	orig_len = VARSIZE_ANY_EXHDR(orig_str);
-	wide_str = (pg_wchar *) palloc(sizeof(pg_wchar) * (orig_len + 1));
+	wide_str = palloc_array(pg_wchar, orig_len + 1);
 	wide_len = pg_mb2wchar_with_len(VARDATA_ANY(orig_str), wide_str, orig_len);
 
 	/* determine options */
@@ -1036,23 +1036,24 @@ setup_regexp_matches(text *orig_str, text *pattern, text *flags,
 
 	if (eml > 1)
 	{
-		int64		maxsiz = eml * (int64) maxlen;
 		int			conv_bufsiz;
 
 		/*
 		 * Make the conversion buffer large enough for any substring of
-		 * interest.
+		 * interest. We can't use the original string's byte length as a
+		 * tighter bound, because that assumes the input is validly encoded;
+		 * but pg_mb2wchar_with_len() can accept strings that are invalid in
+		 * the database encoding, and converting such a character back to
+		 * multibyte form can take more bytes than it did in the input.
 		 *
-		 * Worst case: assume we need the maximum size (maxlen*eml), but take
-		 * advantage of the fact that the original string length in bytes is an
-		 * upper bound on the byte length of any fetched substring (and we know
-		 * that len+1 is safe to allocate because the varlena header is longer
-		 * than 1 byte).
+		 * This can't overflow, nor exceed what palloc will accept: maxlen is
+		 * at most wide_len, which is at most orig_len, and we have already
+		 * successfully allocated (orig_len + 1) * sizeof(pg_wchar) bytes for
+		 * wide_str. That relies on eml being no more than sizeof(pg_wchar),
+		 * which is true of all supported encodings.
 		 */
-		if (maxsiz > orig_len)
-			conv_bufsiz = orig_len + 1;
-		else
-			conv_bufsiz = maxsiz + 1;	/* safe since maxsiz < 2^30 */
+		Assert(eml <= sizeof(pg_wchar));
+		conv_bufsiz = maxlen * eml + 1;
 
 		matchctx->conv_buf = palloc(conv_bufsiz);
 		matchctx->conv_bufsiz = conv_bufsiz;


### PR DESCRIPTION
## Problem
`setup_regexp_matches()` sizes the buffer used to convert matched substrings back
from `pg_wchar` form at the smaller of `maxlen * eml` and the original string's
byte length, assuming a conversion can never produce more bytes than the string it
came from. That holds only for validly encoded input. `pg_mb2wchar_with_len()`
silently accepts bytes that are invalid in the database encoding, turning each such
byte into one `pg_wchar`, and converting that back can take more bytes than the
input did. A string made of such bytes therefore overruns the conversion buffer by
up to its own length, corrupting the following memory. `regexp_matches()`,
`regexp_split_to_table()` and `regexp_split_to_array()` are affected.
(CVE-2026-14664, CVSS 8.8)

## Fix
Cherry-pick of upstream `890327639962` (Masahiko Sawada, REL_14): drop the tighter
`orig_len` bound and always allocate `maxlen * eml + 1` bytes, with an assertion
that `eml <= sizeof(pg_wchar)`. This is the same commit already merged on `main`
for WHPG7 (PR #256).

## WarehousePG adaptation
The only conflict was in the comment paragraph the commit replaces: the old
"Worst case" text is wrapped differently on this branch than on REL_14, so git
could not match the pre-image. Resolved by taking upstream's replacement text; the
resulting conversion-buffer allocation logic is identical to upstream REL_14, while
the rest of `setup_regexp_matches()` keeps this branch's older signature and control
flow. The required overflow-safe `palloc_array()` is already available on this
branch. `regexp_match()`, named in the upstream commit message,
does not exist on this branch (added in PostgreSQL 10); the affected functions here
are `regexp_matches()`, `regexp_split_to_table()` and `regexp_split_to_array()`.